### PR TITLE
BSDP: Exchange returns list of pointers, not list of objects

### DIFF
--- a/dhcpv4/bsdp/client.go
+++ b/dhcpv4/bsdp/client.go
@@ -36,8 +36,8 @@ func castVendorOpt(ack *dhcpv4.DHCPv4) {
 
 // Exchange runs a full BSDP exchange (Inform[list], Ack, Inform[select],
 // Ack). Returns a list of DHCPv4 structures representing the exchange.
-func (c *Client) Exchange(ifname string, informList *dhcpv4.DHCPv4) ([]dhcpv4.DHCPv4, error) {
-	conversation := make([]dhcpv4.DHCPv4, 1)
+func (c *Client) Exchange(ifname string, informList *dhcpv4.DHCPv4) ([]*dhcpv4.DHCPv4, error) {
+	conversation := make([]*dhcpv4.DHCPv4, 1)
 	var err error
 
 	// Get our file descriptor for the broadcast socket.
@@ -57,7 +57,7 @@ func (c *Client) Exchange(ifname string, informList *dhcpv4.DHCPv4) ([]dhcpv4.DH
 			return conversation, err
 		}
 	}
-	conversation[0] = *informList
+	conversation[0] = informList
 
 	// ACK[LIST]
 	ackForList, err := dhcpv4.BroadcastSendReceive(sendFd, recvFd, informList, c.ReadTimeout, c.WriteTimeout, dhcpv4.MessageTypeAck)
@@ -67,7 +67,7 @@ func (c *Client) Exchange(ifname string, informList *dhcpv4.DHCPv4) ([]dhcpv4.DH
 
 	// Rewrite vendor-specific option for pretty printing.
 	castVendorOpt(ackForList)
-	conversation = append(conversation, *ackForList)
+	conversation = append(conversation, ackForList)
 
 	// Parse boot images sent back by server
 	bootImages, err := ParseBootImageListFromAck(*ackForList)
@@ -83,7 +83,7 @@ func (c *Client) Exchange(ifname string, informList *dhcpv4.DHCPv4) ([]dhcpv4.DH
 	if err != nil {
 		return conversation, err
 	}
-	conversation = append(conversation, *informSelect)
+	conversation = append(conversation, informSelect)
 
 	// ACK[SELECT]
 	ackForSelect, err := dhcpv4.BroadcastSendReceive(sendFd, recvFd, informSelect, c.ReadTimeout, c.WriteTimeout, dhcpv4.MessageTypeAck)
@@ -91,5 +91,5 @@ func (c *Client) Exchange(ifname string, informList *dhcpv4.DHCPv4) ([]dhcpv4.DH
 	if err != nil {
 		return conversation, err
 	}
-	return append(conversation, *ackForSelect), nil
+	return append(conversation, ackForSelect), nil
 }


### PR DESCRIPTION
As done in https://github.com/insomniacslk/dhcp/pull/121 , return a list of pointers rather than a list of objects to avoid unnecessary copies