### PR TITLE
BSDP: Fix parsing offset for boot image lists

### DIFF
--- a/dhcpv4/bsdp/bsdp_option_boot_image_list.go
+++ b/dhcpv4/bsdp/bsdp_option_boot_image_list.go
@@ -34,7 +34,7 @@ func ParseOptBootImageList(data []byte) (*OptBootImageList, error) {
 	var bootImages []BootImage
 	idx := 2
 	for {
-		if idx >= len(data) {
+		if idx >= length+2 {
 			break
 		}
 		image, err := BootImageFromBytes(data[idx:])

--- a/dhcpv4/bsdp/bsdp_option_boot_image_list_test.go
+++ b/dhcpv4/bsdp/bsdp_option_boot_image_list_test.go
@@ -101,13 +101,32 @@ func TestParseOptBootImageList(t *testing.T) {
 		0x1, 0x0, 0x03, 0xe9, // ID
 		4, // name length
 		'b', 's', 'd', 'p', '-', '1',
-		// boot image 1
+		// boot image 2
 		0x80, 0x0, 0x23, 0x31, // ID
 		6, // name length
 		'b', 's', 'd', 'p', '-', '2',
 	}
 	_, err = ParseOptBootImageList(data)
 	require.Error(t, err, "should get error from bad boot image")
+
+	// Should not get error parsing boot image with excess length.
+	data = []byte{
+		9,  // code
+		22, // length
+		// boot image 1
+		0x1, 0x0, 0x03, 0xe9, // ID
+		6, // name length
+		'b', 's', 'd', 'p', '-', '1',
+		// boot image 2
+		0x80, 0x0, 0x23, 0x31, // ID
+		6, // name length
+		'b', 's', 'd', 'p', '-', '2',
+
+		// Simulate another option after boot image list
+		7, 4, 0x80, 0x0, 0x23, 0x32,
+	}
+	_, err = ParseOptBootImageList(data)
+	require.NoError(t, err, "should not get error from options after boot image list")
 }
 
 func TestOptBootImageListString(t *testing.T) {


### PR DESCRIPTION
While parsing boot images, the current code reads to the end of the data
stream; however, this could lead to reading past the boot image option
and reading into the next option. Instead, contain how far the option
parsing code reads by only looking at the max length specified in the
option.

Before fix, failing tests (added in this PR):
```
$ go test ./...
?       github.com/insomniacslk/dhcp    [no test files]
# github.com/insomniacslk/dhcp/netboot
netboot/netconf.go:118:13: undefined: netlink.AddrReplace
ok      github.com/insomniacslk/dhcp/dhcpv4     (cached)
ok      github.com/insomniacslk/dhcp/dhcpv4/async       (cached)
--- FAIL: TestParseOptBootImageList (0.00s)
        bsdp_option_boot_image_list_test.go:129:
                        Error Trace:    bsdp_option_boot_image_list_test.go:129
                        Error:          Received unexpected error:
                                        parsing bytes stream: not enough bytes for BootImage
                        Test:           TestParseOptBootImageList
                        Messages:       should not get error from options after boot image list
--- FAIL: TestParseOptVendorSpecificInformation (0.00s)
        option_vendor_specific_information_test.go:107:
                        Error Trace:    option_vendor_specific_information_test.go:107
                        Error:          Received unexpected error:
                                        parsing bytes stream: not enough bytes for BootImage
                        Test:           TestParseOptVendorSpecificInformation
FAIL
```

Afterwards, all bsdp tests pass.