### PR TITLE
Remove build tags

### DIFF
--- a/dhcpv4/bsdp/boot_image.go
+++ b/dhcpv4/bsdp/boot_image.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/boot_image_test.go
+++ b/dhcpv4/bsdp/boot_image_test.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_boot_image_list.go
+++ b/dhcpv4/bsdp/bsdp_option_boot_image_list.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_boot_image_list_test.go
+++ b/dhcpv4/bsdp/bsdp_option_boot_image_list_test.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_default_boot_image_id.go
+++ b/dhcpv4/bsdp/bsdp_option_default_boot_image_id.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_default_boot_image_id_test.go
+++ b/dhcpv4/bsdp/bsdp_option_default_boot_image_id_test.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_generic.go
+++ b/dhcpv4/bsdp/bsdp_option_generic.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_generic_test.go
+++ b/dhcpv4/bsdp/bsdp_option_generic_test.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_machine_name.go
+++ b/dhcpv4/bsdp/bsdp_option_machine_name.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_machine_name_test.go
+++ b/dhcpv4/bsdp/bsdp_option_machine_name_test.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_message_type.go
+++ b/dhcpv4/bsdp/bsdp_option_message_type.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_message_type_test.go
+++ b/dhcpv4/bsdp/bsdp_option_message_type_test.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_reply_port.go
+++ b/dhcpv4/bsdp/bsdp_option_reply_port.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_reply_port_test.go
+++ b/dhcpv4/bsdp/bsdp_option_reply_port_test.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_selected_boot_image_id.go
+++ b/dhcpv4/bsdp/bsdp_option_selected_boot_image_id.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_selected_boot_image_id_test.go
+++ b/dhcpv4/bsdp/bsdp_option_selected_boot_image_id_test.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_server_identifier.go
+++ b/dhcpv4/bsdp/bsdp_option_server_identifier.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_server_identifier_test.go
+++ b/dhcpv4/bsdp/bsdp_option_server_identifier_test.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_server_priority.go
+++ b/dhcpv4/bsdp/bsdp_option_server_priority.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_server_priority_test.go
+++ b/dhcpv4/bsdp/bsdp_option_server_priority_test.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_version.go
+++ b/dhcpv4/bsdp/bsdp_option_version.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_option_version_test.go
+++ b/dhcpv4/bsdp/bsdp_option_version_test.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/bsdp_test.go
+++ b/dhcpv4/bsdp/bsdp_test.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/client.go
+++ b/dhcpv4/bsdp/client.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/doc.go
+++ b/dhcpv4/bsdp/doc.go
@@ -1,0 +1,10 @@
+/*
+The BSDP package implements Apple's Boot Service Discovery Protocol (a
+pxe-boot-like netboot protocol for booting macOS hardware from
+network-connected servers).
+
+The Canonical implementation is defined here:
+http://opensource.apple.com/source/bootp/bootp-198.1/Documentation/BSDP.doc
+*/
+
+package bsdp

--- a/dhcpv4/bsdp/option_vendor_specific_information.go
+++ b/dhcpv4/bsdp/option_vendor_specific_information.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/option_vendor_specific_information_test.go
+++ b/dhcpv4/bsdp/option_vendor_specific_information_test.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package bsdp
 
 import (

--- a/dhcpv4/bsdp/types.go
+++ b/dhcpv4/bsdp/types.go
@@ -1,8 +1,12 @@
-// +build darwin
-
 package bsdp
 
 import "github.com/insomniacslk/dhcp/dhcpv4"
+
+// DefaultMacOSVendorClassIdentifier is a default vendor class identifier used
+// on non-darwin hosts where the vendor class identifier cannot be determined.
+// It should mostly be used for debugging if testing BSDP on a non-darwin
+// system.
+const DefaultMacOSVendorClassIdentifier = "AAPLBSDP/i386/MacMini6,1"
 
 // Options (occur as sub-options of DHCP option 43).
 const (

--- a/dhcpv4/bsdp/vendor_class_identifier.go
+++ b/dhcpv4/bsdp/vendor_class_identifier.go
@@ -1,0 +1,9 @@
+// +build !darwin
+
+package bsdp
+
+// MakeVendorClassIdentifier calls the sysctl syscall on macOS to get the
+// platform model.
+func MakeVendorClassIdentifier() (string, error) {
+	return DefaultMacOSVendorClassIdentifier, nil
+}

--- a/dhcpv4/bsdp/vendor_class_identifier.go
+++ b/dhcpv4/bsdp/vendor_class_identifier.go
@@ -2,8 +2,8 @@
 
 package bsdp
 
-// MakeVendorClassIdentifier calls the sysctl syscall on macOS to get the
-// platform model.
+// MakeVendorClassIdentifier returns a static vendor class identifier for BSDP
+// use on non-darwin hosts.
 func MakeVendorClassIdentifier() (string, error) {
 	return DefaultMacOSVendorClassIdentifier, nil
 }

--- a/dhcpv4/bsdp/vendor_class_identifier_darwin.go
+++ b/dhcpv4/bsdp/vendor_class_identifier_darwin.go
@@ -1,0 +1,17 @@
+package bsdp
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// MakeVendorClassIdentifier calls the sysctl syscall on macOS to get the
+// platform model.
+func MakeVendorClassIdentifier() (string, error) {
+	// Fetch hardware model for class ID.
+	hwModel, err := syscall.Sysctl("hw.model")
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("AAPLBSDPC/i386/%s", hwModel), nil
+}


### PR DESCRIPTION
Removes build tags from BSDP and breaks vendor class identifier into
OS-specific implementations so it is easier to integrate bsdp with other
libs.