### PR TITLE
[WIP] Test that we do not break router7 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 sudo: required
 
 go:
-  - "1.8"
   - "1.9"
   - "1.10"
   - "1.11rc1"

--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -13,3 +13,15 @@ for d in $(go list ./... | grep -v vendor); do
         rm profile.out
     fi
 done
+
+# check that we are not breaking some projects that depend on us. Remove this after moving to
+# Go versioned modules, see https://github.com/insomniacslk/dhcp/issues/123
+
+# from https://github.com/rtr7/router7/blob/aa404c3c54d9ad655479d7978ed18e81fe6ca05c/.travis.yml#L14
+# TODO: get rid of this once https://github.com/google/gopacket/pull/470 is merged
+go get github.com/google/gopacket/pcapgo
+(cd $GOPATH/src/github.com/google/gopacket && wget -qO- https://patch-diff.githubusercontent.com/raw/google/gopacket/pull/470.patch | patch -p1)
+
+go get github.com/rtr7/router7/cmd/...
+cd "${GOPATH}/src/github.com/rtr7/router7"
+go build github.com/rtr7/router7/cmd/...


### PR DESCRIPTION
In a couple of commits we broke a project that depends on this library (router7). I've added a simple build of router7 at the end of the tests until we move to a stable API and versioned modules