### PR TITLE
OptUserClass does not allow empty user classes

### DIFF
--- a/dhcpv6/option_userclass.go
+++ b/dhcpv6/option_userclass.go
@@ -69,5 +69,8 @@ func ParseOptUserClass(data []byte) (*OptUserClass, error) {
 		opt.UserClasses = append(opt.UserClasses, data[2:ucLen+2])
 		data = data[2+ucLen:]
 	}
+	if len(opt.UserClasses) < 1 {
+		return nil, errors.New("ParseOptUserClass: at least one user class is required")
+	}
 	return &opt, nil
 }

--- a/dhcpv6/option_userclass_test.go
+++ b/dhcpv6/option_userclass_test.go
@@ -11,7 +11,7 @@ func TestParseOptUserClass(t *testing.T) {
 		0, 9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
 	opt, err := ParseOptUserClass(expected)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(opt.UserClasses))
 	require.Equal(t, []byte("linuxboot"), opt.UserClasses[0])
 }
@@ -22,7 +22,7 @@ func TestParseOptUserClassMultiple(t *testing.T) {
 		0, 4, 't', 'e', 's', 't',
 	}
 	opt, err := ParseOptUserClass(expected)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, len(opt.UserClasses), 2)
 	require.Equal(t, []byte("linuxboot"), opt.UserClasses[0])
 	require.Equal(t, []byte("test"), opt.UserClasses[1])
@@ -30,9 +30,8 @@ func TestParseOptUserClassMultiple(t *testing.T) {
 
 func TestParseOptUserClassNone(t *testing.T) {
 	expected := []byte{}
-	opt, err := ParseOptUserClass(expected)
-	require.Nil(t, err)
-	require.Equal(t, 0, len(opt.UserClasses))
+	_, err := ParseOptUserClass(expected)
+	require.Error(t, err)
 }
 
 func TestOptUserClassToBytes(t *testing.T) {


### PR DESCRIPTION
As noted by @pmazzini , there must be at least one user class defined if this option is used. The RFC says:

```
The data area of the user class option MUST contain one or more
instances of user class data.  Each instance of the user class data
is formatted as follows:
```

This patch enforces and tests this behaviour.