### PR TITLE
Removed workaround for pcapgo.OpenEthernet from tests

### DIFF
--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -16,12 +16,6 @@ done
 
 # check that we are not breaking some projects that depend on us. Remove this after moving to
 # Go versioned modules, see https://github.com/insomniacslk/dhcp/issues/123
-
-# from https://github.com/rtr7/router7/blob/aa404c3c54d9ad655479d7978ed18e81fe6ca05c/.travis.yml#L14
-# TODO: get rid of this once https://github.com/google/gopacket/pull/470 is merged
-go get github.com/google/gopacket/pcapgo
-(cd $GOPATH/src/github.com/google/gopacket && wget -qO- https://patch-diff.githubusercontent.com/raw/google/gopacket/pull/470.patch | patch -p1)
-
 go get github.com/rtr7/router7/cmd/...
 cd "${GOPATH}/src/github.com/rtr7/router7"
 go build github.com/rtr7/router7/cmd/...


### PR DESCRIPTION
Removed the workaround from TravisCI tests where we patched manually pcapgo (see https://github.com/insomniacslk/dhcp/pull/152 ), since the relevant gopacket PR has been merged.