### PR TITLE
BSDP: Refactor to use dhcpv4.GetOneOption

### DIFF
--- a/dhcpv4/bsdp/bsdp_test.go
+++ b/dhcpv4/bsdp/bsdp_test.go
@@ -40,7 +40,7 @@ func TestParseBootImageListFromAck(t *testing.T) {
 func TestParseBootImageListFromAckNoVendorOption(t *testing.T) {
 	ack, _ := dhcpv4.New()
 	images, err := ParseBootImageListFromAck(*ack)
-	require.NoError(t, err)
+	require.Error(t, err)
 	require.Empty(t, images, "no BootImages")
 }
 

--- a/dhcpv4/bsdp/option_vendor_specific_information.go
+++ b/dhcpv4/bsdp/option_vendor_specific_information.go
@@ -143,7 +143,7 @@ func (o *OptVendorSpecificInformation) GetOptions(code dhcpv4.OptionCode) []dhcp
 }
 
 // GetOption returns the first suboption that matches the OptionCode code.
-func (o *OptVendorSpecificInformation) GetOption(code dhcpv4.OptionCode) dhcpv4.Option {
+func (o *OptVendorSpecificInformation) GetOneOption(code dhcpv4.OptionCode) dhcpv4.Option {
 	opts := o.GetOptions(code)
 	if len(opts) == 0 {
 		return nil

--- a/dhcpv4/bsdp/option_vendor_specific_information_test.go
+++ b/dhcpv4/bsdp/option_vendor_specific_information_test.go
@@ -153,7 +153,7 @@ func TestOptVendorSpecificInformationGetOptions(t *testing.T) {
 	require.Equal(t, Version1_0, foundOpts[1].(*OptVersion).Version)
 }
 
-func TestOptVendorSpecificInformationGetOption(t *testing.T) {
+func TestOptVendorSpecificInformationGetOneOption(t *testing.T) {
 	// No option
 	o := &OptVendorSpecificInformation{
 		[]dhcpv4.Option{
@@ -161,7 +161,7 @@ func TestOptVendorSpecificInformationGetOption(t *testing.T) {
 			&OptVersion{Version1_1},
 		},
 	}
-	foundOpt := o.GetOption(OptionBootImageList)
+	foundOpt := o.GetOneOption(OptionBootImageList)
 	require.Nil(t, foundOpt, "should not get options")
 
 	// One option
@@ -171,7 +171,7 @@ func TestOptVendorSpecificInformationGetOption(t *testing.T) {
 			&OptVersion{Version1_1},
 		},
 	}
-	foundOpt = o.GetOption(OptionMessageType)
+	foundOpt = o.GetOneOption(OptionMessageType)
 	require.Equal(t, MessageTypeList, foundOpt.(*OptMessageType).Type)
 
 	// Multiple options
@@ -182,6 +182,6 @@ func TestOptVendorSpecificInformationGetOption(t *testing.T) {
 			&OptVersion{Version1_0},
 		},
 	}
-	foundOpt = o.GetOption(OptionVersion)
+	foundOpt = o.GetOneOption(OptionVersion)
 	require.Equal(t, Version1_1, foundOpt.(*OptVersion).Version)
 }


### PR DESCRIPTION
Refactors BSDP code to use `dhcpv4.GetOneOption` instead of manually
searching through the list of options.