### PR TITLE
NewRelayReplFromRelayForw: add remoteid

### DIFF
--- a/dhcpv6/dhcpv6relay.go
+++ b/dhcpv6/dhcpv6relay.go
@@ -170,14 +170,14 @@ func NewRelayReplFromRelayForw(relayForw, msg DHCPv6) (DHCPv6, error) {
 		optrid             []Option
 	)
 	if relayForw == nil {
-		return nil, errors.New("RELAY_FORW cannot be nil")
+		return nil, errors.New("MessageTypeRelayForward cannot be nil")
 	}
 	relay, ok := relayForw.(*DHCPv6Relay)
 	if !ok {
 		return nil, errors.New("Not a DHCPv6Relay")
 	}
 	if relay.Type() != MessageTypeRelayForward {
-		return nil, errors.New("The passed packet is not of type RELAY_FORW")
+		return nil, errors.New("The passed packet is not of type MessageTypeRelayForward")
 	}
 	if msg == nil {
 		return nil, errors.New("The passed message cannot be nil")

--- a/dhcpv6/dhcpv6relay.go
+++ b/dhcpv6/dhcpv6relay.go
@@ -165,6 +165,7 @@ func NewRelayReplFromRelayForw(relayForw, msg DHCPv6) (DHCPv6, error) {
 		err                error
 		linkAddr, peerAddr []net.IP
 		optiids            []Option
+		optrid             []Option
 	)
 	if relayForw == nil {
 		return nil, errors.New("RELAY_FORW cannot be nil")
@@ -186,6 +187,7 @@ func NewRelayReplFromRelayForw(relayForw, msg DHCPv6) (DHCPv6, error) {
 		linkAddr = append(linkAddr, relay.LinkAddr())
 		peerAddr = append(peerAddr, relay.PeerAddr())
 		optiids = append(optiids, relay.GetOneOption(OptionInterfaceID))
+		optrid = append(optrid, relay.GetOneOption(OptionRemoteID))
 		decap, err := DecapsulateRelay(relay)
 		if err != nil {
 			return nil, err
@@ -199,6 +201,9 @@ func NewRelayReplFromRelayForw(relayForw, msg DHCPv6) (DHCPv6, error) {
 	for i := len(linkAddr) - 1; i >= 0; i-- {
 		msg, err = EncapsulateRelay(msg, MessageTypeRelayReply, linkAddr[i], peerAddr[i])
 		if opt := optiids[i]; opt != nil {
+			msg.AddOption(opt)
+		}
+		if opt := optrid[i]; opt != nil {
 			msg.AddOption(opt)
 		}
 		if err != nil {

--- a/dhcpv6/dhcpv6relay.go
+++ b/dhcpv6/dhcpv6relay.go
@@ -170,7 +170,7 @@ func NewRelayReplFromRelayForw(relayForw, msg DHCPv6) (DHCPv6, error) {
 		optrid             []Option
 	)
 	if relayForw == nil {
-		return nil, errors.New("MessageTypeRelayForward cannot be nil")
+		return nil, errors.New("Relay message cannot be nil")
 	}
 	relay, ok := relayForw.(*DHCPv6Relay)
 	if !ok {

--- a/dhcpv6/dhcpv6relay_test.go
+++ b/dhcpv6/dhcpv6relay_test.go
@@ -108,7 +108,7 @@ func TestDHCPv6RelayToBytes(t *testing.T) {
 }
 
 func TestNewRelayRepFromRelayForw(t *testing.T) {
-	// create a new RelayForward
+	// create a new relay forward
 	rf := DHCPv6Relay{}
 	rf.SetMessageType(MessageTypeRelayForward)
 	rf.SetPeerAddr(net.IPv6linklocalallrouters)

--- a/dhcpv6/dhcpv6relay_test.go
+++ b/dhcpv6/dhcpv6relay_test.go
@@ -108,19 +108,23 @@ func TestDHCPv6RelayToBytes(t *testing.T) {
 }
 
 func TestNewRelayRepFromRelayForw(t *testing.T) {
+	// create a new RelayForward
 	rf := DHCPv6Relay{}
 	rf.SetMessageType(MessageTypeRelayForward)
 	rf.SetPeerAddr(net.IPv6linklocalallrouters)
 	rf.SetLinkAddr(net.IPv6interfacelocalallnodes)
-	oro := OptRelayMsg{}
-	s := DHCPv6Message{}
-	s.SetMessage(MessageTypeSolicit)
-	cid := OptClientId{}
-	s.AddOption(&cid)
-	oro.SetRelayMessage(&s)
-	rf.AddOption(&oro)
+	rf.AddOption(&OptInterfaceId{})
+	rf.AddOption(&OptRemoteId{})
 
-	a, err := NewAdvertiseFromSolicit(&s)
+	// create the inner message
+	s, err := NewMessage()
+	require.NoError(t, err)
+	s.AddOption(&OptClientId{})
+	orm := OptRelayMsg{}
+	orm.SetRelayMessage(s)
+	rf.AddOption(&orm)
+
+	a, err := NewAdvertiseFromSolicit(s)
 	require.NoError(t, err)
 	rr, err := NewRelayReplFromRelayForw(&rf, a)
 	require.NoError(t, err)
@@ -129,6 +133,8 @@ func TestNewRelayRepFromRelayForw(t *testing.T) {
 	require.Equal(t, relay.HopCount(), rf.HopCount())
 	require.Equal(t, relay.PeerAddr(), rf.PeerAddr())
 	require.Equal(t, relay.LinkAddr(), rf.LinkAddr())
+	require.NotNil(t, rr.GetOneOption(OptionInterfaceID))
+	require.NotNil(t, rr.GetOneOption(OptionRemoteID))
 	m, err := relay.GetInnerMessage()
 	require.NoError(t, err)
 	require.Equal(t, m, a)


### PR DESCRIPTION
Add the remote id option when creating a relay reply.

According to https://tools.ietf.org/html/rfc4649#section-5 this shouldn't be needed:

> There is no requirement that a server return this option and its data
> in a RELAY-REPLY message.

However, there are some relay agents that expect this data so I am adding it to the reply.

cc @gorhamc