### PR TITLE
Dynamically determine loopback interface for server test

### DIFF
--- a/dhcpv6/server_test.go
+++ b/dhcpv6/server_test.go
@@ -9,13 +9,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// utility function to return the loopback interface name
+func getLoopbackInterface() string {
+        var ifaces []net.Interface
+        var err error
+        if ifaces, err = net.Interfaces(); err != nil {
+                return ""
+        }
+
+        for _, iface := range ifaces {
+            if iface.Flags & net.FlagLoopback != 0 || iface.Name[:2] == "lo" {
+                    return iface.Name
+            }
+        }
+
+        return ""
+}
+
 // utility function to set up a client and a server instance and run it in
 // background. The caller needs to call Server.Close() once finished.
 func setUpClientAndServer(handler Handler) (*Client, *Server) {
 	laddr := net.UDPAddr{
 		IP:   net.ParseIP("::1"),
 		Port: 0,
-		Zone: "lo",
 	}
 	s := NewServer(laddr, handler)
 	go s.ActivateAndServe()
@@ -23,7 +39,6 @@ func setUpClientAndServer(handler Handler) (*Client, *Server) {
 	c := NewClient()
 	c.LocalAddr = &net.UDPAddr{
 		IP:   net.ParseIP("::1"),
-		Zone: "lo",
 	}
 	for {
 		if s.LocalAddr() != nil {
@@ -35,7 +50,6 @@ func setUpClientAndServer(handler Handler) (*Client, *Server) {
 	c.RemoteAddr = &net.UDPAddr{
 		IP:   net.ParseIP("::1"),
 		Port: s.LocalAddr().(*net.UDPAddr).Port,
-		Zone: "lo",
 	}
 
 	return c, s
@@ -45,7 +59,6 @@ func TestNewServer(t *testing.T) {
 	laddr := net.UDPAddr{
 		IP:   net.ParseIP("::1"),
 		Port: 0,
-		Zone: "lo",
 	}
 	handler := func(conn net.PacketConn, peer net.Addr, m DHCPv6) {}
 	s := NewServer(laddr, handler)
@@ -71,7 +84,6 @@ func TestServerActivateAndServe(t *testing.T) {
 	c, s := setUpClientAndServer(handler)
 	defer s.Close()
 
-	_, _, err := c.Solicit("lo", nil)
-
+	_, _, err := c.Solicit(getLoopbackInterface(), nil)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
"lo" isn't configured everywhere. In FreeBSD for example, TestServerActivateAndServe() fails as the loopback address is "lo0", not "lo".

Also, I don't believe the Zone is required for net.UDPAddr as ::1 is being used, not an fe80:: address. On FreeBSD, since the "lo" Zone doesn't exist, it can't be mapped to an interface index and seems to be silently dropped (I can put "asdf" and it does the same thing). The tests still work fine though.