### PR TITLE
Added OptGenericIP to simplify creation of options that wrap an IP address

### DIFF
--- a/dhcpv4/option_broadcast_address.go
+++ b/dhcpv4/option_broadcast_address.go
@@ -1,36 +1,23 @@
 package dhcpv4
 
-import (
-	"fmt"
-	"net"
-)
+import "fmt"
 
-// This option implements the server identifier option
+// This option implements the broadcast address option
 // https://tools.ietf.org/html/rfc2132
 
-// OptBroadcastAddress represents an option encapsulating the server identifier.
+// OptBroadcastAddress represents an option encapsulating the broadcast address.
 type OptBroadcastAddress struct {
-	BroadcastAddress net.IP
+	OptGenericIP
 }
 
 // ParseOptBroadcastAddress returns a new OptBroadcastAddress from a byte
 // stream, or error if any.
 func ParseOptBroadcastAddress(data []byte) (*OptBroadcastAddress, error) {
-	if len(data) < 2 {
-		return nil, ErrShortByteStream
+	opt, err := ParseOptGenericIP(OptionBroadcastAddress, data)
+	if err != nil {
+		return nil, err
 	}
-	code := OptionCode(data[0])
-	if code != OptionBroadcastAddress {
-		return nil, fmt.Errorf("expected code %v, got %v", OptionBroadcastAddress, code)
-	}
-	length := int(data[1])
-	if length != 4 {
-		return nil, fmt.Errorf("unexepcted length: expected 4, got %v", length)
-	}
-	if len(data) < 6 {
-		return nil, ErrShortByteStream
-	}
-	return &OptBroadcastAddress{BroadcastAddress: net.IP(data[2 : 2+length])}, nil
+	return &OptBroadcastAddress{OptGenericIP: *opt}, nil
 }
 
 // Code returns the option code.
@@ -40,17 +27,10 @@ func (o *OptBroadcastAddress) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptBroadcastAddress) ToBytes() []byte {
-	ret := []byte{byte(o.Code()), byte(o.Length())}
-	return append(ret, o.BroadcastAddress.To4()...)
+	return o.OptGenericIP.ToBytes(OptionBroadcastAddress)
 }
 
 // String returns a human-readable string.
 func (o *OptBroadcastAddress) String() string {
-	return fmt.Sprintf("Broadcast Address -> %v", o.BroadcastAddress.String())
-}
-
-// Length returns the length of the data portion (excluding option code an byte
-// length).
-func (o *OptBroadcastAddress) Length() int {
-	return len(o.BroadcastAddress.To4())
+	return fmt.Sprintf("Broadcast Address -> %v", o.IP.String())
 }

--- a/dhcpv4/option_broadcast_address_test.go
+++ b/dhcpv4/option_broadcast_address_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestOptBroadcastAddressInterfaceMethods(t *testing.T) {
 	ip := net.IP{192, 168, 0, 1}
-	o := OptBroadcastAddress{BroadcastAddress: ip}
+	o := OptBroadcastAddress{OptGenericIP{IP: ip}}
 
 	require.Equal(t, OptionBroadcastAddress, o.Code(), "Code")
 
@@ -40,5 +40,5 @@ func TestParseOptBroadcastAddress(t *testing.T) {
 
 	o, err = ParseOptBroadcastAddress([]byte{byte(OptionBroadcastAddress), 4, 192, 168, 0, 1})
 	require.NoError(t, err)
-	require.Equal(t, net.IP{192, 168, 0, 1}, o.BroadcastAddress)
+	require.Equal(t, net.IP{192, 168, 0, 1}, o.IP)
 }

--- a/dhcpv4/option_generic_ip.go
+++ b/dhcpv4/option_generic_ip.go
@@ -1,0 +1,79 @@
+package dhcpv4
+
+import (
+	"fmt"
+	"net"
+)
+
+/*
+This is a helper option that provides facilities to create options that
+contain an IPv4 address. It cannot be used directly, but the deriving
+implementations have to embed it, and implement `Code() OptionCode`,
+`ToBytes() []byte`, `String() string` and
+`Parse(data []byte) (*YourNewOption, error)`. The latter is a function,
+the others are methods of the new option.
+
+Example of a new OptMyIPOption based on OptGenericIP:
+
+type OptMyIPOption struct {
+	OptGenericIP
+}
+
+func ParseOptMyIPOption(data []byte) (*OptMyIPOption, error) {
+	opt, err := ParseOptGenericIP(OptionMyIPOption, data)
+	if err != nil {
+		return nil, err
+	}
+	return &Opt
+	return &OptMyIPOption{OptGenericIP: *opt}, nil
+}
+
+func (o OptMyIPOption) String() string {
+	return fmt.Sprintf("OptMyIPOption -> %v", o.Value)
+}
+
+func (o OptMyIPOption) Code() OptionCode {
+	return OptionMyIPOption
+}
+
+func (o OptMyIPOption) ToBytes() []byte {
+	return o.OptGenericIP.ToBytes(OptionMyIPOption)
+}
+*/
+
+// OptGenericIP represents an option encapsulating the server identifier.
+type OptGenericIP struct {
+	IP net.IP
+}
+
+// ParseOptGenericIP returns a new OptGenericIP from a byte stream, or error if
+// any.
+func ParseOptGenericIP(optCode OptionCode, data []byte) (*OptGenericIP, error) {
+	if len(data) < 2 {
+		return nil, ErrShortByteStream
+	}
+	code := OptionCode(data[0])
+	if code != optCode {
+		return nil, fmt.Errorf("expected code %v, got %v", optCode, code)
+	}
+	length := int(data[1])
+	if length != 4 {
+		return nil, fmt.Errorf("unexepcted length: expected 4, got %v", length)
+	}
+	if len(data) < 6 {
+		return nil, ErrShortByteStream
+	}
+	return &OptGenericIP{IP: net.IP(data[2 : 2+length])}, nil
+}
+
+// ToBytes returns a serialized stream of bytes for this option.
+func (o *OptGenericIP) ToBytes(optCode OptionCode) []byte {
+	ret := []byte{byte(optCode), byte(o.Length())}
+	return append(ret, o.IP.To4()...)
+}
+
+// Length returns the length of the data portion (excluding option code an byte
+// length).
+func (o *OptGenericIP) Length() int {
+	return len(o.IP.To4())
+}


### PR DESCRIPTION
OptGenericIP is a fake option that simplifies the creation of other options that wrap an IP address.
