### PR TITLE
DHCPv4: Add sendto address

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -32,6 +32,7 @@ type DHCPv4 struct {
 	yourIPAddr     net.IP
 	serverIPAddr   net.IP
 	gatewayIPAddr  net.IP
+	sendToIPAddr   net.IP
 	clientHwAddr   [16]byte
 	serverHostName [64]byte
 	bootFileName   [128]byte
@@ -470,6 +471,16 @@ func (d *DHCPv4) GatewayIPAddr() net.IP {
 // SetGatewayIPAddr sets the gateway IP address.
 func (d *DHCPv4) SetGatewayIPAddr(gatewayIPAddr net.IP) {
 	d.gatewayIPAddr = gatewayIPAddr
+}
+
+// SendToIPAddr returns the sendto IP address.
+func (d *DHCPv4) SendToIPAddr() net.IP {
+	return d.sendToIPAddr
+}
+
+// SetSendToIPAddr sets the sendto IP address.
+func (d *DHCPv4) SetSendToIPAddr(sendToIPAddr net.IP) {
+	d.sendToIPAddr = sendToIPAddr
 }
 
 // ClientHwAddr returns the client hardware (MAC) address.

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -71,6 +71,7 @@ func TestFromBytes(t *testing.T) {
 	require.True(t, d.ClientIPAddr().Equal(net.IPv4zero))
 	require.True(t, d.YourIPAddr().Equal(net.IPv4zero))
 	require.True(t, d.GatewayIPAddr().Equal(net.IPv4zero))
+	require.Nil(t, d.SendToIPAddr())
 	clientHwAddr := d.ClientHwAddr()
 	require.Equal(t, clientHwAddr[:], []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
 	hostname := d.ServerHostName()
@@ -210,6 +211,11 @@ func TestSettersAndGetters(t *testing.T) {
 	require.True(t, d.GatewayIPAddr().Equal(net.IPv4(13, 14, 15, 16)))
 	d.SetGatewayIPAddr(net.IPv4(16, 15, 14, 13))
 	require.True(t, d.GatewayIPAddr().Equal(net.IPv4(16, 15, 14, 13)))
+
+	// getter/setter for SendToIPAddr
+	require.Nil(t, d.SendToIPAddr())
+	d.SetGatewayIPAddr(net.IPv4(5, 4, 3, 2))
+	require.True(t, d.SendToIPAddr().Equal(net.IPv4(5, 4, 3, 2)))
 
 	// getter/setter for ClientHwAddr
 	hwaddr := d.ClientHwAddr()


### PR DESCRIPTION
Sometimes you may want to send a packet to an address other than e.g.
the gateway address stored inside the packet. In these instances, you
need another field in which to store the address. The `SendToIPAddr`
field in the DHCPv4 struct is nominally `nil`, but in these rare
occasions where you do want to send another address, consumer code can
set the address.