### PR TITLE
DHCPv6 client now waits for specific packet types

### DIFF
--- a/dhcpv6/client.go
+++ b/dhcpv6/client.go
@@ -59,7 +59,7 @@ func (c *Client) Exchange(ifname string, solicit DHCPv6) ([]DHCPv6, error) {
 	return conversation, nil
 }
 
-func (c *Client) sendReceive(ifname string, packet DHCPv6) (DHCPv6, error) {
+func (c *Client) sendReceive(ifname string, packet DHCPv6, expected MessageType) (DHCPv6, error) {
 	if packet == nil {
 		return nil, fmt.Errorf("Packet to send cannot be nil")
 	}
@@ -109,13 +109,19 @@ func (c *Client) sendReceive(ifname string, packet DHCPv6) (DHCPv6, error) {
 	buf := make([]byte, maxUDPReceivedPacketSize)
 	oobdata := []byte{} // ignoring oob data
 	conn.SetReadDeadline(time.Now().Add(c.ReadTimeout))
-	n, _, _, _, err := conn.ReadMsgUDP(buf, oobdata)
-	if err != nil {
-		return nil, err
-	}
-	adv, err := FromBytes(buf[:n])
-	if err != nil {
-		return nil, err
+	var adv DHCPv6
+	for {
+		n, _, _, _, err := conn.ReadMsgUDP(buf, oobdata)
+		if err != nil {
+			return nil, err
+		}
+		adv, err = FromBytes(buf[:n])
+		if err != nil {
+			return nil, err
+		}
+		if adv.Type() == expected {
+			break
+		}
 	}
 	return adv, nil
 }
@@ -130,7 +136,7 @@ func (c *Client) Solicit(ifname string, solicit DHCPv6) (DHCPv6, DHCPv6, error) 
 			return nil, nil, err
 		}
 	}
-	advertise, err := c.sendReceive(ifname, solicit)
+	advertise, err := c.sendReceive(ifname, solicit, ADVERTISE)
 	return solicit, advertise, err
 }
 
@@ -144,6 +150,6 @@ func (c *Client) Request(ifname string, advertise, request DHCPv6) (DHCPv6, DHCP
 			return nil, nil, err
 		}
 	}
-	reply, err := c.sendReceive(ifname, request)
+	reply, err := c.sendReceive(ifname, request, REPLY)
 	return request, reply, err
 }

--- a/dhcpv6/types.go
+++ b/dhcpv6/types.go
@@ -5,6 +5,8 @@ package dhcpv6
 type MessageType uint8
 
 const (
+	// MSGTYPE_NONE is used internally and is not part of the RFC
+	MSGTYPE_NONE        MessageType = 0
 	SOLICIT             MessageType = 1
 	ADVERTISE           MessageType = 2
 	REQUEST             MessageType = 3


### PR DESCRIPTION
Before this patch the client just took whatever DHCP message it
received, without checking if it's what it wants. Now it checks for the
message type.
If the message is not a relay, also check the transaction ID