### PR TITLE
Added tests for OptClientId and using net.HardwareAddr for DUID

### DIFF
--- a/dhcpv6/duid.go
+++ b/dhcpv6/duid.go
@@ -3,6 +3,7 @@ package dhcpv6
 import (
 	"encoding/binary"
 	"fmt"
+	"net"
 
 	"github.com/insomniacslk/dhcp/iana"
 )
@@ -28,7 +29,7 @@ type Duid struct {
 	Type                 DuidType
 	HwType               iana.HwTypeType // for DUID-LLT and DUID-LL. Ignored otherwise. RFC 826
 	Time                 uint32          // for DUID-LLT. Ignored otherwise
-	LinkLayerAddr        []byte
+	LinkLayerAddr        net.HardwareAddr
 	EnterpriseNumber     uint32 // for DUID-EN. Ignored otherwise
 	EnterpriseIdentifier []byte // for DUID-EN. Ignored otherwise
 	Uuid                 []byte // for DUID-UUID. Ignored otherwise

--- a/dhcpv6/option_clientid.go
+++ b/dhcpv6/option_clientid.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 )
 
+// OptClientId represents a Client ID option
 type OptClientId struct {
 	Cid Duid
 }
@@ -32,8 +33,9 @@ func (op *OptClientId) String() string {
 	return fmt.Sprintf("OptClientId{cid=%v}", op.Cid.String())
 }
 
-// build an OptClientId structure from a sequence of bytes.
-// The input data does not include option code and length bytes.
+// ParseOptClientId builds an OptClientId structure from a sequence
+// of bytes. The input data does not include option code and length
+// bytes.
 func ParseOptClientId(data []byte) (*OptClientId, error) {
 	if len(data) < 2 {
 		// at least the DUID type is necessary to continue

--- a/dhcpv6/option_clientid_test.go
+++ b/dhcpv6/option_clientid_test.go
@@ -1,0 +1,67 @@
+package dhcpv6
+
+import (
+	"net"
+	"testing"
+
+	"github.com/insomniacslk/dhcp/iana"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOptClientId(t *testing.T) {
+	data := []byte{
+		0, 3, // DUID_LL
+		0, 1, // hwtype ethernet
+		0, 1, 2, 3, 4, 5, // hw addr
+	}
+	opt, err := ParseOptClientId(data)
+	require.NoError(t, err)
+	require.Equal(t, opt.Cid.Type, DUID_LL)
+	require.Equal(t, opt.Cid.HwType, iana.HwTypeEthernet)
+	require.Equal(t, opt.Cid.LinkLayerAddr, net.HardwareAddr([]byte{0, 1, 2, 3, 4, 5}))
+}
+
+func TestOptClientIdToBytes(t *testing.T) {
+	opt := OptClientId{
+		Cid: Duid{
+			Type:          DUID_LL,
+			HwType:        iana.HwTypeEthernet,
+			LinkLayerAddr: net.HardwareAddr([]byte{5, 4, 3, 2, 1, 0}),
+		},
+	}
+	expected := []byte{
+		0, 1, // OPTION_CLIENTID
+		0, 10, // length
+		0, 3, // DUID_LL
+		0, 1, // hwtype ethernet
+		5, 4, 3, 2, 1, 0, // hw addr
+	}
+	require.Equal(t, expected, opt.ToBytes())
+}
+
+func TestOptClientIdDecodeEncode(t *testing.T) {
+	data := []byte{
+		0, 3, // DUID_LL
+		0, 1, // hwtype ethernet
+		5, 4, 3, 2, 1, 0, // hw addr
+	}
+	expected := append([]byte{
+		0, 1, // OPTION_CLIENTID
+		0, 10, // length
+	}, data...)
+	opt, err := ParseOptClientId(data)
+	require.NoError(t, err)
+	require.Equal(t, expected, opt.ToBytes())
+}
+
+func TestOptionClientId(t *testing.T) {
+	opt := OptClientId{
+		Cid: Duid{
+			Type:          DUID_LL,
+			HwType:        iana.HwTypeEthernet,
+			LinkLayerAddr: net.HardwareAddr([]byte{0xde, 0xad, 0, 0, 0xbe, 0xef}),
+		},
+	}
+	require.Equal(t, opt.Length(), 10)
+	require.Equal(t, opt.Code(), OPTION_CLIENTID)
+}


### PR DESCRIPTION
Two things are changed in this diff:
* a breaking change: Duid.LinkLayerAddr is not a `[]byte` anymore but a more appropriate `net.HardwareAddr` (defined as a `[]byte`)
* tests for OptClientId
