### PR TITLE
Avoid panic on malformed OptIAPrefix

### DIFF
--- a/dhcpv6/option_iaprefix.go
+++ b/dhcpv6/option_iaprefix.go
@@ -86,8 +86,8 @@ func (op *OptIAPrefix) String() string {
 // The input data does not include option code and length bytes.
 func ParseOptIAPrefix(data []byte) (*OptIAPrefix, error) {
 	opt := OptIAPrefix{}
-	if len(data) < 12 {
-		return nil, fmt.Errorf("Invalid IA for Prefix Delegation data length. Expected at least 12 bytes, got %v", len(data))
+	if len(data) < 25 {
+		return nil, fmt.Errorf("Invalid IA for Prefix Delegation data length. Expected at least 25 bytes, got %v", len(data))
 	}
 	opt.preferredLifetime = binary.BigEndian.Uint32(data[:4])
 	opt.validLifetime = binary.BigEndian.Uint32(data[4:8])

--- a/dhcpv6/option_iaprefix_test.go
+++ b/dhcpv6/option_iaprefix_test.go
@@ -50,3 +50,15 @@ func TestOptIAPrefixToBytes(t *testing.T) {
 		t.Fatalf("Invalid ToBytes result. Expected %v, got %v", expected, toBytes)
 	}
 }
+
+func TestOptIAPrefixParseInvalidTooShort(t *testing.T) {
+	buf := []byte{
+		0xaa, 0xbb, 0xcc, 0xdd, // preferredLifetime
+		0xee, 0xff, 0x00, 0x11, // validLifetime
+		36,                     // prefixLength
+		0, 0, 0, 0, 0, 0, 0,    // truncated ipv6Prefix
+	}
+	if opt, err := ParseOptIAPrefix(buf); err == nil {
+		t.Fatalf("ParseOptIAPrefix: Expected error on truncated option, got %v", opt)
+	}
+}


### PR DESCRIPTION
Noticed the length check on ParseOptIAPrefix() is wrong. The other DHCPv6 options seem okay.