### PR TITLE
Netboot: don't fail if no netboot url is returned

### DIFF
--- a/netboot/netboot.go
+++ b/netboot/netboot.go
@@ -87,7 +87,9 @@ func ConversationToNetconf(conversation []dhcpv6.DHCPv6) (*NetConf, string, erro
 			return nil, "", errors.New("no bootfile URL option found in ADVERTISE")
 		}
 	}
-	obf := opt.(*dhcpv6.OptBootFileURL)
-	bootfile = string(obf.BootFileURL)
+	if opt != nil {
+		obf := opt.(*dhcpv6.OptBootFileURL)
+		bootfile = string(obf.BootFileURL)
+	}
 	return netconf, bootfile, nil
 }


### PR DESCRIPTION
Currently a netboot attempt will fail if no netboot  URL is returned by the DHCPv6 server.

This patch doesn't make it fail anymore - just the returned URL will be an empty string