### PR TITLE
add NewReplyFromDHCPv6Message

### DIFF
--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -111,6 +111,10 @@ func TestNewReplyFromDHCPv6Message(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, rep.(*DHCPv6Message).TransactionID(), req.TransactionID())
 	require.Equal(t, rep.Type(), REPLY)
+
+	relay := DHCPv6Relay{}
+	rep, err = NewReplyFromDHCPv6Message(&relay)
+	require.Error(t, err)
 }
 
 // TODO test NewSolicit

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -97,23 +97,39 @@ func TestNewAdvertiseFromSolicit(t *testing.T) {
 }
 
 func TestNewReplyFromDHCPv6Message(t *testing.T) {
-	req := DHCPv6Message{}
-	req.SetMessage(REQUEST)
-	req.SetTransactionID(0xabcdef)
+	msg := DHCPv6Message{}
+	msg.SetTransactionID(0xabcdef)
 	cid := OptClientId{}
-	req.AddOption(&cid)
+	msg.AddOption(&cid)
 	sid := OptServerId{}
 	duid := Duid{}
 	sid.Sid = duid
-	req.AddOption(&sid)
+	msg.AddOption(&sid)
 
-	rep, err := NewReplyFromDHCPv6Message(&req, WithServerID(duid))
+	msg.SetMessage(CONFIRM)
+	rep, err := NewReplyFromDHCPv6Message(&msg, WithServerID(duid))
 	require.NoError(t, err)
-	require.Equal(t, rep.(*DHCPv6Message).TransactionID(), req.TransactionID())
+	require.Equal(t, rep.(*DHCPv6Message).TransactionID(), msg.TransactionID())
 	require.Equal(t, rep.Type(), REPLY)
 
 	relay := DHCPv6Relay{}
 	rep, err = NewReplyFromDHCPv6Message(&relay)
+	require.Error(t, err)
+
+	msg.SetMessage(RENEW)
+	rep, err = NewReplyFromDHCPv6Message(&msg)
+	require.Equal(t, rep.Type(), REPLY)
+
+	msg.SetMessage(REBIND)
+	rep, err = NewReplyFromDHCPv6Message(&msg)
+	require.Equal(t, rep.Type(), REPLY)
+
+	msg.SetMessage(RELEASE)
+	rep, err = NewReplyFromDHCPv6Message(&msg)
+	require.Equal(t, rep.Type(), REPLY)
+
+	msg.SetMessage(SOLICIT)
+	rep, err = NewReplyFromDHCPv6Message(&msg)
 	require.Error(t, err)
 }
 

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -82,71 +82,34 @@ func TestFromAndToBytes(t *testing.T) {
 	require.Equal(t, expected, toBytes)
 }
 
-func withServerID(d DHCPv6) DHCPv6 {
-	sid := OptServerId{}
-	d.AddOption(&sid)
-	return d
-}
-
 func TestNewAdvertiseFromSolicit(t *testing.T) {
 	s := DHCPv6Message{}
 	s.SetMessage(SOLICIT)
 	s.SetTransactionID(0xabcdef)
 	cid := OptClientId{}
 	s.AddOption(&cid)
+	duid := Duid{}
 
-	a, err := NewAdvertiseFromSolicit(&s, withServerID)
+	a, err := NewAdvertiseFromSolicit(&s, WithServerID(duid))
 	require.NoError(t, err)
 	require.Equal(t, a.(*DHCPv6Message).TransactionID(), s.TransactionID())
 	require.Equal(t, a.Type(), ADVERTISE)
 }
 
-func TestNewReplyFromRequest(t *testing.T) {
+func TestNewReplyFromDHCPv6Message(t *testing.T) {
 	req := DHCPv6Message{}
 	req.SetMessage(REQUEST)
 	req.SetTransactionID(0xabcdef)
 	cid := OptClientId{}
 	req.AddOption(&cid)
 	sid := OptServerId{}
+	duid := Duid{}
+	sid.Sid = duid
 	req.AddOption(&sid)
 
-	rep, err := NewReplyFromRequest(&req)
+	rep, err := NewReplyFromDHCPv6Message(&req, WithServerID(duid))
 	require.NoError(t, err)
 	require.Equal(t, rep.(*DHCPv6Message).TransactionID(), req.TransactionID())
-	require.Equal(t, rep.Type(), REPLY)
-}
-
-func TestNewReplyFromRenew(t *testing.T) {
-	ren := DHCPv6Message{}
-	ren.SetMessage(RENEW)
-	ren.SetTransactionID(0xabcdef)
-	cid := OptClientId{}
-	ren.AddOption(&cid)
-
-	rep, err := NewReplyFromRenew(&ren)
-	require.Error(t, err)
-
-	sid := OptServerId{}
-	ren.AddOption(&sid)
-	rep, err = NewReplyFromRenew(&ren)
-	require.Equal(t, rep.(*DHCPv6Message).TransactionID(), ren.TransactionID())
-	require.Equal(t, rep.Type(), REPLY)
-}
-
-func TestNewReplyFromRebind(t *testing.T) {
-	reb := DHCPv6Message{}
-	reb.SetMessage(REPLY)
-	rep, err := NewReplyFromRebind(&reb)
-	require.Error(t, err)
-
-	reb.SetMessage(REBIND)
-	reb.SetTransactionID(0xabcdef)
-	cid := OptClientId{}
-	reb.AddOption(&cid)
-
-	rep, err = NewReplyFromRebind(&reb)
-	require.NoError(t, err)
-	require.Equal(t, rep.(*DHCPv6Message).TransactionID(), reb.TransactionID())
 	require.Equal(t, rep.Type(), REPLY)
 }
 

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -111,10 +111,6 @@ func TestNewReplyFromDHCPv6Message(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, rep.(*DHCPv6Message).TransactionID(), req.TransactionID())
 	require.Equal(t, rep.Type(), REPLY)
-
-	relay := DHCPv6Relay{}
-	rep, err = NewReplyFromDHCPv6Message(&relay)
-	require.Error(t, err)
 }
 
 // TODO test NewSolicit

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -112,24 +112,30 @@ func TestNewReplyFromDHCPv6Message(t *testing.T) {
 	require.Equal(t, rep.(*DHCPv6Message).TransactionID(), msg.TransactionID())
 	require.Equal(t, rep.Type(), REPLY)
 
-	relay := DHCPv6Relay{}
-	rep, err = NewReplyFromDHCPv6Message(&relay)
-	require.Error(t, err)
-
 	msg.SetMessage(RENEW)
-	rep, err = NewReplyFromDHCPv6Message(&msg)
+	rep, err = NewReplyFromDHCPv6Message(&msg, WithServerID(duid))
+	require.NoError(t, err)
+	require.Equal(t, rep.(*DHCPv6Message).TransactionID(), msg.TransactionID())
 	require.Equal(t, rep.Type(), REPLY)
 
 	msg.SetMessage(REBIND)
-	rep, err = NewReplyFromDHCPv6Message(&msg)
+	rep, err = NewReplyFromDHCPv6Message(&msg, WithServerID(duid))
+	require.NoError(t, err)
+	require.Equal(t, rep.(*DHCPv6Message).TransactionID(), msg.TransactionID())
 	require.Equal(t, rep.Type(), REPLY)
 
 	msg.SetMessage(RELEASE)
-	rep, err = NewReplyFromDHCPv6Message(&msg)
+	rep, err = NewReplyFromDHCPv6Message(&msg, WithServerID(duid))
+	require.NoError(t, err)
+	require.Equal(t, rep.(*DHCPv6Message).TransactionID(), msg.TransactionID())
 	require.Equal(t, rep.Type(), REPLY)
 
 	msg.SetMessage(SOLICIT)
 	rep, err = NewReplyFromDHCPv6Message(&msg)
+	require.Error(t, err)
+
+	relay := DHCPv6Relay{}
+	rep, err = NewReplyFromDHCPv6Message(&relay)
 	require.Error(t, err)
 }
 

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -198,7 +198,9 @@ func NewRequestFromAdvertise(advertise DHCPv6, modifiers ...Modifier) (DHCPv6, e
 	return d, nil
 }
 
-// NewReplyFromDHCPv6Message creates a new REPLY packet based on a DHCPv6Message.
+// NewReplyFromDHCPv6Message creates a new REPLY packet based on a
+// DHCPv6Message. The function is to be used when generating a reply to
+// REQUEST, CONFIRM, RENEW, REBIND and RELEASE packets.
 func NewReplyFromDHCPv6Message(message DHCPv6, modifiers ...Modifier) (DHCPv6, error) {
 	if message == nil {
 		return nil, errors.New("DHCPv6Message cannot be nil")

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -198,17 +198,13 @@ func NewRequestFromAdvertise(advertise DHCPv6, modifiers ...Modifier) (DHCPv6, e
 	return d, nil
 }
 
-// NewReplyFromMessage creates a new REPLY packet based on a MESSAGE packet.
-func NewReplyFromMessage(message DHCPv6, modifiers ...Modifier) (DHCPv6, error) {
+// NewReplyFromDHCPv6Message creates a new REPLY packet based on a DHCPv6Message.
+func NewReplyFromDHCPv6Message(message DHCPv6, modifiers ...Modifier) (DHCPv6, error) {
 	if message == nil {
-		return nil, errors.New("MESSAGE cannot be nil")
+		return nil, errors.New("DHCPv6Message cannot be nil")
 	}
 	switch message.Type() {
-		case REQUEST:
-		case CONFIRM:
-		case RENEW:
-		case REBIND:
-		case RELEASE:
+		case REQUEST, CONFIRM, RENEW, REBIND, RELEASE:
 		default:
 			return nil, errors.New("Cannot create REPLY from the passed message type set")
 	}
@@ -233,35 +229,6 @@ func NewReplyFromMessage(message DHCPv6, modifiers ...Modifier) (DHCPv6, error) 
 		d = mod(d)
 	}
 	return d, nil
-}
-
-// NewReplyFromMessageWithServerID creates a new REPLY packet based on a MESSAGE packet.
-func NewReplyFromMessageWithServerID(message DHCPv6, modifiers ...Modifier) (DHCPv6, error) {
-	if message == nil {
-		return nil, errors.New("MESSAGE cannot be nil")
-	}
-	// get Server ID
-	sid := message.GetOneOption(OPTION_SERVERID)
-	if sid == nil {
-		return nil, errors.New("Server ID cannot be nil when building REPLY")
-	}
-	modifiers = append(modifiers, WithServerID(sid.(*OptServerId).Sid))
-	return NewReplyFromMessage(message, modifiers...)
-}
-
-// NewReplyFromRebind creates a new REPLY packet based on a REBIND packet.
-func NewReplyFromRebind(rebind DHCPv6, modifiers ...Modifier) (DHCPv6, error) {
-	return NewReplyFromMessage(rebind, modifiers...)
-}
-
-// NewReplyFromRenew creates a new REPLY packet based on a RENEW packet.
-func NewReplyFromRenew(renew DHCPv6, modifiers ...Modifier) (DHCPv6, error) {
-	return NewReplyFromMessageWithServerID(renew, modifiers...)
-}
-
-// NewReplyFromRequest creates a new REPLY packet based on a REQUEST packet.
-func NewReplyFromRequest(request DHCPv6, modifiers ...Modifier) (DHCPv6, error) {
-	return NewReplyFromMessageWithServerID(request, modifiers...)
 }
 
 func (d *DHCPv6Message) Type() MessageType {

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -198,26 +198,32 @@ func NewRequestFromAdvertise(advertise DHCPv6, modifiers ...Modifier) (DHCPv6, e
 	return d, nil
 }
 
-// NewReplyFromRebind creates a new REPLY packet based on a REBIND packet.
-func NewReplyFromRebind(rebind DHCPv6, modifiers ...Modifier) (DHCPv6, error) {
-	if rebind == nil {
-		return nil, errors.New("REBIND cannot be nil")
+// NewReplyFromMessage creates a new REPLY packet based on a MESSAGE packet.
+func NewReplyFromMessage(message DHCPv6, modifiers ...Modifier) (DHCPv6, error) {
+	if message == nil {
+		return nil, errors.New("MESSAGE cannot be nil")
 	}
-	if rebind.Type() != REBIND {
-		return nil, errors.New("The passed REBIND must have REBIND type set")
+	switch message.Type() {
+		case REQUEST:
+		case CONFIRM:
+		case RENEW:
+		case REBIND:
+		case RELEASE:
+		default:
+			return nil, errors.New("Cannot create REPLY from the passed message type set")
 	}
-	reb, ok := rebind.(*DHCPv6Message)
+	msg, ok := message.(*DHCPv6Message)
 	if !ok {
-		return nil, errors.New("The passed REBIND must be of DHCPv6Message type")
+		return nil, errors.New("The passed MESSAGE must be of DHCPv6Message type")
 	}
-	// build REPLY from REBIND
+	// build REPLY from MESSAGE
 	rep := DHCPv6Message{}
 	rep.SetMessage(REPLY)
-	rep.SetTransactionID(reb.TransactionID())
+	rep.SetTransactionID(msg.TransactionID())
 	// add Client ID
-	cid := reb.GetOneOption(OPTION_CLIENTID)
+	cid := message.GetOneOption(OPTION_CLIENTID)
 	if cid == nil {
-		return nil, errors.New("Client ID cannot be nil in REBIND when building REPLY")
+		return nil, errors.New("Client ID cannot be nil when building REPLY")
 	}
 	rep.AddOption(cid)
 
@@ -227,80 +233,35 @@ func NewReplyFromRebind(rebind DHCPv6, modifiers ...Modifier) (DHCPv6, error) {
 		d = mod(d)
 	}
 	return d, nil
+}
+
+// NewReplyFromMessageWithServerID creates a new REPLY packet based on a MESSAGE packet.
+func NewReplyFromMessageWithServerID(message DHCPv6, modifiers ...Modifier) (DHCPv6, error) {
+	if message == nil {
+		return nil, errors.New("MESSAGE cannot be nil")
+	}
+	// get Server ID
+	sid := message.GetOneOption(OPTION_SERVERID)
+	if sid == nil {
+		return nil, errors.New("Server ID cannot be nil when building REPLY")
+	}
+	modifiers = append(modifiers, WithServerID(sid.(*OptServerId).Sid))
+	return NewReplyFromMessage(message, modifiers...)
+}
+
+// NewReplyFromRebind creates a new REPLY packet based on a REBIND packet.
+func NewReplyFromRebind(rebind DHCPv6, modifiers ...Modifier) (DHCPv6, error) {
+	return NewReplyFromMessage(rebind, modifiers...)
 }
 
 // NewReplyFromRenew creates a new REPLY packet based on a RENEW packet.
 func NewReplyFromRenew(renew DHCPv6, modifiers ...Modifier) (DHCPv6, error) {
-	if renew == nil {
-		return nil, errors.New("RENEW cannot be nil")
-	}
-	if renew.Type() != RENEW {
-		return nil, errors.New("The passed RENEW must have RENEW type set")
-	}
-	ren, ok := renew.(*DHCPv6Message)
-	if !ok {
-		return nil, errors.New("The passed RENEW must be of DHCPv6Message type")
-	}
-	// build REPLY from RENEW
-	rep := DHCPv6Message{}
-	rep.SetMessage(REPLY)
-	rep.SetTransactionID(ren.TransactionID())
-	// add Client ID
-	cid := ren.GetOneOption(OPTION_CLIENTID)
-	if cid == nil {
-		return nil, errors.New("Client ID cannot be nil in RENEW when building REPLY")
-	}
-	rep.AddOption(cid)
-	// add Server ID
-	sid := ren.GetOneOption(OPTION_SERVERID)
-	if sid == nil {
-		return nil, errors.New("Server ID cannot be nil in RENEW when building REPLY")
-	}
-	rep.AddOption(sid)
-
-	// apply modifiers
-	d := DHCPv6(&rep)
-	for _, mod := range modifiers {
-		d = mod(d)
-	}
-	return d, nil
+	return NewReplyFromMessageWithServerID(renew, modifiers...)
 }
 
 // NewReplyFromRequest creates a new REPLY packet based on a REQUEST packet.
 func NewReplyFromRequest(request DHCPv6, modifiers ...Modifier) (DHCPv6, error) {
-	if request == nil {
-		return nil, errors.New("REQUEST cannot be nil")
-	}
-	if request.Type() != REQUEST {
-		return nil, errors.New("The passed REQUEST must have REQUEST type set")
-	}
-	req, ok := request.(*DHCPv6Message)
-	if !ok {
-		return nil, errors.New("The passed REQUEST must be of DHCPv6Message type")
-	}
-	// build REPLY from REQUEST
-	rep := DHCPv6Message{}
-	rep.SetMessage(REPLY)
-	rep.SetTransactionID(req.TransactionID())
-	// add Client ID
-	cid := req.GetOneOption(OPTION_CLIENTID)
-	if cid == nil {
-		return nil, errors.New("Client ID cannot be nil in REQUEST when building REPLY")
-	}
-	rep.AddOption(cid)
-	// add Server ID
-	sid := req.GetOneOption(OPTION_SERVERID)
-	if sid == nil {
-		return nil, errors.New("Server ID cannot be nil in REQUEST when building REPLY")
-	}
-	rep.AddOption(sid)
-
-	// apply modifiers
-	d := DHCPv6(&rep)
-	for _, mod := range modifiers {
-		d = mod(d)
-	}
-	return d, nil
+	return NewReplyFromMessageWithServerID(request, modifiers...)
 }
 
 func (d *DHCPv6Message) Type() MessageType {


### PR DESCRIPTION
Add a more generic NewReplyFromDHCPv6Message to avoid code duplication.
This is one step closer towards fixing issue #73.