### PR TITLE
Pass through unknown DUIDs

### DIFF
--- a/dhcpv6/duid.go
+++ b/dhcpv6/duid.go
@@ -33,6 +33,7 @@ type Duid struct {
 	EnterpriseNumber     uint32 // for DUID-EN. Ignored otherwise
 	EnterpriseIdentifier []byte // for DUID-EN. Ignored otherwise
 	Uuid                 []byte // for DUID-UUID. Ignored otherwise
+	Opaque               []byte // for unknown DUIDs
 }
 
 func (d *Duid) Length() int {
@@ -44,8 +45,9 @@ func (d *Duid) Length() int {
 		return 6 + len(d.EnterpriseIdentifier)
 	} else if d.Type == DUID_UUID {
 		return 18
+	} else {
+		return 2 + len(d.Opaque)
 	}
-	panic(fmt.Sprintf("Unknown DUID type: %v", d.Type))
 }
 
 func (d *Duid) ToBytes() []byte {
@@ -69,8 +71,11 @@ func (d *Duid) ToBytes() []byte {
 		buf := make([]byte, 2)
 		binary.BigEndian.PutUint16(buf[0:2], uint16(d.Type))
 		return append(buf, d.Uuid...)
+	} else {
+		buf := make([]byte, 2)
+		binary.BigEndian.PutUint16(buf[0:2], uint16(d.Type))
+		return append(buf, d.Opaque...)
 	}
-	panic(fmt.Sprintf("Unknown DUID type: %v", d.Type))
 }
 
 func (d *Duid) String() string {
@@ -124,6 +129,8 @@ func DuidFromBytes(data []byte) (*Duid, error) {
 			return nil, fmt.Errorf("Invalid DUID-UUID length. Expected 18, got %v", len(data))
 		}
 		d.Uuid = data[2:18]
+	} else {
+		d.Opaque = data[2:]
 	}
 	return &d, nil
 }

--- a/dhcpv6/duid_test.go
+++ b/dhcpv6/duid_test.go
@@ -104,3 +104,17 @@ func TestDuidUuidToBytes(t *testing.T) {
 		t.Fatalf("Invalid ToBytes result. Expected %v, got %v", expected, toBytes)
 	}
 }
+
+func TestOpaqueDuid(t *testing.T) {
+	duid := []byte("\x00\x0a\x00\x03\x00\x01\x4c\x5e\x0c\x43\xbf\x39")
+	d, err := DuidFromBytes(duid)
+	if err != nil {
+		t.Fatalf("DuidFromBytes: unexpected error: %v", err)
+	}
+	if got, want := d.Length(), len(duid); got != want {
+		t.Errorf("Length: unexpected result: got %d, want %d", got, want)
+	}
+	if got, want := d.ToBytes(), duid; !bytes.Equal(got, want) {
+		t.Fatalf("ToBytes: unexpected result: got %x, want %x", got, want)
+	}
+}


### PR DESCRIPTION
I’m building on a program which works with user-supplied DUIDs. Before this
change, the code would panic when users provide a DUID which is not (yet)
implemented.

In addition to this being a better failure mode, the behavior is also mandated
by the DHCPv6 RFC: https://tools.ietf.org/html/rfc3315#section-9 states:

    Clients and servers MUST treat DUIDs as opaque values and MUST only
    compare DUIDs for equality.