### PR TITLE
dhcpv6: added modifiers

### DIFF
--- a/dhcpv6/dhcpv6.go
+++ b/dhcpv6/dhcpv6.go
@@ -77,6 +77,7 @@ func FromBytes(data []byte) (DHCPv6, error) {
 	}
 }
 
+// NewMessage creates a new DHCPv6 message with default options
 func NewMessage() (DHCPv6, error) {
 	tid, err := GenerateTransactionID()
 	if err != nil {
@@ -110,9 +111,9 @@ func getOption(options []Option, code OptionCode) Option {
 	return opts[0]
 }
 
-// Decapsulate extracts the content of a relay message. It does not recurse if
-// there are nested relay messages. Returns the original packet if is not not a
-// relay message
+// DecapsulateRelay extracts the content of a relay message. It does not recurse
+// if there are nested relay messages. Returns the original packet if is not not
+// a relay message
 func DecapsulateRelay(l DHCPv6) (DHCPv6, error) {
 	if !l.IsRelay() {
 		return l, nil
@@ -128,8 +129,8 @@ func DecapsulateRelay(l DHCPv6) (DHCPv6, error) {
 	return relayOpt.RelayMessage(), nil
 }
 
-// Encapsulate creates a DHCPv6Relay message containing the passed DHCPv6 object.
-// struct as payload. The passed message type must be  either RELAY_FORW or
+// EncapsulateRelay creates a DHCPv6Relay message containing the passed DHCPv6
+// message as payload. The passed message type must be  either RELAY_FORW or
 // RELAY_REPL
 func EncapsulateRelay(d DHCPv6, mType MessageType, linkAddr, peerAddr net.IP) (DHCPv6, error) {
 	if mType != RELAY_FORW && mType != RELAY_REPL {

--- a/dhcpv6/dhcpv6.go
+++ b/dhcpv6/dhcpv6.go
@@ -19,6 +19,10 @@ type DHCPv6 interface {
 	AddOption(Option)
 }
 
+// Modifier defines the signature for functions that can modify DHCPv6
+// structures. This is used to simplify packet manipulation
+type Modifier func(d DHCPv6) DHCPv6
+
 func FromBytes(data []byte) (DHCPv6, error) {
 	var (
 		isRelay     = false
@@ -73,7 +77,7 @@ func FromBytes(data []byte) (DHCPv6, error) {
 	}
 }
 
-func NewMessage() (*DHCPv6Message, error) {
+func NewMessage() (DHCPv6, error) {
 	tid, err := GenerateTransactionID()
 	if err != nil {
 		return nil, err

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -31,9 +31,9 @@ func TestNewMessage(t *testing.T) {
 	d, err := NewMessage()
 	require.NoError(t, err)
 	require.NotNil(t, d)
-	require.Equal(t, SOLICIT, d.messageType)
-	require.NotEqual(t, 0, d.transactionID)
-	require.Empty(t, d.options)
+	require.Equal(t, SOLICIT, d.Type())
+	require.NotEqual(t, 0, d.(*DHCPv6Message).transactionID)
+	require.Empty(t, d.(*DHCPv6Message).options)
 }
 
 func TestSettersAndGetters(t *testing.T) {

--- a/dhcpv6/modifiers.go
+++ b/dhcpv6/modifiers.go
@@ -4,6 +4,7 @@ import (
 	"log"
 )
 
+// WithNetboot adds bootfile URL and bootfile param options to a DHCPv6 packet.
 func WithNetboot(d DHCPv6) DHCPv6 {
 	msg, ok := d.(*DHCPv6Message)
 	if !ok {
@@ -23,6 +24,7 @@ func WithNetboot(d DHCPv6) DHCPv6 {
 	return d
 }
 
+// WithUserClass adds a user class option to the packet
 func WithUserClass(uc string) Modifier {
 	return func(d DHCPv6) DHCPv6 {
 		ouc := OptUserClass{UserClass: []byte("FbLoL")}
@@ -31,6 +33,7 @@ func WithUserClass(uc string) Modifier {
 	}
 }
 
+// WithArchType adds an arch type option to the packet
 func WithArchType(at ArchType) Modifier {
 	return func(d DHCPv6) DHCPv6 {
 		ao := OptClientArchType{ArchType: at}

--- a/dhcpv6/modifiers.go
+++ b/dhcpv6/modifiers.go
@@ -1,0 +1,40 @@
+package dhcpv6
+
+import (
+	"log"
+)
+
+func WithNetboot(d DHCPv6) DHCPv6 {
+	msg, ok := d.(*DHCPv6Message)
+	if !ok {
+		log.Printf("WithNetboot: not a DHCPv6Message")
+		return d
+	}
+	// add OPT_BOOTFILE_URL and OPT_BOOTFILE_PARAM
+	opt := msg.GetOneOption(OPTION_ORO)
+	if opt == nil {
+		opt = &OptRequestedOption{}
+	}
+	// TODO only add options if they are not there already
+	oro := opt.(*OptRequestedOption)
+	oro.AddRequestedOption(OPT_BOOTFILE_URL)
+	oro.AddRequestedOption(OPT_BOOTFILE_PARAM)
+	msg.UpdateOption(oro)
+	return d
+}
+
+func WithUserClass(uc string) Modifier {
+	return func(d DHCPv6) DHCPv6 {
+		ouc := OptUserClass{UserClass: []byte("FbLoL")}
+		d.AddOption(&ouc)
+		return d
+	}
+}
+
+func WithArchType(at ArchType) Modifier {
+	return func(d DHCPv6) DHCPv6 {
+		ao := OptClientArchType{ArchType: at}
+		d.AddOption(&ao)
+		return d
+	}
+}


### PR DESCRIPTION
Added support for packet modifiers, i.e. functions that can arbitrarily
manipulate a DHCPv6 packet. These modifiers are used by NewMessage,
NewSolicitForInterface, NewRequestForAdvertise, and can be used by other
packet creation functions.
A bunch of sample modifiers have been added under modifiers.go , too.
With the introduction of modifiers I also removed some options that
should not necessarily be in a standard DHCPv6 message.

In order to implement modifiers in a consistent manner, this patch also
modifies the return value of the `New*` functions, from `DHCPv6Message`
to `DHCPv6`.