### PR TITLE
DHCPv6: Other ALL_CAPS constants to CamelCase

### DIFF
--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -188,7 +188,7 @@ func TestNewSolicitWithCID(t *testing.T) {
 	require.NoError(t, err)
 
 	duid := Duid{
-		Type:          DUID_LL,
+		Type:          DuidLL,
 		HwType:        iana.HwTypeEthernet,
 		LinkLayerAddr: hwAddr,
 	}

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -101,7 +101,7 @@ func NewSolicitForInterface(ifname string, modifiers ...Modifier) (DHCPv6, error
 		return nil, err
 	}
 	duid := Duid{
-		Type:          DUID_LLT,
+		Type:          DuidLLT,
 		HwType:        iana.HwTypeEthernet,
 		Time:          GetTime(),
 		LinkLayerAddr: iface.HardwareAddr,

--- a/dhcpv6/duid.go
+++ b/dhcpv6/duid.go
@@ -12,17 +12,17 @@ type DuidType uint16
 
 // DUID types
 const (
-	DUID_LLT  DuidType = 1
-	DUID_EN   DuidType = 2
-	DUID_LL   DuidType = 3
-	DUID_UUID DuidType = 4
+	DuidLLT  DuidType = 1
+	DuidEN   DuidType = 2
+	DuidLL   DuidType = 3
+	DuidUUID DuidType = 4
 )
 
 var DuidTypeToString = map[DuidType]string{
-	DUID_LL:   "DUID-LL",
-	DUID_LLT:  "DUID-LLT",
-	DUID_EN:   "DUID-EN",
-	DUID_UUID: "DUID-UUID",
+	DuidLL:   "DUID-LL",
+	DuidLLT:  "DUID-LLT",
+	DuidEN:   "DUID-EN",
+	DuidUUID: "DUID-UUID",
 }
 
 type Duid struct {
@@ -37,13 +37,13 @@ type Duid struct {
 }
 
 func (d *Duid) Length() int {
-	if d.Type == DUID_LLT {
+	if d.Type == DuidLLT {
 		return 8 + len(d.LinkLayerAddr)
-	} else if d.Type == DUID_LL {
+	} else if d.Type == DuidLL {
 		return 4 + len(d.LinkLayerAddr)
-	} else if d.Type == DUID_EN {
+	} else if d.Type == DuidEN {
 		return 6 + len(d.EnterpriseIdentifier)
-	} else if d.Type == DUID_UUID {
+	} else if d.Type == DuidUUID {
 		return 18
 	} else {
 		return 2 + len(d.Opaque)
@@ -51,23 +51,23 @@ func (d *Duid) Length() int {
 }
 
 func (d *Duid) ToBytes() []byte {
-	if d.Type == DUID_LLT {
+	if d.Type == DuidLLT {
 		buf := make([]byte, 8)
 		binary.BigEndian.PutUint16(buf[0:2], uint16(d.Type))
 		binary.BigEndian.PutUint16(buf[2:4], uint16(d.HwType))
 		binary.BigEndian.PutUint32(buf[4:8], d.Time)
 		return append(buf, d.LinkLayerAddr...)
-	} else if d.Type == DUID_LL {
+	} else if d.Type == DuidLL {
 		buf := make([]byte, 4)
 		binary.BigEndian.PutUint16(buf[0:2], uint16(d.Type))
 		binary.BigEndian.PutUint16(buf[2:4], uint16(d.HwType))
 		return append(buf, d.LinkLayerAddr...)
-	} else if d.Type == DUID_EN {
+	} else if d.Type == DuidEN {
 		buf := make([]byte, 6)
 		binary.BigEndian.PutUint16(buf[0:2], uint16(d.Type))
 		binary.BigEndian.PutUint32(buf[2:6], d.EnterpriseNumber)
 		return append(buf, d.EnterpriseIdentifier...)
-	} else if d.Type == DUID_UUID {
+	} else if d.Type == DuidUUID {
 		buf := make([]byte, 2)
 		binary.BigEndian.PutUint16(buf[0:2], uint16(d.Type))
 		return append(buf, d.Uuid...)
@@ -105,26 +105,26 @@ func DuidFromBytes(data []byte) (*Duid, error) {
 	}
 	d := Duid{}
 	d.Type = DuidType(binary.BigEndian.Uint16(data[0:2]))
-	if d.Type == DUID_LLT {
+	if d.Type == DuidLLT {
 		if len(data) < 8 {
 			return nil, fmt.Errorf("Invalid DUID-LLT: shorter than 8 bytes")
 		}
 		d.HwType = iana.HwTypeType(binary.BigEndian.Uint16(data[2:4]))
 		d.Time = binary.BigEndian.Uint32(data[4:8])
 		d.LinkLayerAddr = data[8:]
-	} else if d.Type == DUID_LL {
+	} else if d.Type == DuidLL {
 		if len(data) < 4 {
 			return nil, fmt.Errorf("Invalid DUID-LL: shorter than 4 bytes")
 		}
 		d.HwType = iana.HwTypeType(binary.BigEndian.Uint16(data[2:4]))
 		d.LinkLayerAddr = data[4:]
-	} else if d.Type == DUID_EN {
+	} else if d.Type == DuidEN {
 		if len(data) < 6 {
 			return nil, fmt.Errorf("Invalid DUID-EN: shorter than 6 bytes")
 		}
 		d.EnterpriseNumber = binary.BigEndian.Uint32(data[2:6])
 		d.EnterpriseIdentifier = data[6:]
-	} else if d.Type == DUID_UUID {
+	} else if d.Type == DuidUUID {
 		if len(data) != 18 {
 			return nil, fmt.Errorf("Invalid DUID-UUID length. Expected 18, got %v", len(data))
 		}

--- a/dhcpv6/duid_test.go
+++ b/dhcpv6/duid_test.go
@@ -14,26 +14,26 @@ func TestDuidInvalidTooShort(t *testing.T) {
 	_, err := DuidFromBytes([]byte{0})
 	require.Error(t, err)
 
-	// too short DUID_LL (must be at least 4 bytes)
+	// too short DuidLL (must be at least 4 bytes)
 	_, err = DuidFromBytes([]byte{0, 3, 0xa})
 	require.Error(t, err)
 
-	// too short DUID_EN (must be at least 6 bytes)
+	// too short DuidEN (must be at least 6 bytes)
 	_, err = DuidFromBytes([]byte{0, 2, 0xa, 0xb, 0xc})
 	require.Error(t, err)
 
-	// too short DUID_LLT (must be at least 8 bytes)
+	// too short DuidLLT (must be at least 8 bytes)
 	_, err = DuidFromBytes([]byte{0, 1, 0xa, 0xb, 0xc, 0xd, 0xe})
 	require.Error(t, err)
 
-	// too short DUID_UUID (must be at least 18 bytes)
+	// too short DuidUUID (must be at least 18 bytes)
 	_, err = DuidFromBytes([]byte{0, 4, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf})
 	require.Error(t, err)
 }
 
 func TestDuidLLTFromBytes(t *testing.T) {
 	buf := []byte{
-		0, 1, // DUID_LLT
+		0, 1, // DuidLLT
 		0, 1, // HwTypeEthernet
 		0x01, 0x02, 0x03, 0x04, // time
 		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, // link-layer addr
@@ -41,7 +41,7 @@ func TestDuidLLTFromBytes(t *testing.T) {
 	duid, err := DuidFromBytes(buf)
 	require.NoError(t, err)
 	require.Equal(t, 14, duid.Length())
-	require.Equal(t, DUID_LLT, duid.Type)
+	require.Equal(t, DuidLLT, duid.Type)
 	require.Equal(t, uint32(0x01020304), duid.Time)
 	require.Equal(t, iana.HwTypeEthernet, duid.HwType)
 	require.Equal(t, net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, duid.LinkLayerAddr)
@@ -49,40 +49,40 @@ func TestDuidLLTFromBytes(t *testing.T) {
 
 func TestDuidLLFromBytes(t *testing.T) {
 	buf := []byte{
-		0, 3, // DUID_LL
+		0, 3, // DuidLL
 		0, 1, // HwTypeEthernet
 		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, // link-layer addr
 	}
 	duid, err := DuidFromBytes(buf)
 	require.NoError(t, err)
 	require.Equal(t, 10, duid.Length())
-	require.Equal(t, DUID_LL, duid.Type)
+	require.Equal(t, DuidLL, duid.Type)
 	require.Equal(t, iana.HwTypeEthernet, duid.HwType)
 	require.Equal(t, net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, duid.LinkLayerAddr)
 }
 
 func TestDuidUuidFromBytes(t *testing.T) {
 	buf := []byte{
-		0x00, 0x04, // DUID_UUID
+		0x00, 0x04, // DuidUUID
 	}
 	uuid := []byte{0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07, 0x00, 0x08}
 	buf = append(buf, uuid...)
 	duid, err := DuidFromBytes(buf)
 	require.NoError(t, err)
 	require.Equal(t, 18, duid.Length())
-	require.Equal(t, DUID_UUID, duid.Type)
+	require.Equal(t, DuidUUID, duid.Type)
 	require.Equal(t, uuid, duid.Uuid)
 }
 
 func TestDuidLLTToBytes(t *testing.T) {
 	expected := []byte{
-		0, 1, // DUID_LLT
+		0, 1, // DuidLLT
 		0, 1, // HwTypeEthernet
 		0x01, 0x02, 0x03, 0x04, // time
 		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, // link-layer addr
 	}
 	duid := Duid{
-		Type:          DUID_LLT,
+		Type:          DuidLLT,
 		HwType:        iana.HwTypeEthernet,
 		Time:          uint32(0x01020304),
 		LinkLayerAddr: []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
@@ -96,7 +96,7 @@ func TestDuidUuidToBytes(t *testing.T) {
 	expected := []byte{00, 04}
 	expected = append(expected, uuid...)
 	duid := Duid{
-		Type: DUID_UUID,
+		Type: DuidUUID,
 		Uuid: uuid,
 	}
 	toBytes := duid.ToBytes()

--- a/dhcpv6/modifiers_test.go
+++ b/dhcpv6/modifiers_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestWithClientID(t *testing.T) {
 	duid := Duid{
-		Type:          DUID_LL,
+		Type:          DuidLL,
 		HwType:        iana.HwTypeEthernet,
 		LinkLayerAddr: net.HardwareAddr([]byte{0xfa, 0xce, 0xb0, 0x00, 0x00, 0x0c}),
 	}
@@ -24,7 +24,7 @@ func TestWithClientID(t *testing.T) {
 
 func TestWithServerID(t *testing.T) {
 	duid := Duid{
-		Type:          DUID_LL,
+		Type:          DuidLL,
 		HwType:        iana.HwTypeEthernet,
 		LinkLayerAddr: net.HardwareAddr([]byte{0xfa, 0xce, 0xb0, 0x00, 0x00, 0x0c}),
 	}

--- a/dhcpv6/option_archtype.go
+++ b/dhcpv6/option_archtype.go
@@ -13,30 +13,30 @@ type ArchType uint16
 
 // see rfc4578
 const (
-	INTEL_X86PC       ArchType = 0
-	NEC_PC98          ArchType = 1
-	EFI_ITANIUM       ArchType = 2
-	DEC_ALPHA         ArchType = 3
-	ARC_X86           ArchType = 4
-	INTEL_LEAN_CLIENT ArchType = 5
-	EFI_IA32          ArchType = 6
-	EFI_BC            ArchType = 7
-	EFI_XSCALE        ArchType = 8
-	EFI_X86_64        ArchType = 9
+	Intelx86PC      ArchType = 0
+	NECPC98         ArchType = 1
+	EFIItanium      ArchType = 2
+	DECAlpha        ArchType = 3
+	ARCx86          ArchType = 4
+	IntelLeanClient ArchType = 5
+	EFIIA32         ArchType = 6
+	EFIBC           ArchType = 7
+	EFIXscale       ArchType = 8
+	EFIx8664        ArchType = 9
 )
 
 // ArchTypeToStringMap maps an ArchType to a mnemonic name
 var ArchTypeToStringMap = map[ArchType]string{
-	INTEL_X86PC:       "Intel x86PC",
-	NEC_PC98:          "NEC/PC98",
-	EFI_ITANIUM:       "EFI Itanium",
-	DEC_ALPHA:         "DEC Alpha",
-	ARC_X86:           "Arc x86",
-	INTEL_LEAN_CLIENT: "Intel Lean Client",
-	EFI_IA32:          "EFI IA32",
-	EFI_BC:            "EFI BC",
-	EFI_XSCALE:        "EFI Xscale",
-	EFI_X86_64:        "EFI x86-64",
+	Intelx86PC:      "Intel x86PC",
+	NECPC98:         "NEC/PC98",
+	EFIItanium:      "EFI Itanium",
+	DECAlpha:        "DEC Alpha",
+	ARCx86:          "Arc x86",
+	IntelLeanClient: "Intel Lean Client",
+	EFIIA32:         "EFI IA32",
+	EFIBC:           "EFI BC",
+	EFIXscale:       "EFI Xscale",
+	EFIx8664:        "EFI x86-64",
 }
 
 // OptClientArchType represents an option CLIENT_ARCH_TYPE

--- a/dhcpv6/option_archtype_test.go
+++ b/dhcpv6/option_archtype_test.go
@@ -8,11 +8,11 @@ import (
 
 func TestParseOptClientArchType(t *testing.T) {
 	data := []byte{
-		0, 6, // EFI_IA32
+		0, 6, // EFIIA32
 	}
 	opt, err := ParseOptClientArchType(data)
 	require.NoError(t, err)
-	require.Equal(t, opt.ArchType, EFI_IA32)
+	require.Equal(t, opt.ArchType, EFIIA32)
 }
 
 func TestParseOptClientArchTypeInvalid(t *testing.T) {
@@ -23,12 +23,12 @@ func TestParseOptClientArchTypeInvalid(t *testing.T) {
 
 func TestOptClientArchTypeParseAndToBytes(t *testing.T) {
 	data := []byte{
-		0, 8, // EFI_XSCALE
+		0, 8, // EFIXscale
 	}
 	expected := []byte{
 		0, 61, // OPTION_CLIENT_ARCH_TYPE
 		0, 2, // length
-		0, 8, // EFI_XSCALE
+		0, 8, // EFIXscale
 	}
 	opt, err := ParseOptClientArchType(data)
 	require.NoError(t, err)
@@ -37,7 +37,7 @@ func TestOptClientArchTypeParseAndToBytes(t *testing.T) {
 
 func TestOptClientArchType(t *testing.T) {
 	opt := OptClientArchType{
-		ArchType: EFI_ITANIUM,
+		ArchType: EFIItanium,
 	}
 	require.Equal(t, opt.Length(), 2)
 	require.Equal(t, opt.Code(), OPTION_CLIENT_ARCH_TYPE)

--- a/dhcpv6/option_clientid_test.go
+++ b/dhcpv6/option_clientid_test.go
@@ -10,13 +10,13 @@ import (
 
 func TestParseOptClientId(t *testing.T) {
 	data := []byte{
-		0, 3, // DUID_LL
+		0, 3, // DuidLL
 		0, 1, // hwtype ethernet
 		0, 1, 2, 3, 4, 5, // hw addr
 	}
 	opt, err := ParseOptClientId(data)
 	require.NoError(t, err)
-	require.Equal(t, opt.Cid.Type, DUID_LL)
+	require.Equal(t, opt.Cid.Type, DuidLL)
 	require.Equal(t, opt.Cid.HwType, iana.HwTypeEthernet)
 	require.Equal(t, opt.Cid.LinkLayerAddr, net.HardwareAddr([]byte{0, 1, 2, 3, 4, 5}))
 }
@@ -24,7 +24,7 @@ func TestParseOptClientId(t *testing.T) {
 func TestOptClientIdToBytes(t *testing.T) {
 	opt := OptClientId{
 		Cid: Duid{
-			Type:          DUID_LL,
+			Type:          DuidLL,
 			HwType:        iana.HwTypeEthernet,
 			LinkLayerAddr: net.HardwareAddr([]byte{5, 4, 3, 2, 1, 0}),
 		},
@@ -32,7 +32,7 @@ func TestOptClientIdToBytes(t *testing.T) {
 	expected := []byte{
 		0, 1, // OPTION_CLIENTID
 		0, 10, // length
-		0, 3, // DUID_LL
+		0, 3, // DuidLL
 		0, 1, // hwtype ethernet
 		5, 4, 3, 2, 1, 0, // hw addr
 	}
@@ -41,7 +41,7 @@ func TestOptClientIdToBytes(t *testing.T) {
 
 func TestOptClientIdDecodeEncode(t *testing.T) {
 	data := []byte{
-		0, 3, // DUID_LL
+		0, 3, // DuidLL
 		0, 1, // hwtype ethernet
 		5, 4, 3, 2, 1, 0, // hw addr
 	}
@@ -57,7 +57,7 @@ func TestOptClientIdDecodeEncode(t *testing.T) {
 func TestOptionClientId(t *testing.T) {
 	opt := OptClientId{
 		Cid: Duid{
-			Type:          DUID_LL,
+			Type:          DuidLL,
 			HwType:        iana.HwTypeEthernet,
 			LinkLayerAddr: net.HardwareAddr([]byte{0xde, 0xad, 0, 0, 0xbe, 0xef}),
 		},

--- a/dhcpv6/option_nii.go
+++ b/dhcpv6/option_nii.go
@@ -10,21 +10,21 @@ import (
 
 // see rfc4578
 const (
-	NII_LANDESK_NOPXE   = 0
-	NII_PXE_GEN_I       = 1
-	NII_PXE_GEN_II      = 2
-	NII_UNDI_NOEFI      = 3
-	NII_UNDI_EFI_GEN_I  = 4
-	NII_UNDI_EFI_GEN_II = 5
+	NIILANDeskNoPXE = 0
+	NIIPXEGenI      = 1
+	NIIPXEGenII     = 2
+	NIIUNDINoEFI    = 3
+	NIIUNDIEFIGenI  = 4
+	NIIUNDIEFIGenII = 5
 )
 
 var NIIToStringMap = map[uint8]string{
-	NII_LANDESK_NOPXE:   "LANDesk service agent boot ROMs. No PXE",
-	NII_PXE_GEN_I:       "First gen. PXE boot ROMs",
-	NII_PXE_GEN_II:      "Second gen. PXE boot ROMs",
-	NII_UNDI_NOEFI:      "UNDI 32/64 bit. UEFI drivers, no UEFI runtime",
-	NII_UNDI_EFI_GEN_I:  "UNDI 32/64 bit. UEFI runtime 1st gen",
-	NII_UNDI_EFI_GEN_II: "UNDI 32/64 bit. UEFI runtime 2nd gen",
+	NIILANDeskNoPXE: "LANDesk service agent boot ROMs. No PXE",
+	NIIPXEGenI:      "First gen. PXE boot ROMs",
+	NIIPXEGenII:     "Second gen. PXE boot ROMs",
+	NIIUNDINoEFI:    "UNDI 32/64 bit. UEFI drivers, no UEFI runtime",
+	NIIUNDIEFIGenI:  "UNDI 32/64 bit. UEFI runtime 1st gen",
+	NIIUNDIEFIGenII: "UNDI 32/64 bit. UEFI runtime 2nd gen",
 }
 
 type OptNetworkInterfaceId struct {

--- a/dhcpv6/option_serverid_test.go
+++ b/dhcpv6/option_serverid_test.go
@@ -10,13 +10,13 @@ import (
 
 func TestParseOptServerId(t *testing.T) {
 	data := []byte{
-		0, 3, // DUID_LL
+		0, 3, // DuidLL
 		0, 1, // hwtype ethernet
 		0, 1, 2, 3, 4, 5, // hw addr
 	}
 	opt, err := ParseOptServerId(data)
 	require.NoError(t, err)
-	require.Equal(t, opt.Sid.Type, DUID_LL)
+	require.Equal(t, opt.Sid.Type, DuidLL)
 	require.Equal(t, opt.Sid.HwType, iana.HwTypeEthernet)
 	require.Equal(t, opt.Sid.LinkLayerAddr, net.HardwareAddr([]byte{0, 1, 2, 3, 4, 5}))
 }
@@ -24,7 +24,7 @@ func TestParseOptServerId(t *testing.T) {
 func TestOptServerIdToBytes(t *testing.T) {
 	opt := OptServerId{
 		Sid: Duid{
-			Type:          DUID_LL,
+			Type:          DuidLL,
 			HwType:        iana.HwTypeEthernet,
 			LinkLayerAddr: net.HardwareAddr([]byte{5, 4, 3, 2, 1, 0}),
 		},
@@ -32,7 +32,7 @@ func TestOptServerIdToBytes(t *testing.T) {
 	expected := []byte{
 		0, 2, // OPTION_SERVERID
 		0, 10, // length
-		0, 3, // DUID_LL
+		0, 3, // DuidLL
 		0, 1, // hwtype ethernet
 		5, 4, 3, 2, 1, 0, // hw addr
 	}
@@ -41,7 +41,7 @@ func TestOptServerIdToBytes(t *testing.T) {
 
 func TestOptServerIdDecodeEncode(t *testing.T) {
 	data := []byte{
-		0, 3, // DUID_LL
+		0, 3, // DuidLL
 		0, 1, // hwtype ethernet
 		5, 4, 3, 2, 1, 0, // hw addr
 	}
@@ -57,7 +57,7 @@ func TestOptServerIdDecodeEncode(t *testing.T) {
 func TestOptionServerId(t *testing.T) {
 	opt := OptServerId{
 		Sid: Duid{
-			Type:          DUID_LL,
+			Type:          DuidLL,
 			HwType:        iana.HwTypeEthernet,
 			LinkLayerAddr: net.HardwareAddr([]byte{0xde, 0xad, 0, 0, 0xbe, 0xef}),
 		},

--- a/dhcpv6/utils.go
+++ b/dhcpv6/utils.go
@@ -45,7 +45,7 @@ func IsUsingUEFI(msg DHCPv6) bool {
 	if opt := msg.GetOneOption(OPTION_CLIENT_ARCH_TYPE); opt != nil {
 		optat := opt.(*OptClientArchType)
 		// TODO investigate if other types are appropriate
-		if optat.ArchType == EFI_BC || optat.ArchType == EFI_X86_64 {
+		if optat.ArchType == EFIBC || optat.ArchType == EFIx8664 {
 			return true
 		}
 	}

--- a/dhcpv6/utils_test.go
+++ b/dhcpv6/utils_test.go
@@ -24,14 +24,14 @@ func TestIsNetboot(t *testing.T) {
 
 func TestIsUsingUEFIArchTypeTrue(t *testing.T) {
 	msg := DHCPv6Message{}
-	opt := OptClientArchType{ArchType: EFI_BC}
+	opt := OptClientArchType{ArchType: EFIBC}
 	msg.AddOption(&opt)
 	require.True(t, IsUsingUEFI(&msg))
 }
 
 func TestIsUsingUEFIArchTypeFalse(t *testing.T) {
 	msg := DHCPv6Message{}
-	opt := OptClientArchType{ArchType: INTEL_X86PC}
+	opt := OptClientArchType{ArchType: Intelx86PC}
 	msg.AddOption(&opt)
 	require.False(t, IsUsingUEFI(&msg))
 }


### PR DESCRIPTION
This changes all other ALL_CAPS constants in various other files in
dhcpv6 to CamelCase. These are a bit more controversial changes and IMO
don't enhance readability (in some cases, it makes it worse)... Feel
free to comment whether you agree or disagree with these changes.