### PR TITLE
DHCPv6: Fix message type constants

### DIFF
--- a/dhcpv6/client.go
+++ b/dhcpv6/client.go
@@ -81,16 +81,16 @@ func (c *Client) sendReceive(ifname string, packet DHCPv6, expectedType MessageT
 	if packet == nil {
 		return nil, fmt.Errorf("Packet to send cannot be nil")
 	}
-	if expectedType == MSGTYPE_NONE {
+	if expectedType == MessageTypeNone {
 		// infer the expected type from the packet being sent
-		if packet.Type() == SOLICIT {
-			expectedType = ADVERTISE
-		} else if packet.Type() == REQUEST {
-			expectedType = REPLY
-		} else if packet.Type() == RELAY_FORW {
-			expectedType = RELAY_REPL
-		} else if packet.Type() == LEASEQUERY {
-			expectedType = LEASEQUERY_REPLY
+		if packet.Type() == MessageTypeSolicit {
+			expectedType = MessageTypeAdvertise
+		} else if packet.Type() == MessageTypeRequest {
+			expectedType = MessageTypeReply
+		} else if packet.Type() == MessageTypeRelayForward {
+			expectedType = MessageTypeRelayReply
+		} else if packet.Type() == MessageTypeLeaseQuery {
+			expectedType = MessageTypeLeaseQueryReply
 		} // and probably more
 	}
 	// if no LocalAddr is specified, get the interface's link-local address
@@ -167,7 +167,7 @@ func (c *Client) sendReceive(ifname string, packet DHCPv6, expectedType MessageT
 				continue
 			}
 		}
-		if expectedType == MSGTYPE_NONE {
+		if expectedType == MessageTypeNone {
 			// just take whatever arrived
 			break
 		} else if adv.Type() == expectedType {
@@ -190,7 +190,7 @@ func (c *Client) Solicit(ifname string, solicit DHCPv6, modifiers ...Modifier) (
 	for _, mod := range modifiers {
 		solicit = mod(solicit)
 	}
-	advertise, err := c.sendReceive(ifname, solicit, MSGTYPE_NONE)
+	advertise, err := c.sendReceive(ifname, solicit, MessageTypeNone)
 	return solicit, advertise, err
 }
 
@@ -207,6 +207,6 @@ func (c *Client) Request(ifname string, advertise, request DHCPv6, modifiers ...
 	for _, mod := range modifiers {
 		request = mod(request)
 	}
-	reply, err := c.sendReceive(ifname, request, MSGTYPE_NONE)
+	reply, err := c.sendReceive(ifname, request, MessageTypeNone)
 	return request, reply, err
 }

--- a/dhcpv6/dhcpv6.go
+++ b/dhcpv6/dhcpv6.go
@@ -30,7 +30,7 @@ func FromBytes(data []byte) (DHCPv6, error) {
 		headerSize  int
 		messageType = MessageType(data[0])
 	)
-	if messageType == RELAY_FORW || messageType == RELAY_REPL {
+	if messageType == MessageTypeRelayForward || messageType == MessageTypeRelayReply {
 		isRelay = true
 	}
 	if isRelay {
@@ -85,7 +85,7 @@ func NewMessage(modifiers ...Modifier) (DHCPv6, error) {
 		return nil, err
 	}
 	msg := DHCPv6Message{
-		messageType:   SOLICIT,
+		messageType:   MessageTypeSolicit,
 		transactionID: *tid,
 	}
 	// apply modifiers
@@ -181,7 +181,7 @@ func DecapsulateRelayIndex(l DHCPv6, index int) (DHCPv6, error) {
 // message as payload. The passed message type must be  either RELAY_FORW or
 // RELAY_REPL
 func EncapsulateRelay(d DHCPv6, mType MessageType, linkAddr, peerAddr net.IP) (DHCPv6, error) {
-	if mType != RELAY_FORW && mType != RELAY_REPL {
+	if mType != MessageTypeRelayForward && mType != MessageTypeRelayReply {
 		return nil, fmt.Errorf("Message type must be either RELAY_FORW or RELAY_REPL")
 	}
 	outer := DHCPv6Relay{

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -71,7 +71,7 @@ func NewSolicitWithCID(duid Duid, modifiers ...Modifier) (DHCPv6, error) {
 	if err != nil {
 		return nil, err
 	}
-	d.(*DHCPv6Message).SetMessage(SOLICIT)
+	d.(*DHCPv6Message).SetMessage(MessageTypeSolicit)
 	d.AddOption(&OptClientId{Cid: duid})
 	oro := new(OptRequestedOption)
 	oro.SetRequestedOptions([]OptionCode{
@@ -114,7 +114,7 @@ func NewAdvertiseFromSolicit(solicit DHCPv6, modifiers ...Modifier) (DHCPv6, err
 	if solicit == nil {
 		return nil, errors.New("SOLICIT cannot be nil")
 	}
-	if solicit.Type() != SOLICIT {
+	if solicit.Type() != MessageTypeSolicit {
 		return nil, errors.New("The passed SOLICIT must have SOLICIT type set")
 	}
 	sol, ok := solicit.(*DHCPv6Message)
@@ -123,7 +123,7 @@ func NewAdvertiseFromSolicit(solicit DHCPv6, modifiers ...Modifier) (DHCPv6, err
 	}
 	// build ADVERTISE from SOLICIT
 	adv := DHCPv6Message{}
-	adv.SetMessage(ADVERTISE)
+	adv.SetMessage(MessageTypeAdvertise)
 	adv.SetTransactionID(sol.TransactionID())
 	// add Client ID
 	cid := sol.GetOneOption(OPTION_CLIENTID)
@@ -146,7 +146,7 @@ func NewRequestFromAdvertise(advertise DHCPv6, modifiers ...Modifier) (DHCPv6, e
 	if advertise == nil {
 		return nil, fmt.Errorf("ADVERTISE cannot be nil")
 	}
-	if advertise.Type() != ADVERTISE {
+	if advertise.Type() != MessageTypeAdvertise {
 		return nil, fmt.Errorf("The passed ADVERTISE must have ADVERTISE type set")
 	}
 	adv, ok := advertise.(*DHCPv6Message)
@@ -155,7 +155,7 @@ func NewRequestFromAdvertise(advertise DHCPv6, modifiers ...Modifier) (DHCPv6, e
 	}
 	// build REQUEST from ADVERTISE
 	req := DHCPv6Message{}
-	req.SetMessage(REQUEST)
+	req.SetMessage(MessageTypeRequest)
 	req.SetTransactionID(adv.TransactionID())
 	// add Client ID
 	cid := adv.GetOneOption(OPTION_CLIENTID)
@@ -207,9 +207,9 @@ func NewReplyFromDHCPv6Message(message DHCPv6, modifiers ...Modifier) (DHCPv6, e
 		return nil, errors.New("DHCPv6Message cannot be nil")
 	}
 	switch message.Type() {
-		case REQUEST, CONFIRM, RENEW, REBIND, RELEASE:
-		default:
-			return nil, errors.New("Cannot create REPLY from the passed message type set")
+	case MessageTypeRequest, MessageTypeConfirm, MessageTypeRenew, MessageTypeRebind, MessageTypeRelease:
+	default:
+		return nil, errors.New("Cannot create REPLY from the passed message type set")
 	}
 	msg, ok := message.(*DHCPv6Message)
 	if !ok {
@@ -217,7 +217,7 @@ func NewReplyFromDHCPv6Message(message DHCPv6, modifiers ...Modifier) (DHCPv6, e
 	}
 	// build REPLY from MESSAGE
 	rep := DHCPv6Message{}
-	rep.SetMessage(REPLY)
+	rep.SetMessage(MessageTypeReply)
 	rep.SetTransactionID(msg.TransactionID())
 	// add Client ID
 	cid := message.GetOneOption(OPTION_CLIENTID)
@@ -243,7 +243,7 @@ func (d *DHCPv6Message) SetMessage(messageType MessageType) {
 	if msgString == "" {
 		log.Printf("Warning: unknown DHCPv6 message type: %v", messageType)
 	}
-	if messageType == RELAY_FORW || messageType == RELAY_REPL {
+	if messageType == MessageTypeRelayForward || messageType == MessageTypeRelayReply {
 		log.Printf("Warning: using a RELAY message type with a non-relay message: %v (%v)",
 			msgString, messageType)
 	}

--- a/dhcpv6/dhcpv6relay.go
+++ b/dhcpv6/dhcpv6relay.go
@@ -173,7 +173,7 @@ func NewRelayReplFromRelayForw(relayForw, msg DHCPv6) (DHCPv6, error) {
 	if !ok {
 		return nil, errors.New("Not a DHCPv6Relay")
 	}
-	if relay.Type() != RELAY_FORW {
+	if relay.Type() != MessageTypeRelayForward {
 		return nil, errors.New("The passed packet is not of type RELAY_FORW")
 	}
 	if msg == nil {
@@ -197,7 +197,7 @@ func NewRelayReplFromRelayForw(relayForw, msg DHCPv6) (DHCPv6, error) {
 		}
 	}
 	for i := len(linkAddr) - 1; i >= 0; i-- {
-		msg, err = EncapsulateRelay(msg, RELAY_REPL, linkAddr[i], peerAddr[i])
+		msg, err = EncapsulateRelay(msg, MessageTypeRelayReply, linkAddr[i], peerAddr[i])
 		if opt := optiids[i]; opt != nil {
 			msg.AddOption(opt)
 		}

--- a/dhcpv6/option_relaymsg_test.go
+++ b/dhcpv6/option_relaymsg_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestRelayMsgParseOptRelayMsg(t *testing.T) {
 	opt, err := ParseOptRelayMsg([]byte{
-		1,                // SOLICIT
+		1,                // MessageTypeSolicit
 		0xaa, 0xbb, 0xcc, // transaction ID
 		0, 8, // option: elapsed time
 		0, 2, // option length
@@ -27,7 +27,7 @@ func TestRelayMsgOptionsFromBytes(t *testing.T) {
 	opts, err := OptionsFromBytes([]byte{
 		0, 9, // option: relay message
 		0, 10, // relayed message length
-		1,                // SOLICIT
+		1,                // MessageTypeSolicit
 		0xaa, 0xbb, 0xcc, // transaction ID
 		0, 8, // option: elapsed time
 		0, 2, // option length
@@ -55,7 +55,7 @@ func TestRelayMsgParseOptRelayMsgSingleEncapsulation(t *testing.T) {
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, // peerAddr
 		0, 9, // option: relay message
 		0, 10, // relayed message length
-		1,                // SOLICIT
+		1,                // MessageTypeSolicit
 		0xaa, 0xbb, 0xcc, // transaction ID
 		0, 8, // option: elapsed time
 		0, 2, // option length
@@ -70,8 +70,8 @@ func TestRelayMsgParseOptRelayMsgSingleEncapsulation(t *testing.T) {
 			reflect.TypeOf(d),
 		)
 	}
-	if mType := r.Type(); mType != RELAY_FORW {
-		t.Fatalf("Invalid messge type for relay. Expected %v, got %v", RELAY_FORW, mType)
+	if mType := r.Type(); mType != MessageTypeRelayForward {
+		t.Fatalf("Invalid messge type for relay. Expected %v, got %v", MessageTypeRelayForward, mType)
 	}
 	if len(r.options) != 1 {
 		t.Fatalf("Invalid number of options. Expected 1, got %v", len(r.options))
@@ -94,9 +94,9 @@ func TestRelayMsgParseOptRelayMsgSingleEncapsulation(t *testing.T) {
 			reflect.TypeOf(innerDHCP),
 		)
 	}
-	if dType := innerDHCP.Type(); dType != SOLICIT {
-		t.Fatalf("Invalid inner DHCP type. Expected SOLICIT (%v), got %v",
-			SOLICIT, dType,
+	if dType := innerDHCP.Type(); dType != MessageTypeSolicit {
+		t.Fatalf("Invalid inner DHCP type. Expected MessageTypeSolicit (%v), got %v",
+			MessageTypeSolicit, dType,
 		)
 	}
 	if tID := innerDHCP.TransactionID(); tID != 0xaabbcc {

--- a/dhcpv6/types.go
+++ b/dhcpv6/types.go
@@ -2,53 +2,59 @@ package dhcpv6
 
 // from http://www.networksorcery.com/enp/protocol/dhcpv6.htm
 
+// MessageType represents the kind of DHCPv6 message.
 type MessageType uint8
 
+// The different kinds of DHCPv6 message types.
 const (
-	// MSGTYPE_NONE is used internally and is not part of the RFC
-	MSGTYPE_NONE        MessageType = 0
-	SOLICIT             MessageType = 1
-	ADVERTISE           MessageType = 2
-	REQUEST             MessageType = 3
-	CONFIRM             MessageType = 4
-	RENEW               MessageType = 5
-	REBIND              MessageType = 6
-	REPLY               MessageType = 7
-	RELEASE             MessageType = 8
-	DECLINE             MessageType = 9
-	RECONFIGURE         MessageType = 10
-	INFORMATION_REQUEST MessageType = 11
-	RELAY_FORW          MessageType = 12
-	RELAY_REPL          MessageType = 13
-	LEASEQUERY          MessageType = 14
-	LEASEQUERY_REPLY    MessageType = 15
-	LEASEQUERY_DONE     MessageType = 16
-	LEASEQUERY_DATA     MessageType = 17
+	// MessageTypeNone is used internally and is not part of the RFC
+	MessageTypeNone               MessageType = 0
+	MessageTypeSolicit            MessageType = 1
+	MessageTypeAdvertise          MessageType = 2
+	MessageTypeRequest            MessageType = 3
+	MessageTypeConfirm            MessageType = 4
+	MessageTypeRenew              MessageType = 5
+	MessageTypeRebind             MessageType = 6
+	MessageTypeReply              MessageType = 7
+	MessageTypeRelease            MessageType = 8
+	MessageTypeDecline            MessageType = 9
+	MessageTypeReconfigure        MessageType = 10
+	MessageTypeInformationRequest MessageType = 11
+	MessageTypeRelayForward       MessageType = 12
+	MessageTypeRelayReply         MessageType = 13
+	MessageTypeLeaseQuery         MessageType = 14
+	MessageTypeLeaseQueryReply    MessageType = 15
+	MessageTypeLeaseQueryDone     MessageType = 16
+	MessageTypeLeaseQueryData     MessageType = 17
 )
 
+// MessageTypeToString converts a MessageType to a human-readable string
+// representation.
 func MessageTypeToString(t MessageType) string {
-	if m := MessageTypeToStringMap[t]; m != "" {
+	if m, ok := MessageTypeToStringMap[t]; ok {
 		return m
 	}
 	return "Unknown"
 }
 
+// MessageTypeToStringMap contains the mapping of MessageTypes to human-readable
+// strings.
 var MessageTypeToStringMap = map[MessageType]string{
-	SOLICIT:             "SOLICIT",
-	ADVERTISE:           "ADVERTISE",
-	REQUEST:             "REQUEST",
-	CONFIRM:             "CONFIRM",
-	RENEW:               "RENEW",
-	REBIND:              "REBIND",
-	REPLY:               "REPLY",
-	RELEASE:             "RELEASE",
-	DECLINE:             "DECLINE",
-	RECONFIGURE:         "RECONFIGURE",
-	INFORMATION_REQUEST: "INFORMATION-REQUEST",
-	RELAY_FORW:          "RELAY-FORW",
-	RELAY_REPL:          "RELAY-REPL",
-	LEASEQUERY:          "LEASEQUERY",
-	LEASEQUERY_REPLY:    "LEASEQUERY-REPLY",
-	LEASEQUERY_DONE:     "LEASEQUERY-DONE",
-	LEASEQUERY_DATA:     "LEASEQUERY-DATA",
+	MessageTypeSolicit:            "SOLICIT",
+	MessageTypeAdvertise:          "ADVERTISE",
+	MessageTypeRequest:            "REQUEST",
+	MessageTypeConfirm:            "CONFIRM",
+	MessageTypeRenew:              "RENEW",
+	MessageTypeRebind:             "REBIND",
+	MessageTypeReply:              "REPLY",
+	MessageTypeRelease:            "RELEASE",
+	MessageTypeDecline:            "DECLINE",
+	MessageTypeReconfigure:        "RECONFIGURE",
+	MessageTypeInformationRequest: "INFORMATION-REQUEST",
+	MessageTypeRelayForward:       "RELAY-FORW",
+	MessageTypeRelayReply:         "RELAY-REPL",
+	MessageTypeLeaseQuery:         "LEASEQUERY",
+	MessageTypeLeaseQueryReply:    "LEASEQUERY-REPLY",
+	MessageTypeLeaseQueryDone:     "LEASEQUERY-DONE",
+	MessageTypeLeaseQueryData:     "LEASEQUERY-DATA",
 }

--- a/dhcpv6/utils_test.go
+++ b/dhcpv6/utils_test.go
@@ -61,7 +61,7 @@ func TestGetTransactionIDMessage(t *testing.T) {
 func TestGetTransactionIDRelay(t *testing.T) {
 	message, err := NewMessage()
 	require.NoError(t, err)
-	relay, err := EncapsulateRelay(message, RELAY_FORW, nil, nil)
+	relay, err := EncapsulateRelay(message, MessageTypeRelayForward, nil, nil)
 	require.NoError(t, err)
 	transactionID, err := GetTransactionID(relay)
 	require.NoError(t, err)

--- a/netboot/netboot.go
+++ b/netboot/netboot.go
@@ -50,7 +50,7 @@ func ConversationToNetconf(conversation []dhcpv6.DHCPv6) (*NetConf, string, erro
 	var reply dhcpv6.DHCPv6
 	for _, m := range conversation {
 		// look for a REPLY
-		if m.Type() == dhcpv6.REPLY {
+		if m.Type() == dhcpv6.MessageTypeReply {
 			reply = m
 			break
 		}
@@ -74,7 +74,7 @@ func ConversationToNetconf(conversation []dhcpv6.DHCPv6) (*NetConf, string, erro
 		var advertise dhcpv6.DHCPv6
 		for _, m := range conversation {
 			// look for an ADVERTISE
-			if m.Type() == dhcpv6.ADVERTISE {
+			if m.Type() == dhcpv6.MessageTypeAdvertise {
 				advertise = m
 				break
 			}


### PR DESCRIPTION
Renames DHCPv6 constants for message types to CamelCase