### PR TITLE
DHCPv6: Rename Option constants to CamelCase

### DIFF
--- a/dhcpv4/option_userclass_test.go
+++ b/dhcpv4/option_userclass_test.go
@@ -12,7 +12,7 @@ func TestOptUserClassToBytes(t *testing.T) {
 	}
 	data := opt.ToBytes()
 	expected := []byte{
-		77, // OPTION_USER_CLASS
+		77, // OptionUserClass
 		10, // length
 		9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
@@ -57,7 +57,7 @@ func TestOptUserClassToBytesMultiple(t *testing.T) {
 	}
 	data := opt.ToBytes()
 	expected := []byte{
-		77, // OPTION_USER_CLASS
+		77, // OptionUserClass
 		15, // length
 		9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 		4, 't', 'e', 's', 't',

--- a/dhcpv6/dhcpv6.go
+++ b/dhcpv6/dhcpv6.go
@@ -134,7 +134,7 @@ func DecapsulateRelay(l DHCPv6) (DHCPv6, error) {
 	if !l.IsRelay() {
 		return l, nil
 	}
-	opt := l.GetOneOption(OPTION_RELAY_MSG)
+	opt := l.GetOneOption(OptionRelayMsg)
 	if opt == nil {
 		return nil, fmt.Errorf("No OptRelayMsg found")
 	}

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -198,20 +198,20 @@ func TestNewMessageTypeSolicitWithCID(t *testing.T) {
 
 	require.Equal(t, s.Type(), MessageTypeSolicit)
 	// Check CID
-	cidOption := s.GetOneOption(OPTION_CLIENTID)
+	cidOption := s.GetOneOption(OptionClientID)
 	require.NotNil(t, cidOption)
 	cid, ok := cidOption.(*OptClientId)
 	require.True(t, ok)
 	require.Equal(t, cid.Cid, duid)
 
 	// Check ORO
-	oroOption := s.GetOneOption(OPTION_ORO)
+	oroOption := s.GetOneOption(OptionORO)
 	require.NotNil(t, oroOption)
 	oro, ok := oroOption.(*OptRequestedOption)
 	require.True(t, ok)
 	opts := oro.RequestedOptions()
-	require.Contains(t, opts, DNS_RECURSIVE_NAME_SERVER)
-	require.Contains(t, opts, DOMAIN_SEARCH_LIST)
+	require.Contains(t, opts, OptionDNSRecursiveNameServer)
+	require.Contains(t, opts, OptionDomainSearchList)
 	require.Equal(t, len(opts), 2)
 }
 

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -75,8 +75,8 @@ func NewSolicitWithCID(duid Duid, modifiers ...Modifier) (DHCPv6, error) {
 	d.AddOption(&OptClientId{Cid: duid})
 	oro := new(OptRequestedOption)
 	oro.SetRequestedOptions([]OptionCode{
-		DNS_RECURSIVE_NAME_SERVER,
-		DOMAIN_SEARCH_LIST,
+		OptionDNSRecursiveNameServer,
+		OptionDomainSearchList,
 	})
 	d.AddOption(oro)
 	d.AddOption(&OptElapsedTime{})
@@ -126,7 +126,7 @@ func NewAdvertiseFromSolicit(solicit DHCPv6, modifiers ...Modifier) (DHCPv6, err
 	adv.SetMessage(MessageTypeAdvertise)
 	adv.SetTransactionID(sol.TransactionID())
 	// add Client ID
-	cid := sol.GetOneOption(OPTION_CLIENTID)
+	cid := sol.GetOneOption(OptionClientID)
 	if cid == nil {
 		return nil, errors.New("Client ID cannot be nil in SOLICIT when building ADVERTISE")
 	}
@@ -158,13 +158,13 @@ func NewRequestFromAdvertise(advertise DHCPv6, modifiers ...Modifier) (DHCPv6, e
 	req.SetMessage(MessageTypeRequest)
 	req.SetTransactionID(adv.TransactionID())
 	// add Client ID
-	cid := adv.GetOneOption(OPTION_CLIENTID)
+	cid := adv.GetOneOption(OptionClientID)
 	if cid == nil {
 		return nil, fmt.Errorf("Client ID cannot be nil in ADVERTISE when building REQUEST")
 	}
 	req.AddOption(cid)
 	// add Server ID
-	sid := adv.GetOneOption(OPTION_SERVERID)
+	sid := adv.GetOneOption(OptionServerID)
 	if sid == nil {
 		return nil, fmt.Errorf("Server ID cannot be nil in ADVERTISE when building REQUEST")
 	}
@@ -172,7 +172,7 @@ func NewRequestFromAdvertise(advertise DHCPv6, modifiers ...Modifier) (DHCPv6, e
 	// add Elapsed Time
 	req.AddOption(&OptElapsedTime{})
 	// add IA_NA
-	iaNa := adv.GetOneOption(OPTION_IA_NA)
+	iaNa := adv.GetOneOption(OptionIANA)
 	if iaNa == nil {
 		return nil, fmt.Errorf("IA_NA cannot be nil in ADVERTISE when building REQUEST")
 	}
@@ -180,13 +180,13 @@ func NewRequestFromAdvertise(advertise DHCPv6, modifiers ...Modifier) (DHCPv6, e
 	// add OptRequestedOption
 	oro := OptRequestedOption{}
 	oro.SetRequestedOptions([]OptionCode{
-		DNS_RECURSIVE_NAME_SERVER,
-		DOMAIN_SEARCH_LIST,
+		OptionDNSRecursiveNameServer,
+		OptionDomainSearchList,
 	})
 	req.AddOption(&oro)
 	// add OPTION_VENDOR_CLASS, only if present in the original request
 	// TODO implement OptionVendorClass
-	vClass := adv.GetOneOption(OPTION_VENDOR_CLASS)
+	vClass := adv.GetOneOption(OptionVendorClass)
 	if vClass != nil {
 		req.AddOption(vClass)
 	}
@@ -220,7 +220,7 @@ func NewReplyFromDHCPv6Message(message DHCPv6, modifiers ...Modifier) (DHCPv6, e
 	rep.SetMessage(MessageTypeReply)
 	rep.SetTransactionID(msg.TransactionID())
 	// add Client ID
-	cid := message.GetOneOption(OPTION_CLIENTID)
+	cid := message.GetOneOption(OptionClientID)
 	if cid == nil {
 		return nil, errors.New("Client ID cannot be nil when building REPLY")
 	}

--- a/dhcpv6/dhcpv6relay.go
+++ b/dhcpv6/dhcpv6relay.go
@@ -185,7 +185,7 @@ func NewRelayReplFromRelayForw(relayForw, msg DHCPv6) (DHCPv6, error) {
 	for {
 		linkAddr = append(linkAddr, relay.LinkAddr())
 		peerAddr = append(peerAddr, relay.PeerAddr())
-		optiids = append(optiids, relay.GetOneOption(OPTION_INTERFACE_ID))
+		optiids = append(optiids, relay.GetOneOption(OptionInterfaceID))
 		decap, err := DecapsulateRelay(relay)
 		if err != nil {
 			return nil, err

--- a/dhcpv6/modifiers.go
+++ b/dhcpv6/modifiers.go
@@ -29,15 +29,15 @@ func WithNetboot(d DHCPv6) DHCPv6 {
 		log.Printf("WithNetboot: not a DHCPv6Message")
 		return d
 	}
-	// add OPT_BOOTFILE_URL and OPT_BOOTFILE_PARAM
-	opt := msg.GetOneOption(OPTION_ORO)
+	// add OptionBootfileURL and OptionBootfileParam
+	opt := msg.GetOneOption(OptionORO)
 	if opt == nil {
 		opt = &OptRequestedOption{}
 	}
 	// TODO only add options if they are not there already
 	oro := opt.(*OptRequestedOption)
-	oro.AddRequestedOption(OPT_BOOTFILE_URL)
-	oro.AddRequestedOption(OPT_BOOTFILE_PARAM)
+	oro.AddRequestedOption(OptionBootfileURL)
+	oro.AddRequestedOption(OptionBootfileParam)
 	msg.UpdateOption(oro)
 	return d
 }

--- a/dhcpv6/modifiers_test.go
+++ b/dhcpv6/modifiers_test.go
@@ -16,7 +16,7 @@ func TestWithClientID(t *testing.T) {
 	}
 	m, err := NewMessage(WithClientID(duid))
 	require.NoError(t, err)
-	opt := m.GetOneOption(OPTION_CLIENTID)
+	opt := m.GetOneOption(OptionClientID)
 	require.NotNil(t, opt)
 	cid := opt.(*OptClientId)
 	require.Equal(t, cid.Cid, duid)
@@ -30,7 +30,7 @@ func TestWithServerID(t *testing.T) {
 	}
 	m, err := NewMessage(WithServerID(duid))
 	require.NoError(t, err)
-	opt := m.GetOneOption(OPTION_SERVERID)
+	opt := m.GetOneOption(OptionServerID)
 	require.NotNil(t, opt)
 	sid := opt.(*OptServerId)
 	require.Equal(t, sid.Sid, duid)

--- a/dhcpv6/option_archtype.go
+++ b/dhcpv6/option_archtype.go
@@ -45,12 +45,12 @@ type OptClientArchType struct {
 }
 
 func (op *OptClientArchType) Code() OptionCode {
-	return OPTION_CLIENT_ARCH_TYPE
+	return OptionClientArchType
 }
 
 func (op *OptClientArchType) ToBytes() []byte {
 	buf := make([]byte, 6)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_CLIENT_ARCH_TYPE))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionClientArchType))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	binary.BigEndian.PutUint16(buf[4:6], uint16(op.ArchType))
 	return buf

--- a/dhcpv6/option_archtype_test.go
+++ b/dhcpv6/option_archtype_test.go
@@ -26,7 +26,7 @@ func TestOptClientArchTypeParseAndToBytes(t *testing.T) {
 		0, 8, // EFI_XSCALE
 	}
 	expected := []byte{
-		0, 61, // OPTION_CLIENT_ARCH_TYPE
+		0, 61, // OptionClientArchType
 		0, 2, // length
 		0, 8, // EFI_XSCALE
 	}
@@ -40,5 +40,5 @@ func TestOptClientArchType(t *testing.T) {
 		ArchType: EFI_ITANIUM,
 	}
 	require.Equal(t, opt.Length(), 2)
-	require.Equal(t, opt.Code(), OPTION_CLIENT_ARCH_TYPE)
+	require.Equal(t, opt.Code(), OptionClientArchType)
 }

--- a/dhcpv6/option_bootfileurl.go
+++ b/dhcpv6/option_bootfileurl.go
@@ -8,20 +8,20 @@ import (
 	"fmt"
 )
 
-// OptBootFileURL implements the OPT_BOOTFILE_URL option
+// OptBootFileURL implements the OptionBootfileURL option
 type OptBootFileURL struct {
 	BootFileURL []byte
 }
 
 // Code returns the option code
 func (op *OptBootFileURL) Code() OptionCode {
-	return OPT_BOOTFILE_URL
+	return OptionBootfileURL
 }
 
 // ToBytes serializes the option and returns it as a sequence of bytes
 func (op *OptBootFileURL) ToBytes() []byte {
 	buf := make([]byte, 4)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPT_BOOTFILE_URL))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionBootfileURL))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(len(op.BootFileURL)))
 	buf = append(buf, op.BootFileURL...)
 	return buf

--- a/dhcpv6/option_clientid.go
+++ b/dhcpv6/option_clientid.go
@@ -14,12 +14,12 @@ type OptClientId struct {
 }
 
 func (op *OptClientId) Code() OptionCode {
-	return OPTION_CLIENTID
+	return OptionClientID
 }
 
 func (op *OptClientId) ToBytes() []byte {
 	buf := make([]byte, 4)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_CLIENTID))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionClientID))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	buf = append(buf, op.Cid.ToBytes()...)
 	return buf

--- a/dhcpv6/option_clientid_test.go
+++ b/dhcpv6/option_clientid_test.go
@@ -30,7 +30,7 @@ func TestOptClientIdToBytes(t *testing.T) {
 		},
 	}
 	expected := []byte{
-		0, 1, // OPTION_CLIENTID
+		0, 1, // OptionClientID
 		0, 10, // length
 		0, 3, // DUID_LL
 		0, 1, // hwtype ethernet
@@ -46,7 +46,7 @@ func TestOptClientIdDecodeEncode(t *testing.T) {
 		5, 4, 3, 2, 1, 0, // hw addr
 	}
 	expected := append([]byte{
-		0, 1, // OPTION_CLIENTID
+		0, 1, // OptionClientID
 		0, 10, // length
 	}, data...)
 	opt, err := ParseOptClientId(data)
@@ -63,5 +63,5 @@ func TestOptionClientId(t *testing.T) {
 		},
 	}
 	require.Equal(t, opt.Length(), 10)
-	require.Equal(t, opt.Code(), OPTION_CLIENTID)
+	require.Equal(t, opt.Code(), OptionClientID)
 }

--- a/dhcpv6/option_dnsrecursivenameserver.go
+++ b/dhcpv6/option_dnsrecursivenameserver.go
@@ -9,21 +9,21 @@ import (
 	"net"
 )
 
-// OptDNSRecursiveNameServer represents a DNS_RECURSIVE_NAME_SERVER option
+// OptDNSRecursiveNameServer represents a OptionDNSRecursiveNameServer option
 type OptDNSRecursiveNameServer struct {
 	NameServers []net.IP
 }
 
 // Code returns the option code
 func (op *OptDNSRecursiveNameServer) Code() OptionCode {
-	return DNS_RECURSIVE_NAME_SERVER
+	return OptionDNSRecursiveNameServer
 }
 
 // ToBytes returns the option serialized to bytes, including option code and
 // length
 func (op *OptDNSRecursiveNameServer) ToBytes() []byte {
 	buf := make([]byte, 4)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(DNS_RECURSIVE_NAME_SERVER))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionDNSRecursiveNameServer))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	for _, ns := range op.NameServers {
 		buf = append(buf, ns...)

--- a/dhcpv6/option_dnsrecursivenameserver_test.go
+++ b/dhcpv6/option_dnsrecursivenameserver_test.go
@@ -25,7 +25,7 @@ func TestOptDNSRecursiveNameServerToBytes(t *testing.T) {
 	ns2 := net.ParseIP("2001:4860:4860::8888")
 	nameservers := []net.IP{ns1, ns2}
 	expected := []byte{
-		0, 23, // DNS_RECURSIVE_NAME_SERVER
+		0, 23, // OptionDNSRecursiveNameServer
 		0, 32, // length
 	}
 	expected = append(expected, []byte(ns1)...)

--- a/dhcpv6/option_domainsearchlist.go
+++ b/dhcpv6/option_domainsearchlist.go
@@ -8,18 +8,18 @@ import (
 	"fmt"
 )
 
-// OptDomainSearchList list implements a DOMAIN_SEARCH_LIST option
+// OptDomainSearchList list implements a OptionDomainSearchList option
 type OptDomainSearchList struct {
 	DomainSearchList []string
 }
 
 func (op *OptDomainSearchList) Code() OptionCode {
-	return DOMAIN_SEARCH_LIST
+	return OptionDomainSearchList
 }
 
 func (op *OptDomainSearchList) ToBytes() []byte {
 	buf := make([]byte, 4)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(DOMAIN_SEARCH_LIST))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionDomainSearchList))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	buf = append(buf, LabelsToBytes(op.DomainSearchList)...)
 	return buf

--- a/dhcpv6/option_domainsearchlist_test.go
+++ b/dhcpv6/option_domainsearchlist_test.go
@@ -20,7 +20,7 @@ func TestParseOptDomainSearchList(t *testing.T) {
 
 func TestOptDomainSearchListToBytes(t *testing.T) {
 	expected := []byte{
-		0, 24, // DOMAIN_SEARCH_LIST
+		0, 24, // OptionDomainSearchList
 		0, 33, // length
 		7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
 		6, 's', 'u', 'b', 'n', 'e', 't', 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'o', 'r', 'g', 0,

--- a/dhcpv6/option_elapsedtime.go
+++ b/dhcpv6/option_elapsedtime.go
@@ -13,12 +13,12 @@ type OptElapsedTime struct {
 }
 
 func (op *OptElapsedTime) Code() OptionCode {
-	return OPTION_ELAPSED_TIME
+	return OptionElapsedTime
 }
 
 func (op *OptElapsedTime) ToBytes() []byte {
 	buf := make([]byte, 6)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_ELAPSED_TIME))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionElapsedTime))
 	binary.BigEndian.PutUint16(buf[2:4], 2)
 	binary.BigEndian.PutUint16(buf[4:6], uint16(op.ElapsedTime))
 	return buf

--- a/dhcpv6/option_iaaddress.go
+++ b/dhcpv6/option_iaaddress.go
@@ -9,7 +9,7 @@ import (
 	"net"
 )
 
-// OptIAAddress represents an OPTION_IAADDR
+// OptIAAddress represents an OptionIAAddr
 type OptIAAddress struct {
 	IPv6Addr          net.IP
 	PreferredLifetime uint32
@@ -19,13 +19,13 @@ type OptIAAddress struct {
 
 // Code returns the option's code
 func (op *OptIAAddress) Code() OptionCode {
-	return OPTION_IAADDR
+	return OptionIAAddr
 }
 
 // ToBytes serializes the option and returns it as a sequence of bytes
 func (op *OptIAAddress) ToBytes() []byte {
 	buf := make([]byte, 28)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_IAADDR))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionIAAddr))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	copy(buf[4:20], op.IPv6Addr[:])
 	binary.BigEndian.PutUint32(buf[20:24], op.PreferredLifetime)

--- a/dhcpv6/option_iaaddress_test.go
+++ b/dhcpv6/option_iaaddress_test.go
@@ -45,7 +45,7 @@ func TestOptIAAddressParseInvalidBrokenOptions(t *testing.T) {
 
 func TestOptIAAddressToBytes(t *testing.T) {
 	expected := []byte{
-		0, 5, // OPTION_IAADDR
+		0, 5, // OptionIAAddr
 		0, 30, // length
 	}
 	ipBytes := []byte{0x24, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}

--- a/dhcpv6/option_iaprefix.go
+++ b/dhcpv6/option_iaprefix.go
@@ -18,12 +18,12 @@ type OptIAPrefix struct {
 }
 
 func (op *OptIAPrefix) Code() OptionCode {
-	return OPTION_IAPREFIX
+	return OptionIAPrefix
 }
 
 func (op *OptIAPrefix) ToBytes() []byte {
 	buf := make([]byte, 12)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_IAPREFIX))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionIAPrefix))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	binary.BigEndian.PutUint32(buf[4:8], op.preferredLifetime)
 	binary.BigEndian.PutUint32(buf[8:12], op.validLifetime)

--- a/dhcpv6/option_interfaceid.go
+++ b/dhcpv6/option_interfaceid.go
@@ -13,12 +13,12 @@ type OptInterfaceId struct {
 }
 
 func (op *OptInterfaceId) Code() OptionCode {
-	return OPTION_INTERFACE_ID
+	return OptionInterfaceID
 }
 
 func (op *OptInterfaceId) ToBytes() []byte {
 	buf := make([]byte, 4)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_INTERFACE_ID))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionInterfaceID))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(len(op.interfaceId)))
 	buf = append(buf, op.interfaceId...)
 	return buf

--- a/dhcpv6/option_nii.go
+++ b/dhcpv6/option_nii.go
@@ -33,12 +33,12 @@ type OptNetworkInterfaceId struct {
 }
 
 func (op *OptNetworkInterfaceId) Code() OptionCode {
-	return OPTION_NII
+	return OptionNII
 }
 
 func (op *OptNetworkInterfaceId) ToBytes() []byte {
 	buf := make([]byte, 7)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_NII))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionNII))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	buf[4] = op.type_
 	buf[5] = op.major

--- a/dhcpv6/option_nontemporaryaddress.go
+++ b/dhcpv6/option_nontemporaryaddress.go
@@ -16,12 +16,12 @@ type OptIANA struct {
 }
 
 func (op *OptIANA) Code() OptionCode {
-	return OPTION_IA_NA
+	return OptionIANA
 }
 
 func (op *OptIANA) ToBytes() []byte {
 	buf := make([]byte, 16)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_IA_NA))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionIANA))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	copy(buf[4:8], op.IaId[:])
 	binary.BigEndian.PutUint32(buf[8:12], op.T1)

--- a/dhcpv6/option_nontemporaryaddress_test.go
+++ b/dhcpv6/option_nontemporaryaddress_test.go
@@ -47,7 +47,7 @@ func TestOptIANAGetOneOption(t *testing.T) {
 	opt := OptIANA{
 		Options: []Option{&OptElapsedTime{}, oaddr},
 	}
-	require.Equal(t, oaddr, opt.GetOneOption(OPTION_IAADDR))
+	require.Equal(t, oaddr, opt.GetOneOption(OptionIAAddr))
 }
 
 func TestOptIANAGetOneOptionMissingOpt(t *testing.T) {
@@ -57,7 +57,7 @@ func TestOptIANAGetOneOptionMissingOpt(t *testing.T) {
 	opt := OptIANA{
 		Options: []Option{&OptElapsedTime{}, oaddr},
 	}
-	require.Equal(t, nil, opt.GetOneOption(DNS_RECURSIVE_NAME_SERVER))
+	require.Equal(t, nil, opt.GetOneOption(OptionDNSRecursiveNameServer))
 }
 
 func TestOptIANADelOption(t *testing.T) {
@@ -69,13 +69,13 @@ func TestOptIANADelOption(t *testing.T) {
 	optiana1.Options = append(optiana1.Options, &optsc)
 	optiana1.Options = append(optiana1.Options, &optiaaddr)
 	optiana1.Options = append(optiana1.Options, &optiaaddr)
-	optiana1.DelOption(OPTION_IAADDR)
+	optiana1.DelOption(OptionIAAddr)
 	require.Equal(t, optiana1.Options, []Option{&optsc})
 
 	optiana2.Options = append(optiana2.Options, &optiaaddr)
 	optiana2.Options = append(optiana2.Options, &optsc)
 	optiana2.Options = append(optiana2.Options, &optiaaddr)
-	optiana2.DelOption(OPTION_IAADDR)
+	optiana2.DelOption(OptionIAAddr)
 	require.Equal(t, optiana2.Options, []Option{&optsc})
 }
 
@@ -91,7 +91,7 @@ func TestOptIANAToBytes(t *testing.T) {
 		},
 	}
 	expected := []byte{
-		0, 3, // OPTION_IA_NA
+		0, 3, // OptionIANA
 		0, 18, // length
 		1, 2, 3, 4, // IA ID
 		0, 0, 0x30, 0x39, // T1 = 12345

--- a/dhcpv6/option_prefixdelegation.go
+++ b/dhcpv6/option_prefixdelegation.go
@@ -16,12 +16,12 @@ type OptIAForPrefixDelegation struct {
 }
 
 func (op *OptIAForPrefixDelegation) Code() OptionCode {
-	return OPTION_IA_PD
+	return OptionIAPD
 }
 
 func (op *OptIAForPrefixDelegation) ToBytes() []byte {
 	buf := make([]byte, 16)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_IA_PD))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionIAPD))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	copy(buf[4:8], op.iaId[:])
 	binary.BigEndian.PutUint32(buf[8:12], op.t1)

--- a/dhcpv6/option_relaymsg.go
+++ b/dhcpv6/option_relaymsg.go
@@ -13,12 +13,12 @@ type OptRelayMsg struct {
 }
 
 func (op *OptRelayMsg) Code() OptionCode {
-	return OPTION_RELAY_MSG
+	return OptionRelayMsg
 }
 
 func (op *OptRelayMsg) ToBytes() []byte {
 	buf := make([]byte, 4)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_RELAY_MSG))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionRelayMsg))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	buf = append(buf, op.relayMessage.ToBytes()...)
 	return buf

--- a/dhcpv6/option_relaymsg_test.go
+++ b/dhcpv6/option_relaymsg_test.go
@@ -16,9 +16,9 @@ func TestRelayMsgParseOptRelayMsg(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if code := opt.Code(); code != OPTION_RELAY_MSG {
-		t.Fatalf("Invalid option code. Expected OPTION_RELAY_MSG (%v), got %v",
-			OPTION_RELAY_MSG, code,
+	if code := opt.Code(); code != OptionRelayMsg {
+		t.Fatalf("Invalid option code. Expected OptionRelayMsg (%v), got %v",
+			OptionRelayMsg, code,
 		)
 	}
 }
@@ -40,9 +40,9 @@ func TestRelayMsgOptionsFromBytes(t *testing.T) {
 		t.Fatalf("Invalid number of options. Expected 1, got %v", len(opts))
 	}
 	opt := opts[0]
-	if code := opt.Code(); code != OPTION_RELAY_MSG {
-		t.Fatalf("Invalid option code. Expected OPTION_RELAY_MSG (%v), got %v",
-			OPTION_RELAY_MSG, code,
+	if code := opt.Code(); code != OptionRelayMsg {
+		t.Fatalf("Invalid option code. Expected OptionRelayMsg (%v), got %v",
+			OptionRelayMsg, code,
 		)
 	}
 }
@@ -76,9 +76,9 @@ func TestRelayMsgParseOptRelayMsgSingleEncapsulation(t *testing.T) {
 	if len(r.options) != 1 {
 		t.Fatalf("Invalid number of options. Expected 1, got %v", len(r.options))
 	}
-	if code := r.options[0].Code(); code != OPTION_RELAY_MSG {
-		t.Fatalf("Invalid option code. Expected OPTION_RELAY_MSG (%v), got %v",
-			OPTION_RELAY_MSG, code,
+	if code := r.options[0].Code(); code != OptionRelayMsg {
+		t.Fatalf("Invalid option code. Expected OptionRelayMsg (%v), got %v",
+			OptionRelayMsg, code,
 		)
 	}
 	opt := r.options[0]

--- a/dhcpv6/option_remoteid.go
+++ b/dhcpv6/option_remoteid.go
@@ -14,12 +14,12 @@ type OptRemoteId struct {
 }
 
 func (op *OptRemoteId) Code() OptionCode {
-	return OPTION_REMOTE_ID
+	return OptionRemoteID
 }
 
 func (op *OptRemoteId) ToBytes() []byte {
 	buf := make([]byte, 8)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_REMOTE_ID))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionRemoteID))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	binary.BigEndian.PutUint32(buf[4:8], uint32(op.enterpriseNumber))
 	buf = append(buf, op.remoteId...)

--- a/dhcpv6/option_requestedoption.go
+++ b/dhcpv6/option_requestedoption.go
@@ -13,13 +13,13 @@ type OptRequestedOption struct {
 }
 
 func (op *OptRequestedOption) Code() OptionCode {
-	return OPTION_ORO
+	return OptionORO
 }
 
 func (op *OptRequestedOption) ToBytes() []byte {
 	buf := make([]byte, 4)
 	roBytes := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_ORO))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionORO))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	for _, ro := range op.requestedOptions {
 		binary.BigEndian.PutUint16(roBytes, uint16(ro))

--- a/dhcpv6/option_serverid.go
+++ b/dhcpv6/option_serverid.go
@@ -14,12 +14,12 @@ type OptServerId struct {
 }
 
 func (op *OptServerId) Code() OptionCode {
-	return OPTION_SERVERID
+	return OptionServerID
 }
 
 func (op *OptServerId) ToBytes() []byte {
 	buf := make([]byte, 4)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_SERVERID))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionServerID))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	buf = append(buf, op.Sid.ToBytes()...)
 	return buf

--- a/dhcpv6/option_serverid_test.go
+++ b/dhcpv6/option_serverid_test.go
@@ -30,7 +30,7 @@ func TestOptServerIdToBytes(t *testing.T) {
 		},
 	}
 	expected := []byte{
-		0, 2, // OPTION_SERVERID
+		0, 2, // OptionServerID
 		0, 10, // length
 		0, 3, // DUID_LL
 		0, 1, // hwtype ethernet
@@ -46,7 +46,7 @@ func TestOptServerIdDecodeEncode(t *testing.T) {
 		5, 4, 3, 2, 1, 0, // hw addr
 	}
 	expected := append([]byte{
-		0, 2, // OPTION_SERVERID
+		0, 2, // OptionServerID
 		0, 10, // length
 	}, data...)
 	opt, err := ParseOptServerId(data)
@@ -63,5 +63,5 @@ func TestOptionServerId(t *testing.T) {
 		},
 	}
 	require.Equal(t, opt.Length(), 10)
-	require.Equal(t, opt.Code(), OPTION_SERVERID)
+	require.Equal(t, opt.Code(), OptionServerID)
 }

--- a/dhcpv6/option_statuscode.go
+++ b/dhcpv6/option_statuscode.go
@@ -18,13 +18,13 @@ type OptStatusCode struct {
 
 // Code returns the option code
 func (op *OptStatusCode) Code() OptionCode {
-	return OPTION_STATUS_CODE
+	return OptionStatusCode
 }
 
 // ToBytes serializes the option and returns it as a sequence of bytes
 func (op *OptStatusCode) ToBytes() []byte {
 	buf := make([]byte, 6)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_STATUS_CODE))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionStatusCode))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	binary.BigEndian.PutUint16(buf[4:6], uint16(op.StatusCode))
 	buf = append(buf, op.StatusMessage...)

--- a/dhcpv6/option_statuscode_test.go
+++ b/dhcpv6/option_statuscode_test.go
@@ -20,7 +20,7 @@ func TestParseOptStatusCode(t *testing.T) {
 
 func TestOptStatusCodeToBytes(t *testing.T) {
 	expected := []byte{
-		0, 13, // OPTION_STATUS_CODE
+		0, 13, // OptionStatusCode
 		0, 9, // length
 		0, 0, // StatusSuccess
 		's', 'u', 'c', 'c', 'e', 's', 's',

--- a/dhcpv6/option_types.go
+++ b/dhcpv6/option_types.go
@@ -1,152 +1,153 @@
 package dhcpv6
 
-// FIXME: rename all the options to have a consistent name, e.g. OPT_<NAME>
+// All DHCPv6 options.
 const (
-	OPTION_CLIENTID     OptionCode = 1
-	OPTION_SERVERID     OptionCode = 2
-	OPTION_IA_NA        OptionCode = 3
-	OPTION_IA_TA        OptionCode = 4
-	OPTION_IAADDR       OptionCode = 5
-	OPTION_ORO          OptionCode = 6
-	OPTION_PREFERENCE   OptionCode = 7
-	OPTION_ELAPSED_TIME OptionCode = 8
-	OPTION_RELAY_MSG    OptionCode = 9
+	OptionClientID    OptionCode = 1
+	OptionServerID    OptionCode = 2
+	OptionIANA        OptionCode = 3
+	OptionIATA        OptionCode = 4
+	OptionIAAddr      OptionCode = 5
+	OptionORO         OptionCode = 6
+	OptionPreference  OptionCode = 7
+	OptionElapsedTime OptionCode = 8
+	OptionRelayMsg    OptionCode = 9
 	// skip 10
-	OPTION_AUTH                        OptionCode = 11
-	OPTION_UNICAST                     OptionCode = 12
-	OPTION_STATUS_CODE                 OptionCode = 13
-	OPTION_RAPID_COMMIT                OptionCode = 14
-	OPTION_USER_CLASS                  OptionCode = 15
-	OPTION_VENDOR_CLASS                OptionCode = 16
-	OPTION_VENDOR_OPTS                 OptionCode = 17
-	OPTION_INTERFACE_ID                OptionCode = 18
-	OPTION_RECONF_MSG                  OptionCode = 19
-	OPTION_RECONF_ACCEPT               OptionCode = 20
-	SIP_SERVERS_DOMAIN_NAME_LIST       OptionCode = 21
-	SIP_SERVERS_IPV6_ADDRESS_LIST      OptionCode = 22
-	DNS_RECURSIVE_NAME_SERVER          OptionCode = 23
-	DOMAIN_SEARCH_LIST                 OptionCode = 24
-	OPTION_IA_PD                       OptionCode = 25
-	OPTION_IAPREFIX                    OptionCode = 26
-	OPTION_NIS_SERVERS                 OptionCode = 27
-	OPTION_NISP_SERVERS                OptionCode = 28
-	OPTION_NIS_DOMAIN_NAME             OptionCode = 29
-	OPTION_NISP_DOMAIN_NAME            OptionCode = 30
-	SNTP_SERVER_LIST                   OptionCode = 31
-	INFORMATION_REFRESH_TIME           OptionCode = 32
-	BCMCS_CONTROLLER_DOMAIN_NAME_LIST  OptionCode = 33
-	BCMCS_CONTROLLER_IPV6_ADDRESS_LIST OptionCode = 34
+	OptionAuth                           OptionCode = 11
+	OptionUnicast                        OptionCode = 12
+	OptionStatusCode                     OptionCode = 13
+	OptionRapidCommit                    OptionCode = 14
+	OptionUserClass                      OptionCode = 15
+	OptionVendorClass                    OptionCode = 16
+	OptionVendorOpts                     OptionCode = 17
+	OptionInterfaceID                    OptionCode = 18
+	OptionReconfMessage                  OptionCode = 19
+	OptionReconfAccept                   OptionCode = 20
+	OptionSIPServersDomainNameList       OptionCode = 21
+	OptionSIPServersIPv6AddressList      OptionCode = 22
+	OptionDNSRecursiveNameServer         OptionCode = 23
+	OptionDomainSearchList               OptionCode = 24
+	OptionIAPD                           OptionCode = 25
+	OptionIAPrefix                       OptionCode = 26
+	OptionNISServers                     OptionCode = 27
+	OptionNISPServers                    OptionCode = 28
+	OptionNISDomainName                  OptionCode = 29
+	OptionNISPDomainName                 OptionCode = 30
+	OptionSNTPServerList                 OptionCode = 31
+	OptionInformationRefreshTime         OptionCode = 32
+	OptionBCMCSControllerDomainNameList  OptionCode = 33
+	OptionBCMCSControllerIPv6AddressList OptionCode = 34
 	// skip 35
-	OPTION_GEOCONF_CIVIC                        OptionCode = 36
-	OPTION_REMOTE_ID                            OptionCode = 37
-	RELAY_AGENT_SUBSCRIBER_ID                   OptionCode = 38
-	FQDN                                        OptionCode = 39
-	PANA_AUTHENTICATION_AGENT                   OptionCode = 40
-	OPTION_NEW_POSIX_TIMEZONE                   OptionCode = 41
-	OPTION_NEW_TZDB_TIMEZONE                    OptionCode = 42
-	ECHO_REQUEST                                OptionCode = 43
-	OPTION_LQ_QUERY                             OptionCode = 44
-	OPTION_CLIENT_DATA                          OptionCode = 45
-	OPTION_CLT_TIME                             OptionCode = 46
-	OPTION_LQ_RELAY_DATA                        OptionCode = 47
-	OPTION_LQ_CLIENT_LINK                       OptionCode = 48
-	MIPV6_HOME_NETWORK_ID_FQDN                  OptionCode = 49
-	MIPV6_VISITED_HOME_NETWORK_INFORMATION      OptionCode = 50
-	LOST_SERVER                                 OptionCode = 51
-	CAPWAP_ACCESS_CONTROLLER_ADDRESSES          OptionCode = 52
-	RELAY_ID                                    OptionCode = 53
-	OPTION_IPV6_ADDRESS_MOS                     OptionCode = 54
-	OPTION_IPV6_FQDN_MOS                        OptionCode = 55
-	OPTION_NTP_SERVER                           OptionCode = 56
-	OPTION_V6_ACCESS_DOMAIN                     OptionCode = 57
-	OPTION_SIP_UA_CS_LIST                       OptionCode = 58
-	OPT_BOOTFILE_URL                            OptionCode = 59
-	OPT_BOOTFILE_PARAM                          OptionCode = 60
-	OPTION_CLIENT_ARCH_TYPE                     OptionCode = 61
-	OPTION_NII                                  OptionCode = 62
-	OPTION_GEOLOCATION                          OptionCode = 63
-	OPTION_AFTR_NAME                            OptionCode = 64
-	OPTION_ERP_LOCAL_DOMAIN_NAME                OptionCode = 65
-	OPTION_RSOO                                 OptionCode = 66
-	OPTION_PD_EXCLUDE                           OptionCode = 67
-	VIRTUAL_SUBNET_SELECTION                    OptionCode = 68
-	MIPV6_IDENTIFIED_HOME_NETWORK_INFORMATION   OptionCode = 69
-	MIPV6_UNRESTRICTED_HOME_NETWORK_INFORMATION OptionCode = 70
-	MIPV6_HOME_NETWORK_PREFIX                   OptionCode = 71
-	MIPV6_HOME_AGENT_ADDRESS                    OptionCode = 72
-	MIPV6_HOME_AGENT_FQDN                       OptionCode = 73
+	OptionGeoConfCivic                            OptionCode = 36
+	OptionRemoteID                                OptionCode = 37
+	OptionRelayAgentSubscriberID                  OptionCode = 38
+	OptionFQDN                                    OptionCode = 39
+	OptionPANAAuthenticationAgent                 OptionCode = 40
+	OptionNewPOSIXTimezone                        OptionCode = 41
+	OptionNewTZDBTimezone                         OptionCode = 42
+	OptionEchoRequest                             OptionCode = 43
+	OptionLQQuery                                 OptionCode = 44
+	OptionClientData                              OptionCode = 45
+	OptionCLTTime                                 OptionCode = 46
+	OptionLQRelayData                             OptionCode = 47
+	OptionLQClientLink                            OptionCode = 48
+	OptionMIPv6HomeNetworkIDFQDN                  OptionCode = 49
+	OptionMIPv6VisitedHomeNetworkInformation      OptionCode = 50
+	OptionLoSTServer                              OptionCode = 51
+	OptionCAPWAPAccessControllerAddresses         OptionCode = 52
+	OptionRelayID                                 OptionCode = 53
+	OptionIPv6AddressMOS                          OptionCode = 54
+	OptionIPv6FQDNMOS                             OptionCode = 55
+	OptionNTPServer                               OptionCode = 56
+	OptionV6AccessDomain                          OptionCode = 57
+	OptionSIPUACSList                             OptionCode = 58
+	OptionBootfileURL                             OptionCode = 59
+	OptionBootfileParam                           OptionCode = 60
+	OptionClientArchType                          OptionCode = 61
+	OptionNII                                     OptionCode = 62
+	OptionGeolocation                             OptionCode = 63
+	OptionAFTRName                                OptionCode = 64
+	OptionERPLocalDomainName                      OptionCode = 65
+	OptionRSOO                                    OptionCode = 66
+	OptionPDExclude                               OptionCode = 67
+	OptionVirtualSubnetSelection                  OptionCode = 68
+	OptionMIPv6IdentifiedHomeNetworkInformation   OptionCode = 69
+	OptionMIPv6UnrestrictedHomeNetworkInformation OptionCode = 70
+	OptionMIPv6HomeNetworkPrefix                  OptionCode = 71
+	OptionMIPv6HomeAgentAddress                   OptionCode = 72
+	OptionMIPv6HomeAgentFQDN                      OptionCode = 73
 )
 
+// OptionCodeToString maps DHCPv6 OptionCodes to human-readable strings.
 var OptionCodeToString = map[OptionCode]string{
-	OPTION_CLIENTID:                    "OPTION_CLIENTID",
-	OPTION_SERVERID:                    "OPTION_SERVERID",
-	OPTION_IA_NA:                       "OPTION_IA_NA",
-	OPTION_IA_TA:                       "OPTION_IA_TA",
-	OPTION_IAADDR:                      "OPTION_IAADDR",
-	OPTION_ORO:                         "OPTION_ORO",
-	OPTION_PREFERENCE:                  "OPTION_PREFERENCE",
-	OPTION_ELAPSED_TIME:                "OPTION_ELAPSED_TIME",
-	OPTION_RELAY_MSG:                   "OPTION_RELAY_MSG",
-	OPTION_AUTH:                        "OPTION_AUTH",
-	OPTION_UNICAST:                     "OPTION_UNICAST",
-	OPTION_STATUS_CODE:                 "OPTION_STATUS_CODE",
-	OPTION_RAPID_COMMIT:                "OPTION_RAPID_COMMIT",
-	OPTION_USER_CLASS:                  "OPTION_USER_CLASS",
-	OPTION_VENDOR_CLASS:                "OPTION_VENDOR_CLASS",
-	OPTION_VENDOR_OPTS:                 "OPTION_VENDOR_OPTS",
-	OPTION_INTERFACE_ID:                "OPTION_INTERFACE_ID",
-	OPTION_RECONF_MSG:                  "OPTION_RECONF_MSG",
-	OPTION_RECONF_ACCEPT:               "OPTION_RECONF_ACCEPT",
-	SIP_SERVERS_DOMAIN_NAME_LIST:       "SIP Servers Domain Name List",
-	SIP_SERVERS_IPV6_ADDRESS_LIST:      "SIP Servers IPv6 Address List",
-	DNS_RECURSIVE_NAME_SERVER:          "DNS Recursive Name Server",
-	DOMAIN_SEARCH_LIST:                 "Domain Search List",
-	OPTION_IA_PD:                       "OPTION_IA_PD",
-	OPTION_IAPREFIX:                    "OPTION_IAPREFIX",
-	OPTION_NIS_SERVERS:                 "OPTION_NIS_SERVERS",
-	OPTION_NISP_SERVERS:                "OPTION_NISP_SERVERS",
-	OPTION_NIS_DOMAIN_NAME:             "OPTION_NIS_DOMAIN_NAME",
-	OPTION_NISP_DOMAIN_NAME:            "OPTION_NISP_DOMAIN_NAME",
-	SNTP_SERVER_LIST:                   "SNTP Server List",
-	INFORMATION_REFRESH_TIME:           "Information Refresh Time",
-	BCMCS_CONTROLLER_DOMAIN_NAME_LIST:  "BCMCS Controller Domain Name List",
-	BCMCS_CONTROLLER_IPV6_ADDRESS_LIST: "BCMCS Controller IPv6 Address List",
-	OPTION_GEOCONF_CIVIC:               "OPTION_GEOCONF",
-	OPTION_REMOTE_ID:                   "OPTION_REMOTE_ID",
-	RELAY_AGENT_SUBSCRIBER_ID:          "Relay-Agent Subscriber ID",
-	FQDN: "FQDN",
-	PANA_AUTHENTICATION_AGENT:              "PANA Authentication Agent",
-	OPTION_NEW_POSIX_TIMEZONE:              "OPTION_NEW_POSIX_TIME_ZONE",
-	OPTION_NEW_TZDB_TIMEZONE:               "OPTION_NEW_TZDB_TIMEZONE",
-	ECHO_REQUEST:                           "Echo Request",
-	OPTION_LQ_QUERY:                        "OPTION_LQ_QUERY",
-	OPTION_CLIENT_DATA:                     "OPTION_CLIENT_DATA",
-	OPTION_CLT_TIME:                        "OPTION_CLT_TIME",
-	OPTION_LQ_RELAY_DATA:                   "OPTION_LQ_RELAY_DATA",
-	OPTION_LQ_CLIENT_LINK:                  "OPTION_LQ_CLIENT_LINK",
-	MIPV6_HOME_NETWORK_ID_FQDN:             "MIPv6 Home Network ID FQDN",
-	MIPV6_VISITED_HOME_NETWORK_INFORMATION: "MIPv6 Visited Home Network Information",
-	LOST_SERVER:                            "LoST Server",
-	CAPWAP_ACCESS_CONTROLLER_ADDRESSES:     "CAPWAP Access Controller Addresses",
-	RELAY_ID:                                    "RELAY_ID",
-	OPTION_IPV6_ADDRESS_MOS:                     "OPTION-IPv6_Address-MoS",
-	OPTION_IPV6_FQDN_MOS:                        "OPTION-IPv6-FQDN-MoS",
-	OPTION_NTP_SERVER:                           "OPTION_NTP_SERVER",
-	OPTION_V6_ACCESS_DOMAIN:                     "OPTION_V6_ACCESS_DOMAIN",
-	OPTION_SIP_UA_CS_LIST:                       "OPTION_SIP_UA_CS_LIST",
-	OPT_BOOTFILE_URL:                            "OPT_BOOTFILE_URL",
-	OPT_BOOTFILE_PARAM:                          "OPT_BOOTFILE_PARAM",
-	OPTION_CLIENT_ARCH_TYPE:                     "OPTION_CLIENT_ARCH_TYPE",
-	OPTION_NII:                                  "OPTION_NII",
-	OPTION_GEOLOCATION:                          "OPTION_GEOLOCATION",
-	OPTION_AFTR_NAME:                            "OPTION_AFTR_NAME",
-	OPTION_ERP_LOCAL_DOMAIN_NAME:                "OPTION_ERP_LOCAL_DOMAIN_NAME",
-	OPTION_RSOO:                                 "OPTION_RSOO",
-	OPTION_PD_EXCLUDE:                           "OPTION_PD_EXCLUDE",
-	VIRTUAL_SUBNET_SELECTION:                    "Virtual Subnet Selection",
-	MIPV6_IDENTIFIED_HOME_NETWORK_INFORMATION:   "MIPv6 Identified Home Network Information",
-	MIPV6_UNRESTRICTED_HOME_NETWORK_INFORMATION: "MIPv6 Unrestricted Home Network Information",
-	MIPV6_HOME_NETWORK_PREFIX:                   "MIPv6 Home Network Prefix",
-	MIPV6_HOME_AGENT_ADDRESS:                    "MIPv6 Home Agent Address",
-	MIPV6_HOME_AGENT_FQDN:                       "MIPv6 Home Agent FQDN",
+	OptionClientID:                                "OPTION_CLIENTID",
+	OptionServerID:                                "OPTION_SERVERID",
+	OptionIANA:                                    "OPTION_IA_NA",
+	OptionIATA:                                    "OPTION_IA_TA",
+	OptionIAAddr:                                  "OPTION_IAADDR",
+	OptionORO:                                     "OPTION_ORO",
+	OptionPreference:                              "OPTION_PREFERENCE",
+	OptionElapsedTime:                             "OPTION_ELAPSED_TIME",
+	OptionRelayMsg:                                "OPTION_RELAY_MSG",
+	OptionAuth:                                    "OPTION_AUTH",
+	OptionUnicast:                                 "OPTION_UNICAST",
+	OptionStatusCode:                              "OPTION_STATUS_CODE",
+	OptionRapidCommit:                             "OPTION_RAPID_COMMIT",
+	OptionUserClass:                               "OPTION_USER_CLASS",
+	OptionVendorClass:                             "OPTION_VENDOR_CLASS",
+	OptionVendorOpts:                              "OPTION_VENDOR_OPTS",
+	OptionInterfaceID:                             "OPTION_INTERFACE_ID",
+	OptionReconfMessage:                           "OPTION_RECONF_MSG",
+	OptionReconfAccept:                            "OPTION_RECONF_ACCEPT",
+	OptionSIPServersDomainNameList:                "SIP Servers Domain Name List",
+	OptionSIPServersIPv6AddressList:               "SIP Servers IPv6 Address List",
+	OptionDNSRecursiveNameServer:                  "DNS Recursive Name Server",
+	OptionDomainSearchList:                        "Domain Search List",
+	OptionIAPD:                                    "OPTION_IA_PD",
+	OptionIAPrefix:                                "OPTION_IAPREFIX",
+	OptionNISServers:                              "OPTION_NIS_SERVERS",
+	OptionNISPServers:                             "OPTION_NISP_SERVERS",
+	OptionNISDomainName:                           "OPTION_NIS_DOMAIN_NAME",
+	OptionNISPDomainName:                          "OPTION_NISP_DOMAIN_NAME",
+	OptionSNTPServerList:                          "SNTP Server List",
+	OptionInformationRefreshTime:                  "Information Refresh Time",
+	OptionBCMCSControllerDomainNameList:           "BCMCS Controller Domain Name List",
+	OptionBCMCSControllerIPv6AddressList:          "BCMCS Controller IPv6 Address List",
+	OptionGeoConfCivic:                            "OPTION_GEOCONF",
+	OptionRemoteID:                                "OPTION_REMOTE_ID",
+	OptionRelayAgentSubscriberID:                  "Relay-Agent Subscriber ID",
+	OptionFQDN:                                    "FQDN",
+	OptionPANAAuthenticationAgent:                 "PANA Authentication Agent",
+	OptionNewPOSIXTimezone:                        "OPTION_NEW_POSIX_TIME_ZONE",
+	OptionNewTZDBTimezone:                         "OPTION_NEW_TZDB_TIMEZONE",
+	OptionEchoRequest:                             "Echo Request",
+	OptionLQQuery:                                 "OPTION_LQ_QUERY",
+	OptionClientData:                              "OPTION_CLIENT_DATA",
+	OptionCLTTime:                                 "OPTION_CLT_TIME",
+	OptionLQRelayData:                             "OPTION_LQ_RELAY_DATA",
+	OptionLQClientLink:                            "OPTION_LQ_CLIENT_LINK",
+	OptionMIPv6HomeNetworkIDFQDN:                  "MIPv6 Home Network ID FQDN",
+	OptionMIPv6VisitedHomeNetworkInformation:      "MIPv6 Visited Home Network Information",
+	OptionLoSTServer:                              "LoST Server",
+	OptionCAPWAPAccessControllerAddresses:         "CAPWAP Access Controller Addresses",
+	OptionRelayID:                                 "RELAY_ID",
+	OptionIPv6AddressMOS:                          "OPTION-IPv6_Address-MoS",
+	OptionIPv6FQDNMOS:                             "OPTION-IPv6-FQDN-MoS",
+	OptionNTPServer:                               "OPTION_NTP_SERVER",
+	OptionV6AccessDomain:                          "OPTION_V6_ACCESS_DOMAIN",
+	OptionSIPUACSList:                             "OPTION_SIP_UA_CS_LIST",
+	OptionBootfileURL:                             "OPT_BOOTFILE_URL",
+	OptionBootfileParam:                           "OPT_BOOTFILE_PARAM",
+	OptionClientArchType:                          "OPTION_CLIENT_ARCH_TYPE",
+	OptionNII:                                     "OPTION_NII",
+	OptionGeolocation:                             "OPTION_GEOLOCATION",
+	OptionAFTRName:                                "OPTION_AFTR_NAME",
+	OptionERPLocalDomainName:                      "OPTION_ERP_LOCAL_DOMAIN_NAME",
+	OptionRSOO:                                    "OPTION_RSOO",
+	OptionPDExclude:                               "OPTION_PD_EXCLUDE",
+	OptionVirtualSubnetSelection:                  "Virtual Subnet Selection",
+	OptionMIPv6IdentifiedHomeNetworkInformation:   "MIPv6 Identified Home Network Information",
+	OptionMIPv6UnrestrictedHomeNetworkInformation: "MIPv6 Unrestricted Home Network Information",
+	OptionMIPv6HomeNetworkPrefix:                  "MIPv6 Home Network Prefix",
+	OptionMIPv6HomeAgentAddress:                   "MIPv6 Home Agent Address",
+	OptionMIPv6HomeAgentFQDN:                      "MIPv6 Home Agent FQDN",
 }

--- a/dhcpv6/option_userclass.go
+++ b/dhcpv6/option_userclass.go
@@ -17,13 +17,13 @@ type OptUserClass struct {
 
 // Code returns the option code
 func (op *OptUserClass) Code() OptionCode {
-	return OPTION_USER_CLASS
+	return OptionUserClass
 }
 
 // ToBytes serializes the option and returns it as a sequence of bytes
 func (op *OptUserClass) ToBytes() []byte {
 	buf := make([]byte, 4)
-	binary.BigEndian.PutUint16(buf[0:2], uint16(OPTION_USER_CLASS))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionUserClass))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	u16 := make([]byte, 2)
 	for _, uc := range op.UserClasses {

--- a/dhcpv6/option_userclass_test.go
+++ b/dhcpv6/option_userclass_test.go
@@ -40,7 +40,7 @@ func TestOptUserClassToBytes(t *testing.T) {
 	}
 	data := opt.ToBytes()
 	expected := []byte{
-		0, 15, // OPTION_USER_CLASS
+		0, 15, // OptionUserClass
 		0, 11, // length
 		0, 9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
@@ -56,7 +56,7 @@ func TestOptUserClassToBytesMultiple(t *testing.T) {
 	}
 	data := opt.ToBytes()
 	expected := []byte{
-		0, 15, // OPTION_USER_CLASS
+		0, 15, // OptionUserClass
 		0, 17, // length
 		0, 9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 		0, 4, 't', 'e', 's', 't',

--- a/dhcpv6/options.go
+++ b/dhcpv6/options.go
@@ -68,41 +68,41 @@ func ParseOption(dataStart []byte) (Option, error) {
 	)
 	optData := dataStart[4 : 4+length]
 	switch code {
-	case OPTION_CLIENTID:
+	case OptionClientID:
 		opt, err = ParseOptClientId(optData)
-	case OPTION_SERVERID:
+	case OptionServerID:
 		opt, err = ParseOptServerId(optData)
-	case OPTION_ELAPSED_TIME:
+	case OptionElapsedTime:
 		opt, err = ParseOptElapsedTime(optData)
-	case OPTION_ORO:
+	case OptionORO:
 		opt, err = ParseOptRequestedOption(optData)
-	case DNS_RECURSIVE_NAME_SERVER:
+	case OptionDNSRecursiveNameServer:
 		opt, err = ParseOptDNSRecursiveNameServer(optData)
-	case DOMAIN_SEARCH_LIST:
+	case OptionDomainSearchList:
 		opt, err = ParseOptDomainSearchList(optData)
-	case OPTION_IA_NA:
+	case OptionIANA:
 		opt, err = ParseOptIANA(optData)
-	case OPTION_IA_PD:
+	case OptionIAPD:
 		opt, err = ParseOptIAForPrefixDelegation(optData)
-	case OPTION_IAADDR:
+	case OptionIAAddr:
 		opt, err = ParseOptIAAddress(optData)
-	case OPTION_IAPREFIX:
+	case OptionIAPrefix:
 		opt, err = ParseOptIAPrefix(optData)
-	case OPTION_STATUS_CODE:
+	case OptionStatusCode:
 		opt, err = ParseOptStatusCode(optData)
-	case OPTION_RELAY_MSG:
+	case OptionRelayMsg:
 		opt, err = ParseOptRelayMsg(optData)
-	case OPTION_REMOTE_ID:
+	case OptionRemoteID:
 		opt, err = ParseOptRemoteId(optData)
-	case OPTION_INTERFACE_ID:
+	case OptionInterfaceID:
 		opt, err = ParseOptInterfaceId(optData)
-	case OPTION_CLIENT_ARCH_TYPE:
+	case OptionClientArchType:
 		opt, err = ParseOptClientArchType(optData)
-	case OPTION_NII:
+	case OptionNII:
 		opt, err = ParseOptNetworkInterfaceId(optData)
-	case OPT_BOOTFILE_URL:
+	case OptionBootfileURL:
 		opt, err = ParseOptBootFileURL(optData)
-	case OPTION_USER_CLASS:
+	case OptionUserClass:
 		opt, err = ParseOptUserClass(optData)
 	default:
 		opt = &OptionGeneric{OptionCode: code, OptionData: optData}

--- a/dhcpv6/utils.go
+++ b/dhcpv6/utils.go
@@ -11,14 +11,14 @@ import (
 // if the "boot file" option is included in the packet, which is useful for
 // ADVERTISE/REPLY packet.
 func IsNetboot(msg DHCPv6) bool {
-	for _, optoro := range msg.GetOption(OPTION_ORO) {
+	for _, optoro := range msg.GetOption(OptionORO) {
 		for _, o := range optoro.(*OptRequestedOption).RequestedOptions() {
-			if o == OPT_BOOTFILE_URL {
+			if o == OptionBootfileURL {
 				return true
 			}
 		}
 	}
-	if optbf := msg.GetOneOption(OPT_BOOTFILE_URL); optbf != nil {
+	if optbf := msg.GetOneOption(OptionBootfileURL); optbf != nil {
 		return true
 	}
 	return false
@@ -42,14 +42,14 @@ func IsUsingUEFI(msg DHCPv6) bool {
 	//               7    EFI BC
 	//               8    EFI Xscale
 	//               9    EFI x86-64
-	if opt := msg.GetOneOption(OPTION_CLIENT_ARCH_TYPE); opt != nil {
+	if opt := msg.GetOneOption(OptionClientArchType); opt != nil {
 		optat := opt.(*OptClientArchType)
 		// TODO investigate if other types are appropriate
 		if optat.ArchType == EFI_BC || optat.ArchType == EFI_X86_64 {
 			return true
 		}
 	}
-	if opt := msg.GetOneOption(OPTION_USER_CLASS); opt != nil {
+	if opt := msg.GetOneOption(OptionUserClass); opt != nil {
 		optuc := opt.(*OptUserClass)
 		for _, uc := range optuc.UserClasses {
 			if strings.Contains(string(uc), "EFI") {

--- a/dhcpv6/utils_test.go
+++ b/dhcpv6/utils_test.go
@@ -12,7 +12,7 @@ func TestIsNetboot(t *testing.T) {
 
 	msg2 := DHCPv6Message{}
 	optro := OptRequestedOption{}
-	optro.AddRequestedOption(OPT_BOOTFILE_URL)
+	optro.AddRequestedOption(OptionBootfileURL)
 	msg2.AddOption(&optro)
 	require.True(t, IsNetboot(&msg2))
 

--- a/netboot/netboot.go
+++ b/netboot/netboot.go
@@ -67,7 +67,7 @@ func ConversationToNetconf(conversation []dhcpv6.DHCPv6) (*NetConf, string, erro
 		opt      dhcpv6.Option
 		bootfile string
 	)
-	opt = reply.GetOneOption(dhcpv6.OPT_BOOTFILE_URL)
+	opt = reply.GetOneOption(dhcpv6.OptionBootfileURL)
 	if opt == nil {
 		log.Printf("no bootfile URL option found in REPLY, looking for it in ADVERTISE")
 		// as a fallback, look for bootfile URL in the advertise
@@ -82,7 +82,7 @@ func ConversationToNetconf(conversation []dhcpv6.DHCPv6) (*NetConf, string, erro
 		if advertise == nil {
 			return nil, "", errors.New("no ADVERTISE found")
 		}
-		opt = advertise.GetOneOption(dhcpv6.OPT_BOOTFILE_URL)
+		opt = advertise.GetOneOption(dhcpv6.OptionBootfileURL)
 		if opt == nil {
 			return nil, "", errors.New("no bootfile URL option found in ADVERTISE")
 		}

--- a/netboot/netconf.go
+++ b/netboot/netconf.go
@@ -30,7 +30,7 @@ type NetConf struct {
 // GetNetConfFromPacketv6 extracts network configuration information from a DHCPv6
 // Reply packet and returns a populated NetConf structure
 func GetNetConfFromPacketv6(d *dhcpv6.DHCPv6Message) (*NetConf, error) {
-	opt := d.GetOneOption(dhcpv6.OPTION_IA_NA)
+	opt := d.GetOneOption(dhcpv6.OptionIANA)
 	if opt == nil {
 		return nil, errors.New("No option IA NA found")
 	}
@@ -39,7 +39,7 @@ func GetNetConfFromPacketv6(d *dhcpv6.DHCPv6Message) (*NetConf, error) {
 	oiana := opt.(*dhcpv6.OptIANA)
 	iaaddrs := make([]*dhcpv6.OptIAAddress, 0)
 	for _, o := range oiana.Options {
-		if o.Code() == dhcpv6.OPTION_IAADDR {
+		if o.Code() == dhcpv6.OptionIAAddr {
 			iaaddrs = append(iaaddrs, o.(*dhcpv6.OptIAAddress))
 		}
 	}
@@ -55,7 +55,7 @@ func GetNetConfFromPacketv6(d *dhcpv6.DHCPv6Message) (*NetConf, error) {
 		})
 	}
 	// get DNS configuration
-	opt = d.GetOneOption(dhcpv6.DNS_RECURSIVE_NAME_SERVER)
+	opt = d.GetOneOption(dhcpv6.OptionDNSRecursiveNameServer)
 	if opt == nil {
 		return nil, errors.New("No option DNS Recursive Name Servers found ")
 	}
@@ -63,7 +63,7 @@ func GetNetConfFromPacketv6(d *dhcpv6.DHCPv6Message) (*NetConf, error) {
 	// TODO should this be copied?
 	netconf.DNSServers = odnsserv.NameServers
 
-	opt = d.GetOneOption(dhcpv6.DOMAIN_SEARCH_LIST)
+	opt = d.GetOneOption(dhcpv6.OptionDomainSearchList)
 	if opt == nil {
 		return nil, errors.New("No option DNS Domain Search List found")
 	}


### PR DESCRIPTION
To appease linters. All changes were made using global find + replace, but I recommend looking over option_types.go to see all new option names.