### PR TITLE
DHCPv4: syscall -> x/sys/unix

### DIFF
--- a/dhcpv4/bindtodevice_darwin.go
+++ b/dhcpv4/bindtodevice_darwin.go
@@ -4,13 +4,16 @@ package dhcpv4
 
 import (
 	"net"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
+// BindToInterface emulates linux's SO_BINDTODEVICE option for a socket by using
+// SO_IP_BOUND_IF.
 func BindToInterface(fd int, ifname string) error {
 	iface, err := net.InterfaceByName(ifname)
 	if err != nil {
 		return err
 	}
-	return syscall.SetsockoptInt(fd, syscall.IPPROTO_IP, syscall.IP_BOUND_IF, iface.Index)
+	return unix.SetsockoptInt(fd, unix.IPPROTO_IP, unix.IP_BOUND_IF, iface.Index)
 }

--- a/dhcpv4/bindtodevice_linux.go
+++ b/dhcpv4/bindtodevice_linux.go
@@ -2,10 +2,8 @@
 
 package dhcpv4
 
-import (
-	"syscall"
-)
+import "golang.org/x/sys/unix"
 
 func BindToInterface(fd int, ifname string) error {
-	return syscall.BindToDevice(fd, ifname)
+	return unix.BindToDevice(fd, ifname)
 }

--- a/dhcpv4/bsdp/vendor_class_identifier_darwin.go
+++ b/dhcpv4/bsdp/vendor_class_identifier_darwin.go
@@ -2,14 +2,15 @@ package bsdp
 
 import (
 	"fmt"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // MakeVendorClassIdentifier calls the sysctl syscall on macOS to get the
 // platform model.
 func MakeVendorClassIdentifier() (string, error) {
 	// Fetch hardware model for class ID.
-	hwModel, err := syscall.Sysctl("hw.model")
+	hwModel, err := unix.Sysctl("hw.model")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes #156

Build a simple client like so:
```
package main

import (
    "fmt"
    "time"

    "github.com/insomniacslk/dhcp/dhcpv4"
)

func main() {
    client := dhcpv4.Client{ReadTimeout: 5 * time.Second, WriteTimeout: 5 * time.Second}
    conversation, err := client.Exchange("en0", nil)
    if err != nil {
        fmt.Println(err)
    }
    for _, m := range conversation {
        fmt.Println(m.Summary())
    }
}
```

and run:
```
$ sudo ./main
Password:
DHCPv4
  opcode=BootRequest
  hwtype=Ethernet
  hwaddrlen=6
  hopcount=0
  transactionid=0xabfad715
  numseconds=0
  flags=Broadcast (0x8000)
  clientipaddr=0.0.0.0
  youripaddr=0.0.0.0
  serveripaddr=0.0.0.0
  gatewayipaddr=0.0.0.0
  clienthwaddr=8c:85:90:20:2e:33
  serverhostname=
  bootfilename=
  options=
    DHCP Message Type -> DISCOVER
    Parameter Request List -> [Subnet Mask, Router, Domain Name, Domain Name Server]
    End -> []

DHCPv4
  opcode=BootReply
  hwtype=Ethernet
  hwaddrlen=6
  hopcount=0
  transactionid=0xabfad715
  numseconds=0
  flags=Broadcast (0x8000)
  clientipaddr=0.0.0.0
  youripaddr=192.168.0.105
  serveripaddr=0.0.0.0
  gatewayipaddr=0.0.0.0
  clienthwaddr=8c:85:90:20:2e:33
  serverhostname=
  bootfilename=
  options=
    DHCP Message Type -> OFFER
    Server Identifier -> 192.168.0.1
    IP Addresses Lease Time -> 5648
    Subnet Mask -> ffffff00
    Routers -> 192.168.0.1
    Domain Name Servers -> 8.8.8.8, 8.8.4.4
    End -> []

DHCPv4
  opcode=BootRequest
  hwtype=Ethernet
  hwaddrlen=6
  hopcount=0
  transactionid=0xabfad715
  numseconds=0
  flags=Broadcast (0x8000)
  clientipaddr=0.0.0.0
  youripaddr=0.0.0.0
  serveripaddr=192.168.0.1
  gatewayipaddr=0.0.0.0
  clienthwaddr=8c:85:90:20:2e:33
  serverhostname=
  bootfilename=
  options=
    DHCP Message Type -> REQUEST
    Requested IP Address -> 192.168.0.105
    Server Identifier -> 192.168.0.1
    End -> []

DHCPv4
  opcode=BootReply
  hwtype=Ethernet
  hwaddrlen=6
  hopcount=0
  transactionid=0xabfad715
  numseconds=0
  flags=Broadcast (0x8000)
  clientipaddr=0.0.0.0
  youripaddr=192.168.0.105
  serveripaddr=0.0.0.0
  gatewayipaddr=0.0.0.0
  clienthwaddr=8c:85:90:20:2e:33
  serverhostname=
  bootfilename=
  options=
    DHCP Message Type -> ACK
    Server Identifier -> 192.168.0.1
    IP Addresses Lease Time -> 7200
    Subnet Mask -> ffffff00
    Routers -> 192.168.0.1
    Domain Name Servers -> 8.8.8.8, 8.8.4.4
    End -> []
```