### PR TITLE
Unbreak build after changing OptIANA interface

### DIFF
--- a/netboot/netconf.go
+++ b/netboot/netconf.go
@@ -38,7 +38,7 @@ func GetNetConfFromPacketv6(d *dhcpv6.DHCPv6Message) (*NetConf, error) {
 	// get IP configuration
 	oiana := opt.(*dhcpv6.OptIANA)
 	iaaddrs := make([]*dhcpv6.OptIAAddress, 0)
-	for _, o := range oiana.Options() {
+	for _, o := range oiana.Options {
 		if o.Code() == dhcpv6.OPTION_IAADDR {
 			iaaddrs = append(iaaddrs, o.(*dhcpv6.OptIAAddress))
 		}


### PR DESCRIPTION
In https://github.com/insomniacslk/dhcp/commit/bdb0bf25259985b962e230fbac5265a7623afd05 I broke the build of the netboot subackage because I mistakenly pushed to master instead of a branch + PR. Since then I've enabled branch protection, and this commit unbreaks the build.