### PR TITLE
Make Future buffered to avoid concurrency issues

### DIFF
--- a/dhcpv6/future.go
+++ b/dhcpv6/future.go
@@ -35,7 +35,7 @@ func (r *response) Error() error {
 
 // NewFuture creates a new future, which can be written to
 func NewFuture() chan Response {
-	return make(chan Response)
+	return make(chan Response, 1)
 }
 
 // NewResponse creates a new future response


### PR DESCRIPTION
When a future is not being listened to (ex. it timeouts before `AsyncClient` writes a response) a client will be stuck waiting. Making this channel buffered (for one message) fixes the issue.