### PR TITLE
stop parsing after end

### DIFF
--- a/dhcpv4/options.go
+++ b/dhcpv4/options.go
@@ -126,6 +126,9 @@ func OptionsFromBytesWithoutMagicCookie(data []byte) ([]Option, error) {
 			return nil, err
 		}
 		options = append(options, opt)
+		if opt.Code() == OptionEnd {
+			break
+		}
 
 		// Options with zero length have no length byte, so here we handle the
 		// ones with nonzero length

--- a/dhcpv4/options_test.go
+++ b/dhcpv4/options_test.go
@@ -167,12 +167,9 @@ func TestOptionsFromBytes(t *testing.T) {
 	}
 	opts, err := OptionsFromBytes(options)
 	require.NoError(t, err)
-	require.Equal(t, 5, len(opts))
+	require.Equal(t, 2, len(opts))
 	require.Equal(t, opts[0].(*OptionGeneric), &OptionGeneric{OptionCode: OptionNameServer, Data: []byte{192, 168, 1, 1}})
 	require.Equal(t, opts[1].(*OptionGeneric), &OptionGeneric{OptionCode: OptionEnd})
-	require.Equal(t, opts[2].(*OptionGeneric), &OptionGeneric{OptionCode: OptionPad})
-	require.Equal(t, opts[3].(*OptionGeneric), &OptionGeneric{OptionCode: OptionPad})
-	require.Equal(t, opts[4].(*OptionGeneric), &OptionGeneric{OptionCode: OptionPad})
 }
 
 func TestOptionsFromBytesZeroLength(t *testing.T) {


### PR DESCRIPTION
According to the RFC:

>   The end option marks the end of valid information in the vendor
>   field.  Subsequent octets should be filled with pad options.

There are clients sending invalid options after the End Option which breaks the whole packet parsing.

I am not a great fan of this PR though because it may create a mismatch in the length of what we receive and send.

Related issue #131