### PR TITLE
NewSolicitWithCID for DHCPv6

### DIFF
--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -1,8 +1,10 @@
 package dhcpv6
 
 import (
+	"net"
 	"testing"
 
+	"github.com/insomniacslk/dhcp/iana"
 	"github.com/stretchr/testify/require"
 )
 
@@ -148,6 +150,38 @@ func TestNewReplyFromRebind(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, rep.(*DHCPv6Message).TransactionID(), reb.TransactionID())
 	require.Equal(t, rep.Type(), REPLY)
+}
+
+func TestNewSolicitWithCID(t *testing.T) {
+	hwAddr, err := net.ParseMAC("24:0A:9E:9F:EB:2B")
+	require.NoError(t, err)
+
+	duid := Duid{
+		Type:          DUID_LL,
+		HwType:        iana.HwTypeEthernet,
+		LinkLayerAddr: hwAddr,
+	}
+
+	s, err := NewSolicitWithCID(duid)
+	require.NoError(t, err)
+
+	require.Equal(t, s.Type(), SOLICIT)
+	// Check CID
+	cidOption := s.GetOneOption(OPTION_CLIENTID)
+	require.NotNil(t, cidOption)
+	cid, ok := cidOption.(*OptClientId)
+	require.True(t, ok)
+	require.Equal(t, cid.Cid, duid)
+
+	// Check ORO
+	oroOption := s.GetOneOption(OPTION_ORO)
+	require.NotNil(t, oroOption)
+	oro, ok := oroOption.(*OptRequestedOption)
+	require.True(t, ok)
+	opts := oro.RequestedOptions()
+	require.Contains(t, opts, DNS_RECURSIVE_NAME_SERVER)
+	require.Contains(t, opts, DOMAIN_SEARCH_LIST)
+	require.Equal(t, len(opts), 2)
 }
 
 // TODO test NewSolicit


### PR DESCRIPTION
NewSolicit provides functionality between `NewMessage` and `NewSolicitForInterface`, allowing users to create a `SOLICIT` message without the need to provide an interface. This is crucial for generating fake DHCPv6 messages (ex. for a MAC address not associated with a card on the actual device).