### PR TITLE
Implemented basic DHCPv6 server handler

### DIFF
--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -16,6 +16,14 @@ done
 
 # check that we are not breaking some projects that depend on us. Remove this after moving to
 # Go versioned modules, see https://github.com/insomniacslk/dhcp/issues/123
+
+# Skip go1.9 for this check. rtr7/router7 depends on miekg/dns, which does not
+# support go1.9
+if [ "$TRAVIS_GO_VERSION" = "1.9" ]
+then
+    exit 0
+fi
+
 go get github.com/rtr7/router7/cmd/...
 cd "${GOPATH}/src/github.com/rtr7/router7"
 go build github.com/rtr7/router7/cmd/...

--- a/dhcpv6/client.go
+++ b/dhcpv6/client.go
@@ -127,6 +127,13 @@ func (c *Client) sendReceive(ifname string, packet DHCPv6, expectedType MessageT
 		return nil, err
 	}
 	defer conn.Close()
+	// wait for the listener to be ready
+	for {
+		if conn.LocalAddr() != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	// send the packet out
 	conn.SetWriteDeadline(time.Now().Add(c.WriteTimeout))

--- a/dhcpv6/client_test.go
+++ b/dhcpv6/client_test.go
@@ -1,0 +1,14 @@
+package dhcpv6
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient(t *testing.T) {
+	c := NewClient()
+	require.NotNil(t, c)
+	require.Equal(t, DefaultReadTimeout, c.ReadTimeout)
+	require.Equal(t, DefaultWriteTimeout, c.WriteTimeout)
+}

--- a/dhcpv6/server.go
+++ b/dhcpv6/server.go
@@ -66,6 +66,8 @@ type Server struct {
 	localAddr  net.UDPAddr
 }
 
+// LocalAddr returns the local address of the listening socked, or nil if not
+// listening
 func (s *Server) LocalAddr() net.Addr {
 	if s.conn == nil {
 		return nil

--- a/dhcpv6/server.go
+++ b/dhcpv6/server.go
@@ -128,6 +128,7 @@ func (s *Server) ActivateAndServe() error {
 	return nil
 }
 
+// Close sends a termination request to the server, and closes the UDP listener
 func (s *Server) Close() error {
 	s.shouldStop = true
 	for {

--- a/dhcpv6/server.go
+++ b/dhcpv6/server.go
@@ -67,7 +67,7 @@ type Server struct {
 	localAddr  net.UDPAddr
 }
 
-// LocalAddr returns the local address of the listening socked, or nil if not
+// LocalAddr returns the local address of the listening socket, or nil if not
 // listening
 func (s *Server) LocalAddr() net.Addr {
 	s.connMutex.Lock()
@@ -88,6 +88,10 @@ func (s *Server) ActivateAndServe() error {
 		}
 		s.conn = conn
 	}
+	defer func() {
+		s.conn.Close()
+		s.conn = nil
+	}()
 	s.connMutex.Unlock()
 	var (
 		pc *net.UDPConn
@@ -102,7 +106,6 @@ func (s *Server) ActivateAndServe() error {
 	log.Printf("Server listening on %s", pc.LocalAddr())
 	log.Print("Ready to handle requests")
 	for {
-		log.Printf("CHECK")
 		select {
 		case <-s.shouldStop:
 			break
@@ -129,7 +132,6 @@ func (s *Server) ActivateAndServe() error {
 		}
 		s.Handler(pc, peer, m)
 	}
-	s.conn.Close()
 	return nil
 }
 

--- a/dhcpv6/server.go
+++ b/dhcpv6/server.go
@@ -51,14 +51,18 @@ func main() {
 
 */
 
+// Handler is a type that defines the handler function to be called every time a
+// valid DHCPv6 message is received
 type Handler func(conn net.PacketConn, peer net.Addr, m DHCPv6)
 
+// Server represents a DHCPv6 server object
 type Server struct {
 	conn      net.PacketConn
 	LocalAddr net.UDPAddr
 	Handler   Handler
 }
 
+// ActivateAndServe starts the DHCPv6 server
 func (s *Server) ActivateAndServe() error {
 	if s.conn == nil {
 		conn, err := net.ListenUDP("udp6", &s.LocalAddr)
@@ -99,6 +103,7 @@ func (s *Server) ActivateAndServe() error {
 	return nil
 }
 
+// NewServer initializes and returns a new Server object
 func NewServer(addr net.UDPAddr, handler Handler) *Server {
 	return &Server{
 		LocalAddr: addr,

--- a/dhcpv6/server.go
+++ b/dhcpv6/server.go
@@ -6,38 +6,82 @@ import (
 	"net"
 )
 
-type ResponseWriter interface {
-	LocalAddr() net.Addr
-	RemoteAddr() net.Addr
-	WriteMsg(DHCPv6) error
-	Write([]byte) (int, error)
-	Close() error
+/*
+  To use the DHCPv6 server code you have to call NewServer with two arguments:
+  - a handler function, that will be called every time a valid DHCPv6 packet is
+      received, and
+  - an address to listen on.
+
+  The handler is a function that takes as input a packet connection, that can be
+  used to reply to the client; a peer address, that identifies the client sending
+  the request, and the DHCPv6 packet itself. Just implement your custom logic in
+  the handler.
+
+  The address to listen on is used to know IP address, port and optionally the
+  scope to create and UDP6 socket to listen on for DHCPv6 traffic.
+
+  Example program:
+
+
+package main
+
+import (
+	"log"
+	"net"
+
+	"github.com/insomniacslk/dhcp/dhcpv6"
+)
+
+func handler(conn net.PacketConn, peer net.Addr, m dhcpv6.DHCPv6) {
+	// this function will just print the received DHCPv6 message, without replying
+	log.Print(m.Summary())
 }
 
-type Handler interface {
-	ServeDHCP(w ResponseWriter, m *DHCPv6)
+func main() {
+	laddr := net.UDPAddr{
+		IP:   net.ParseIP("::1"),
+		Port: 547,
+	}
+	server := dhcpv6.NewServer(laddr, handler)
+
+	if err := server.ActivateAndServe(); err != nil {
+		log.Fatal(err)
+	}
 }
+
+*/
+
+type Handler func(conn net.PacketConn, peer net.Addr, m DHCPv6)
 
 type Server struct {
-	PacketConn net.PacketConn
-	Handler    Handler
+	conn      net.PacketConn
+	LocalAddr net.UDPAddr
+	Handler   Handler
 }
 
 func (s *Server) ActivateAndServe() error {
-	if s.PacketConn == nil {
-		return fmt.Errorf("Error: no packet connection specified")
+	if s.conn == nil {
+		conn, err := net.ListenUDP("udp6", &s.LocalAddr)
+		if err != nil {
+			return err
+		}
+		s.conn = conn
 	}
-	var pc *net.UDPConn
-	var ok bool
-	if pc, ok = s.PacketConn.(*net.UDPConn); !ok {
+	var (
+		pc *net.UDPConn
+		ok bool
+	)
+	if pc, ok = s.conn.(*net.UDPConn); !ok {
 		return fmt.Errorf("Error: not an UDPConn")
 	}
 	if pc == nil {
 		return fmt.Errorf("ActivateAndServe: Invalid nil PacketConn")
 	}
-	log.Print("Handling requests")
+	log.Printf("Server listening on %s", pc.LocalAddr())
+	log.Print("Ready to handle requests")
 	for {
-		rbuf := make([]byte, 1024) // FIXME this is bad
+		log.Printf("Waiting..")
+		rbuf := make([]byte, 4096) // FIXME this is bad
 		n, peer, err := pc.ReadFrom(rbuf)
 		if err != nil {
 			log.Printf("Error reading from packet conn: %v", err)
@@ -49,8 +93,15 @@ func (s *Server) ActivateAndServe() error {
 			log.Printf("Error parsing DHCPv6 request: %v", err)
 			continue
 		}
-		log.Print(m.Summary())
-		// FIXME use s.Handler
+		s.Handler(pc, peer, m)
 	}
+	s.conn.Close()
 	return nil
+}
+
+func NewServer(addr net.UDPAddr, handler Handler) *Server {
+	return &Server{
+		LocalAddr: addr,
+		Handler:   handler,
+	}
 }

--- a/dhcpv6/server_test.go
+++ b/dhcpv6/server_test.go
@@ -59,8 +59,12 @@ func TestNewServer(t *testing.T) {
 
 func TestServerActivateAndServe(t *testing.T) {
 	handler := func(conn net.PacketConn, peer net.Addr, m DHCPv6) {
-		log.Printf("MESSAGE from %s, reply with %v", peer, m.ToBytes())
-		if _, err := conn.WriteTo(m.ToBytes(), peer); err != nil {
+		adv, err := NewAdvertiseFromSolicit(m)
+		if err != nil {
+			log.Printf("NewAdvertiseFromSolicit failed: %v", err)
+			return
+		}
+		if _, err := conn.WriteTo(adv.ToBytes(), peer); err != nil {
 			log.Printf("Cannot reply to client: %v", err)
 		}
 	}

--- a/dhcpv6/server_test.go
+++ b/dhcpv6/server_test.go
@@ -1,0 +1,21 @@
+package dhcpv6
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServer(t *testing.T) {
+	laddr := net.UDPAddr{
+		IP:   net.ParseIP("::1"),
+		Port: 0,
+	}
+	handler := func(conn net.PacketConn, peer net.Addr, m DHCPv6) {}
+	s := NewServer(laddr, handler)
+	require.NotNil(t, s)
+	require.Nil(t, s.conn)
+	require.Equal(t, laddr, s.LocalAddr)
+	require.NotNil(t, s.Handler)
+}

--- a/dhcpv6/server_test.go
+++ b/dhcpv6/server_test.go
@@ -1,21 +1,73 @@
 package dhcpv6
 
 import (
+	"log"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+// utility function to set up a client and a server instance and run it in
+// background. The caller needs to call Server.Close() once finished.
+func setUpClientAndServer(handler Handler) (*Client, *Server) {
+	laddr := net.UDPAddr{
+		IP:   net.ParseIP("::1"),
+		Port: 0,
+		Zone: "lo",
+	}
+	s := NewServer(laddr, handler)
+	go s.ActivateAndServe()
+
+	c := NewClient()
+	c.LocalAddr = &net.UDPAddr{
+		IP:   net.ParseIP("::1"),
+		Zone: "lo",
+	}
+	for {
+		if s.LocalAddr() != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+		log.Printf("Waiting for server to run...")
+	}
+	c.RemoteAddr = &net.UDPAddr{
+		IP:   net.ParseIP("::1"),
+		Port: s.LocalAddr().(*net.UDPAddr).Port,
+		Zone: "lo",
+	}
+
+	return c, s
+}
 
 func TestNewServer(t *testing.T) {
 	laddr := net.UDPAddr{
 		IP:   net.ParseIP("::1"),
 		Port: 0,
+		Zone: "lo",
 	}
 	handler := func(conn net.PacketConn, peer net.Addr, m DHCPv6) {}
 	s := NewServer(laddr, handler)
+	defer s.Close()
+
 	require.NotNil(t, s)
 	require.Nil(t, s.conn)
-	require.Equal(t, laddr, s.LocalAddr)
+	require.Equal(t, laddr, s.localAddr)
 	require.NotNil(t, s.Handler)
+}
+
+func TestServerActivateAndServe(t *testing.T) {
+	handler := func(conn net.PacketConn, peer net.Addr, m DHCPv6) {
+		log.Printf("MESSAGE from %s, reply with %v", peer, m.ToBytes())
+		if _, err := conn.WriteTo(m.ToBytes(), peer); err != nil {
+			log.Printf("Cannot reply to client: %v", err)
+		}
+	}
+	c, s := setUpClientAndServer(handler)
+	defer s.Close()
+
+	_, _, err := c.Solicit("lo", nil)
+
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Implemented a bare-bone DHCPv6 server code. Now the user can simply provide a handler function
and an address to listen on, to run a basic DHCPv6 server with custom logic.

This also enables integration tests (see `server_test.go` for an example)

Sample run:

Server:
```
$ go run main.go 
2018/09/26 23:57:21 Server listening on [::1]:12345
2018/09/26 23:57:21 Ready to handle requests
2018/09/26 23:57:21 Waiting..
2018/09/27 00:11:37 Handling request from [::1]:42598
2018/09/27 00:11:37 DHCPv6Message
  messageType=SOLICIT
  transactionid=0xaabbcc
  options=[  ]
2018/09/27 00:11:37 Waiting..
^Csignal: interrupt
```

Client:
```
$ echo -en "\x01\xaa\xbb\xcc" | nc -u -6 '::1' 12345 
^C
```