### PR TITLE
Added String methods for types

### DIFF
--- a/dhcpv4/bsdp/bsdp_option_message_type.go
+++ b/dhcpv4/bsdp/bsdp_option_message_type.go
@@ -19,6 +19,13 @@ const (
 	MessageTypeFailed MessageType = 3
 )
 
+func (m MessageType) String() string {
+	if s, ok := MessageTypeToString[m]; ok {
+		return s
+	}
+	return "Unknown"
+}
+
 // MessageTypeToString maps each BSDP message type to a human-readable string.
 var MessageTypeToString = map[MessageType]string{
 	MessageTypeList:   "LIST",
@@ -60,11 +67,7 @@ func (o *OptMessageType) ToBytes() []byte {
 
 // String returns a human-readable string for this option.
 func (o *OptMessageType) String() string {
-	s, ok := MessageTypeToString[o.Type]
-	if !ok {
-		s = "UNKNOWN"
-	}
-	return fmt.Sprintf("BSDP Message Type -> %s", s)
+	return fmt.Sprintf("BSDP Message Type -> %s", o.Type.String())
 }
 
 // Length returns the length of the data portion of this option.

--- a/dhcpv4/bsdp/bsdp_option_message_type_test.go
+++ b/dhcpv4/bsdp/bsdp_option_message_type_test.go
@@ -42,5 +42,5 @@ func TestOptMessageTypeString(t *testing.T) {
 
 	// unknown
 	o = OptMessageType{99}
-	require.Equal(t, "BSDP Message Type -> UNKNOWN", o.String())
+	require.Equal(t, "BSDP Message Type -> Unknown", o.String())
 }

--- a/dhcpv4/bsdp/types.go
+++ b/dhcpv4/bsdp/types.go
@@ -8,10 +8,6 @@ import "github.com/insomniacslk/dhcp/dhcpv4"
 // system.
 const DefaultMacOSVendorClassIdentifier = AppleVendorID + "/i386/MacMini6,1"
 
-// OptionCode represents a BSDP option code. It is equivalent to
-// dhcpv4.OptionCode
-type OptionCode = dhcpv4.OptionCode
-
 // Options (occur as sub-options of DHCP option 43).
 const (
 	OptionMessageType                   dhcpv4.OptionCode = 1
@@ -32,7 +28,7 @@ const (
 
 // OptionCodeToString maps BSDP OptionCodes to human-readable strings
 // describing what they are.
-var OptionCodeToString = map[OptionCode]string{
+var OptionCodeToString = map[dhcpv4.OptionCode]string{
 	OptionMessageType:                   "BSDP Message Type",
 	OptionVersion:                       "BSDP Version",
 	OptionServerIdentifier:              "BSDP Server Identifier",

--- a/dhcpv4/bsdp/types.go
+++ b/dhcpv4/bsdp/types.go
@@ -8,6 +8,10 @@ import "github.com/insomniacslk/dhcp/dhcpv4"
 // system.
 const DefaultMacOSVendorClassIdentifier = AppleVendorID + "/i386/MacMini6,1"
 
+// OptionCode represents a BSDP option code. It is equivalent to
+// dhcpv4.OptionCode
+type OptionCode = dhcpv4.OptionCode
+
 // Options (occur as sub-options of DHCP option 43).
 const (
 	OptionMessageType                   dhcpv4.OptionCode = 1
@@ -28,7 +32,7 @@ const (
 
 // OptionCodeToString maps BSDP OptionCodes to human-readable strings
 // describing what they are.
-var OptionCodeToString = map[dhcpv4.OptionCode]string{
+var OptionCodeToString = map[OptionCode]string{
 	OptionMessageType:                   "BSDP Message Type",
 	OptionVersion:                       "BSDP Version",
 	OptionServerIdentifier:              "BSDP Server Identifier",

--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -307,17 +307,13 @@ func (d *DHCPv4) Opcode() OpcodeType {
 
 // OpcodeToString returns the mnemonic name for the packet's opcode.
 func (d *DHCPv4) OpcodeToString() string {
-	opcode := OpcodeToString[d.opcode]
-	if opcode == "" {
-		opcode = "Invalid"
-	}
-	return opcode
+	return d.opcode.String()
 }
 
 // SetOpcode sets a new opcode for the packet. It prints a warning if the opcode
 // is unknown, but does not generate an error.
 func (d *DHCPv4) SetOpcode(opcode OpcodeType) {
-	if OpcodeToString[opcode] == "" {
+	if _, ok := OpcodeToString[opcode]; !ok {
 		log.Printf("Warning: unknown DHCPv4 opcode: %v", opcode)
 	}
 	d.opcode = opcode
@@ -695,8 +691,7 @@ func (d *DHCPv4) ValidateOptions() {
 				log.Print("Warning: found duplicate End option")
 			}
 			if opt.Code() != OptionEnd && opt.Code() != OptionPad {
-				name := OptionCodeToString[opt.Code()]
-				log.Printf("Warning: found option %v (%v) after End option", opt.Code(), name)
+				log.Printf("Warning: found option %v (%v) after End option", opt.Code(), opt.Code().String())
 			}
 		}
 		if opt.Code() == OptionEnd {

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -250,7 +250,7 @@ func TestToStringMethods(t *testing.T) {
 	d.SetOpcode(OpcodeBootReply)
 	require.Equal(t, "BootReply", d.OpcodeToString())
 	d.SetOpcode(OpcodeType(0))
-	require.Equal(t, "Invalid", d.OpcodeToString())
+	require.Equal(t, "Unknown", d.OpcodeToString())
 
 	// HwTypeToString
 	d.SetHwType(iana.HwTypeEthernet)

--- a/dhcpv4/option_generic.go
+++ b/dhcpv4/option_generic.go
@@ -52,11 +52,7 @@ func (o OptionGeneric) ToBytes() []byte {
 
 // String returns a human-readable representation of a generic option.
 func (o OptionGeneric) String() string {
-	code, ok := OptionCodeToString[o.OptionCode]
-	if !ok {
-		code = "Unknown"
-	}
-	return fmt.Sprintf("%v -> %v", code, o.Data)
+	return fmt.Sprintf("%v -> %v", o.OptionCode.String(), o.Data)
 }
 
 // Length returns the number of bytes comprising the data section of the option.

--- a/dhcpv4/option_message_type.go
+++ b/dhcpv4/option_message_type.go
@@ -43,11 +43,7 @@ func (o *OptMessageType) ToBytes() []byte {
 
 // String returns a human-readable string for this option.
 func (o *OptMessageType) String() string {
-	s, ok := MessageTypeToString[o.MessageType]
-	if !ok {
-		s = "UNKNOWN"
-	}
-	return fmt.Sprintf("DHCP Message Type -> %s", s)
+	return fmt.Sprintf("DHCP Message Type -> %s", o.MessageType.String())
 }
 
 // Length returns the length of the data portion (excluding option code and byte

--- a/dhcpv4/option_message_type_test.go
+++ b/dhcpv4/option_message_type_test.go
@@ -48,5 +48,5 @@ func TestOptMessageTypeString(t *testing.T) {
 
 	// unknown
 	o = OptMessageType{MessageType: 99}
-	require.Equal(t, "DHCP Message Type -> UNKNOWN", o.String())
+	require.Equal(t, "DHCP Message Type -> Unknown", o.String())
 }

--- a/dhcpv4/option_parameter_request_list.go
+++ b/dhcpv4/option_parameter_request_list.go
@@ -53,11 +53,11 @@ func (o *OptParameterRequestList) ToBytes() []byte {
 func (o *OptParameterRequestList) String() string {
 	var optNames []string
 	for _, ro := range o.RequestedOpts {
-		if name, ok := OptionCodeToString[ro]; ok {
-			optNames = append(optNames, name)
-		} else {
-			optNames = append(optNames, fmt.Sprintf("Unknown (%v)", ro))
+		name := ro.String()
+		if name == "Unknown" {
+			name += fmt.Sprintf("%s (%v)", name, ro)
 		}
+		optNames = append(optNames, name)
 	}
 	return fmt.Sprintf("Parameter Request List -> [%v]", strings.Join(optNames, ", "))
 }

--- a/dhcpv4/types.go
+++ b/dhcpv4/types.go
@@ -21,6 +21,13 @@ const (
 	MessageTypeInform   MessageType = 8
 )
 
+func (m MessageType) String() string {
+	if s, ok := MessageTypeToString[m]; ok {
+		return s
+	}
+	return "Unknown"
+}
+
 // MessageTypeToString maps DHCP message types to human-readable strings.
 var MessageTypeToString = map[MessageType]string{
 	MessageTypeDiscover: "DISCOVER",
@@ -41,6 +48,13 @@ const (
 	OpcodeBootRequest OpcodeType = 1
 	OpcodeBootReply   OpcodeType = 2
 )
+
+func (o OpcodeType) String() string {
+	if s, ok := OpcodeToString[o]; ok {
+		return s
+	}
+	return "Unknown"
+}
 
 // OpcodeToString maps an OpcodeType to its mnemonic name
 var OpcodeToString = map[OpcodeType]string{
@@ -211,6 +225,13 @@ const (
 	// Options 224-254 are reserved for private use
 	OptionEnd OptionCode = 255
 )
+
+func (o OptionCode) String() string {
+	if s, ok := OptionCodeToString[o]; ok {
+		return s
+	}
+	return "Unknown"
+}
 
 // OptionCodeToString maps an OptionCode to its mnemonic name
 var OptionCodeToString = map[OptionCode]string{

--- a/dhcpv6/types.go
+++ b/dhcpv6/types.go
@@ -1,5 +1,9 @@
 package dhcpv6
 
+import (
+	"log"
+)
+
 // from http://www.networksorcery.com/enp/protocol/dhcpv6.htm
 
 // MessageType represents the kind of DHCPv6 message.
@@ -28,13 +32,18 @@ const (
 	MessageTypeLeaseQueryData     MessageType = 17
 )
 
+func (m MessageType) String() string {
+	if s, ok := MessageTypeToStringMap[m]; ok {
+		return s
+	}
+	return "Unknown"
+}
+
 // MessageTypeToString converts a MessageType to a human-readable string
 // representation.
 func MessageTypeToString(t MessageType) string {
-	if m, ok := MessageTypeToStringMap[t]; ok {
-		return m
-	}
-	return "Unknown"
+	log.Printf("Warning: MessageTypeToString is deprecated and will be removed, use MessageType.String() instead")
+	return t.String()
 }
 
 // MessageTypeToStringMap contains the mapping of MessageTypes to human-readable


### PR DESCRIPTION
I've added a String method to all the option/message types so we don't need to check the map manually every time, or to use a function (a method is more intuitive).

Only one exception: bsdp.OptionCode cannot be easily converted to this approach unless we define it as its own type