### PR TITLE
Make dhcpv4.Option an interface, add OptionGeneric

### DIFF
--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -263,7 +263,7 @@ func TestToStringMethods(t *testing.T) {
 	require.Equal(t, "/my/boot/file", d.BootFileNameToString())
 }
 
-func TestToBytes(t *testing.T) {
+func TestNewToBytes(t *testing.T) {
 	// the following bytes match what dhcpv4.New would create. Keep them in
 	// sync!
 	expected := []byte{

--- a/dhcpv4/option_generic.go
+++ b/dhcpv4/option_generic.go
@@ -1,0 +1,43 @@
+package dhcpv4
+
+import (
+	"fmt"
+)
+
+// OptionGeneric is an option that only contains the option code and associated
+// data. Every option that does not have a specific implementation will fall
+// back to this option.
+type OptionGeneric struct {
+	OptionCode OptionCode
+	Data       []byte
+}
+
+// Code returns the generic option code.
+func (o OptionGeneric) Code() OptionCode {
+	return o.OptionCode
+}
+
+// ToBytes returns a serialized generic option as a slice of bytes.
+func (o OptionGeneric) ToBytes() []byte {
+	ret := []byte{byte(o.OptionCode)}
+	if o.OptionCode == OptionEnd || o.OptionCode == OptionPad {
+		return ret
+	}
+	ret = append(ret, byte(o.Length()))
+	ret = append(ret, o.Data...)
+	return ret
+}
+
+// String returns a human-readable representation of a generic option.
+func (o OptionGeneric) String() string {
+	code, ok := OptionCodeToString[o.OptionCode]
+	if !ok {
+		code = "Unknown"
+	}
+	return fmt.Sprintf("%v -> %v", code, o.Data)
+}
+
+// Length returns the number of bytes comprising the data section of the option.
+func (o OptionGeneric) Length() int {
+	return len(o.Data)
+}

--- a/dhcpv4/option_generic_test.go
+++ b/dhcpv4/option_generic_test.go
@@ -1,0 +1,70 @@
+package dhcpv4
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionGenericCode(t *testing.T) {
+	o := OptionGeneric{
+		OptionCode: OptionDHCPMessageType,
+		Data:       []byte{byte(MessageTypeDiscover)},
+	}
+	require.Equal(t, OptionDHCPMessageType, o.Code())
+}
+
+func TestOptionGenericData(t *testing.T) {
+	o := OptionGeneric{
+		OptionCode: OptionNameServer,
+		Data:       []byte{192, 168, 0, 1},
+	}
+	require.Equal(t, []byte{192, 168, 0, 1}, o.Data)
+}
+
+func TestOptionGenericToBytes(t *testing.T) {
+	o := OptionGeneric{
+		OptionCode: OptionDHCPMessageType,
+		Data:       []byte{byte(MessageTypeDiscover)},
+	}
+	serialized := o.ToBytes()
+	expected := []byte{53, 1, 1}
+	require.Equal(t, expected, serialized)
+}
+
+func TestOptionGenericToBytesZeroOptions(t *testing.T) {
+	o := OptionGeneric{OptionCode: OptionEnd}
+	serialized := o.ToBytes()
+	expected := []byte{255}
+	require.Equal(t, expected, serialized)
+
+	o = OptionGeneric{OptionCode: OptionPad}
+	serialized = o.ToBytes()
+	expected = []byte{0}
+	require.Equal(t, expected, serialized)
+}
+
+func TestOptionGenericString(t *testing.T) {
+	o := OptionGeneric{
+		OptionCode: OptionDHCPMessageType,
+		Data:       []byte{byte(MessageTypeDiscover)},
+	}
+	require.Equal(t, "DHCP Message Type -> [1]", o.String())
+}
+
+func TestOptionGenericStringUnknown(t *testing.T) {
+	o := OptionGeneric{
+		OptionCode: 102, // Returend option code.
+		Data:       []byte{byte(MessageTypeDiscover)},
+	}
+	require.Equal(t, "Unknown -> [1]", o.String())
+}
+
+func TestOptionGenericLength(t *testing.T) {
+	filename := "/path/to/file"
+	o := OptionGeneric{
+		OptionCode: OptionBootfileName,
+		Data:       []byte(filename),
+	}
+	require.Equal(t, len(filename), o.Length())
+}

--- a/dhcpv4/options.go
+++ b/dhcpv4/options.go
@@ -6,36 +6,43 @@ import (
 	"fmt"
 )
 
-type OptionCode byte
-
+// MagicCookie is the magic 4-byte value at the beginning of the list of options
+// in a DHCPv4 packet.
 var MagicCookie = []byte{99, 130, 83, 99}
 
-// TODO: implement Option as an interface similar to dhcpv6.
-type Option struct {
-	Code OptionCode
-	Data []byte
+// OptionCode is a single byte representing the code for a given Option.
+type OptionCode byte
+
+// Option is an interface that all DHCP v4 options adhere to.
+type Option interface {
+	Code() OptionCode
+	ToBytes() []byte
+	Length() int
+	String() string
 }
 
-func ParseOption(dataStart []byte) (*Option, error) {
-	// Parse a sequence of bytes as a single DHCPv4 option.
-	// Returns the option code, its data, and an error if any.
-	if len(dataStart) == 0 {
-		return nil, errors.New("Invalid zero-length DHCPv4 option")
+// ParseOption parses a sequence of bytes as a single DHCPv4 option, returning
+// the specific option structure or error, if any.
+func ParseOption(data []byte) (Option, error) {
+	if len(data) == 0 {
+		return nil, errors.New("invalid zero-length DHCPv4 option")
 	}
-	opt := OptionCode(dataStart[0])
-	switch opt {
-	case OptionPad, OptionEnd:
-		return &Option{Code: opt, Data: []byte{}}, nil
-	default:
-		length := int(dataStart[1])
-		if len(dataStart) < length+2 {
-			return nil, errors.New(
-				fmt.Sprintf("Invalid data length. Declared %v, actual %v",
-					length, len(dataStart),
-				))
+	code := OptionCode(data[0])
+	var (
+		length     int
+		optionData []byte
+	)
+	if code != OptionPad && code != OptionEnd {
+		length = int(data[1])
+		if len(data) < length+2 {
+			return nil, fmt.Errorf("invalid data length: declared %v, actual %v", length, len(data))
 		}
-		data := dataStart[2 : 2+length]
-		return &Option{Code: opt, Data: data}, nil
+		optionData = data[2 : length+2]
+	}
+
+	switch code {
+	default:
+		return &OptionGeneric{OptionCode: code, Data: optionData}, nil
 	}
 }
 
@@ -44,10 +51,10 @@ func ParseOption(dataStart []byte) (*Option, error) {
 // error if any invalid option or length is found.
 func OptionsFromBytes(data []byte) ([]Option, error) {
 	if len(data) < len(MagicCookie) {
-		return nil, errors.New("Invalid options: shorter than 4 bytes")
+		return nil, errors.New("invalid options: shorter than 4 bytes")
 	}
 	if !bytes.Equal(data[:len(MagicCookie)], MagicCookie) {
-		return nil, fmt.Errorf("Invalid Magic Cookie: %v", data[:len(MagicCookie)])
+		return nil, fmt.Errorf("invalid magic cookie: %v", data[:len(MagicCookie)])
 	}
 	opts, err := OptionsFromBytesWithoutMagicCookie(data[len(MagicCookie):])
 	if err != nil {
@@ -66,56 +73,23 @@ func OptionsFromBytesWithoutMagicCookie(data []byte) ([]Option, error) {
 		if idx == len(data) {
 			break
 		}
+		// This should never happen.
 		if idx > len(data) {
-			// this should never happen
-			return nil, errors.New("Error: Reading past the end of options")
+			return nil, errors.New("read past the end of options")
 		}
 		opt, err := ParseOption(data[idx:])
 		idx++
 		if err != nil {
 			return nil, err
 		}
-		options = append(options, *opt)
+		options = append(options, opt)
 
 		// Options with zero length have no length byte, so here we handle the
 		// ones with nonzero length
-		if len(opt.Data) > 0 {
+		if opt.Length() > 0 {
 			idx++
 		}
-		idx += len(opt.Data)
+		idx += opt.Length()
 	}
 	return options, nil
-}
-
-// OptionsToBytes converts a list of options to a wire-format representation
-// with the DHCP magic cookie prepended.
-func OptionsToBytes(options []Option) []byte {
-	return append(MagicCookie, OptionsToBytesWithoutMagicCookie(options)...)
-}
-
-// OptionsToBytesWithoutMagicCookie converts a list of options to a wire-format
-// representation.
-func OptionsToBytesWithoutMagicCookie(options []Option) []byte {
-	ret := []byte{}
-	for _, opt := range options {
-		ret = append(ret, opt.ToBytes()...)
-	}
-	return ret
-}
-
-func (o *Option) String() string {
-	code, ok := OptionCodeToString[o.Code]
-	if !ok {
-		code = "Unknown"
-	}
-	return fmt.Sprintf("%v -> %v", code, o.Data)
-}
-
-func (o *Option) ToBytes() []byte {
-	// Convert a single option to its wire-format representation
-	ret := []byte{byte(o.Code)}
-	if o.Code != OptionPad && o.Code != OptionEnd {
-		ret = append(ret, byte(len(o.Data)))
-	}
-	return append(ret, o.Data...)
 }

--- a/dhcpv4/types.go
+++ b/dhcpv4/types.go
@@ -8,14 +8,14 @@ type MessageType byte
 
 // DHCP message types
 const (
-	MessageTypeDiscover MessageType = iota + 1
-	MessageTypeOffer
-	MessageTypeRequest
-	MessageTypeDecline
-	MessageTypeAck
-	MessageTypeNak
-	MessageTypeRelease
-	MessageTypeInform
+	MessageTypeDiscover MessageType = 1
+	MessageTypeOffer    MessageType = 2
+	MessageTypeRequest  MessageType = 3
+	MessageTypeDecline  MessageType = 4
+	MessageTypeAck      MessageType = 5
+	MessageTypeNak      MessageType = 6
+	MessageTypeRelease  MessageType = 7
+	MessageTypeInform   MessageType = 8
 )
 
 // OpcodeType represents a DHCPv4 opcode.


### PR DESCRIPTION
This PR sets the stage for breaking out the implementation of all DHCPv4 options to their own separate options that implement the `dhcpv4.Option` interface. This makes things much more flexible for e.g. BSDP (+ pretty-printing vendor-specific options). This PR also adds an `OptionGeneric`, similar to `dhcpv6.OptionGeneric` that can implement all other options.

Some other small changes:
* Changes `DHCPv4.clientHwAddr` to a `net.HardwareAddr`
* Changes `DHCPv4.serverHostName` to a `string`
* Changes `DHCPv4.bootFileName` to a `string`