### PR TITLE
Refactor client code, add timeout capabilities

### DIFF
--- a/dhcpv4/bsdp/client.go
+++ b/dhcpv4/bsdp/client.go
@@ -3,21 +3,22 @@
 package bsdp
 
 import (
-	"fmt"
-	"net"
-	"syscall"
+	"errors"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
 )
 
-// Client is a BSDP-specific client suitable for performing BSDP exchanges.
-type Client dhcpv4.Client
-
 // Exchange runs a full BSDP exchange (Inform[list], Ack, Inform[select],
 // Ack). Returns a list of DHCPv4 structures representing the exchange.
-func (c *Client) Exchange(ifname string, informList *dhcpv4.DHCPv4) ([]dhcpv4.DHCPv4, error) {
+func Exchange(client *dhcpv4.Client, ifname string, informList *dhcpv4.DHCPv4) ([]dhcpv4.DHCPv4, error) {
 	conversation := make([]dhcpv4.DHCPv4, 1)
 	var err error
+
+	// Get our file descriptor for the broadcast socket.
+	fd, err := dhcpv4.MakeBroadcastSocket(ifname)
+	if err != nil {
+		return conversation, err
+	}
 
 	// INFORM[LIST]
 	if informList == nil {
@@ -28,92 +29,33 @@ func (c *Client) Exchange(ifname string, informList *dhcpv4.DHCPv4) ([]dhcpv4.DH
 	}
 	conversation[0] = *informList
 
-	// TODO: deduplicate with code in dhcpv4/client.go
-	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_RAW, syscall.IPPROTO_RAW)
+	// ACK[LIST]
+	ackForList, err := dhcpv4.SendReceive(client, fd, informList)
 	if err != nil {
 		return conversation, err
 	}
-	err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
-	if err != nil {
-		return conversation, err
-	}
-	err = syscall.SetsockoptInt(fd, syscall.IPPROTO_IP, syscall.IP_HDRINCL, 1)
-	if err != nil {
-		return conversation, err
-	}
-	err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_BROADCAST, 1)
-	if err != nil {
-		return conversation, err
-	}
-	err = dhcpv4.BindToInterface(fd, ifname)
-	if err != nil {
-		return conversation, err
-	}
-
-	bcast := [4]byte{}
-	copy(bcast[:], net.IPv4bcast)
-	daddr := syscall.SockaddrInet4{Port: dhcpv4.ClientPort, Addr: bcast}
-	packet, err := dhcpv4.MakeRawBroadcastPacket(informList.ToBytes())
-	if err != nil {
-		return conversation, err
-	}
-	err = syscall.Sendto(fd, packet, 0, &daddr)
-	if err != nil {
-		return conversation, err
-	}
-
-	// ACK 1
-	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: dhcpv4.ClientPort})
-	if err != nil {
-		return conversation, err
-	}
-	defer conn.Close()
-
-	buf := make([]byte, dhcpv4.MaxUDPReceivedPacketSize)
-	oobdata := []byte{} // ignoring oob data
-	n, _, _, _, err := conn.ReadMsgUDP(buf, oobdata)
-	ack1, err := dhcpv4.FromBytes(buf[:n])
-	if err != nil {
-		return conversation, err
-	}
-	// TODO match the packet content
-	// TODO check that the peer address matches the declared server IP and port
-	conversation = append(conversation, *ack1)
+	conversation = append(conversation, *ackForList)
 
 	// Parse boot images sent back by server
-	bootImages, err := ParseBootImageListFromAck(*ack1)
+	bootImages, err := ParseBootImageListFromAck(*ackForList)
 	if err != nil {
 		return conversation, err
 	}
 	if len(bootImages) == 0 {
-		return conversation, fmt.Errorf("Got no BootImages from server")
+		return conversation, errors.New("got no BootImages from server")
 	}
 
 	// INFORM[SELECT]
-	informSelect, err := InformSelectForAck(*ack1, dhcpv4.ClientPort, bootImages[0])
+	informSelect, err := InformSelectForAck(*ackForList, dhcpv4.ClientPort, bootImages[0])
 	if err != nil {
 		return conversation, err
 	}
 	conversation = append(conversation, *informSelect)
-	packet, err = dhcpv4.MakeRawBroadcastPacket(informSelect.ToBytes())
-	if err != nil {
-		return conversation, err
-	}
-	err = syscall.Sendto(fd, packet, 0, &daddr)
-	if err != nil {
-		return conversation, err
-	}
 
-	// ACK 2
-	buf = make([]byte, dhcpv4.MaxUDPReceivedPacketSize)
-	n, _, _, _, err = conn.ReadMsgUDP(buf, oobdata)
-	ack2, err := dhcpv4.FromBytes(buf[:n])
+	// ACK[SELECT]
+	ackForSelect, err := dhcpv4.SendReceive(client, fd, informSelect)
 	if err != nil {
 		return conversation, err
 	}
-	// TODO match the packet content
-	// TODO check that the peer address matches the declared server IP and port
-	conversation = append(conversation, *ack2)
-
-	return conversation, nil
+	return append(conversation, *ackForSelect), nil
 }


### PR DESCRIPTION
Previously there was a lot of shared code in the implementations of `dhcpv4.Exchange` and `bsdp.Exchange`. This PR refactors that into a lot of shared code, with only the actual `Exchange` funcs being different (as they should be).

It also compresses the logic of sending out on the broadcast address and receiving from it into a single function.

Testing on an instance where BSDP works properly:
```
DHCPv4
  opcode=BootRequest
  hwtype=Ethernet
  hwaddrlen=6
  hopcount=0
  transactionid=0xeeb85048
  numseconds=0
  flags=Unicast (0x00)
  clientipaddr=192.168.0.30
  youripaddr=0.0.0.0
  serveripaddr=0.0.0.0
  gatewayipaddr=0.0.0.0
  clienthwaddr=<MAC>
  serverhostname=
  bootfilename=
  options=
    DHCP Message Type -> [8]
    Vendor Specific Information -> [1 1 1 2 2 1 1]
    Parameter Request List -> [43 60]
    Maximum DHCP Message Size -> [5 220]
    Class Identifier -> [65 65 80 76 66 83 68 80 67 47 105 51 56 54 47 77 97 99 109 105 110 105 55 44 49]
    End -> []

DHCPv4
  opcode=BootReply
  hwtype=Ethernet
  hwaddrlen=6
  hopcount=0
  transactionid=0xeeb85048
  numseconds=0
  flags=Unicast (0x00)
  clientipaddr=192.168.0.30
  youripaddr=192.168.0.30
  serveripaddr=0.0.0.0
  gatewayipaddr=0.0.0.0
  clienthwaddr=<MAC>
  serverhostname=
  bootfilename=
  options=
    Subnet Mask -> [255 255 255 0]
    Router -> [192 168 0 1]
    Vendor Specific Information -> [1 1 1 4 2 128 128 7 4 129 0 16 0 9 18 129 0 16 0 13 102 97 99 101 98 111 111 116 45 98 115 100 112]
    DHCP Message Type -> [5]
    Server Identifier -> <SERVER IP>
    Class Identifier -> [65 65 80 76 66 83 68 80 67]
    End -> []

DHCPv4
  opcode=BootRequest
  hwtype=Ethernet
  hwaddrlen=6
  hopcount=0
  transactionid=0xeeb85048
  numseconds=0
  flags=Unicast (0x00)
  clientipaddr=0.0.0.0
  youripaddr=0.0.0.0
  serveripaddr=0.0.0.0
  gatewayipaddr=0.0.0.0
  clienthwaddr=<MAC>
  serverhostname=
  bootfilename=
  options=
    Class Identifier -> [65 65 80 76 66 83 68 80 67 47 105 51 56 54 47 77 97 99 109 105 110 105 55 44 49]
    Parameter Request List -> [1 3 67 43 60]
    DHCP Message Type -> [8]
    Vendor Specific Information -> [1 1 2 2 2 1 1 8 4 129 0 16 0 3 4 10 111 211 42]
    End -> []

DHCPv4
  opcode=BootReply
  hwtype=Ethernet
  hwaddrlen=6
  hopcount=2
  transactionid=0xeeb85048
  numseconds=0
  flags=Broadcast (0x8000)
  clientipaddr=192.168.0.30
  youripaddr=192.168.0.30
  serveripaddr=0.0.0.0
  gatewayipaddr=0.0.0.0
  clienthwaddr=<MAC>
  serverhostname=
  bootfilename=
  options=
    Subnet Mask -> [255 255 255 0]
    Router -> [192 168 0 1]
    Vendor Specific Information -> [1 1 2 8 4 129 0 16 0 130 10 78 101 116 98 111 111 116 48 48 49]
    DHCP Message Type -> [5]
    Server Identifier -> <SERVER IP>
    Class Identifier -> [65 65 80 76 66 83 68 80 67]
    End -> []
```

Testing in a case where BSDP times out:
```
read udp4 0.0.0.0:68: i/o timeout
DHCPv4
  opcode=BootRequest
  hwtype=Ethernet
  hwaddrlen=6
  hopcount=0
  transactionid=0x7b664e5e
  numseconds=0
  flags=Unicast (0x00)
  clientipaddr=<CLIENT IP>
  youripaddr=0.0.0.0
  serveripaddr=0.0.0.0
  gatewayipaddr=0.0.0.0
  clienthwaddr=<MAC>
  serverhostname=
  bootfilename=
  options=
    DHCP Message Type -> [8]
    Vendor Specific Information -> [1 1 1 2 2 1 1]
    Parameter Request List -> [43 60]
    Maximum DHCP Message Size -> [5 220]
    Class Identifier -> [65 65 80 76 66 83 68 80 67 47 105 51 56 54 47 77 97 99 109 105 110 105 55 44 49]
    End -> []
```