### PR TITLE
Custom client/server addresses/ports for DHCPv4 client

### DIFF
--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -247,7 +247,7 @@ func (c *Client) sendReceive(sendFd, recvFd int, packet *DHCPv4, messageType Mes
 	if err != nil {
 		return nil, err
 	}
-	packetBytes, err := makeRawPacket(packet.ToBytes(), raddr, laddr)
+	packetBytes, err := MakeRawPacket(packet.ToBytes(), raddr, laddr)
 	if err != nil {
 		return nil, err
 	}

--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -50,6 +50,7 @@ func NewClient() *Client {
 // MakeRawBroadcastPacket leverages MakeRawPacket to create a raw packet suitable
 // for UDP broadcast.
 func MakeRawBroadcastPacket(payload []byte) ([]byte, error) {
+	log.Printf("Warning: dhcpv4.MakeRawBroadcastPacket() is deprecated and will be removed.")
 	serverAddr := &net.UDPAddr{IP: net.IPv4bcast, Port: ServerPort}
 	clientAddr := &net.UDPAddr{IP: net.IPv4zero, Port: ClientPort}
 	return MakeRawPacket(payload, serverAddr, clientAddr)

--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -28,16 +28,6 @@ var (
 	DefaultWriteTimeout = 3 * time.Second
 )
 
-// ClientExchangeOptions specifies a set of options to be used for a particular
-// exchange.
-type ClientExchangeOptions struct {
-	// UnicastSocket is used to ask the library to use an unicast socket instead
-	// of a broadcast socket for the DHCPv4 exchange. Note that it's on the
-	// user of the library to set up the actual DHCP packet (ex: by specifying a
-	// server address) so this actually works as expected.
-	UnicastSocket bool
-}
-
 // Client is the object that actually performs the DHCP exchange. It currently
 // only has read and write timeout values, plus (optional) local and remote
 // addresses.

--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -82,8 +82,8 @@ func MakeRawPacket(payload []byte, serverAddr, clientAddr *net.UDPAddr) ([]byte,
 	return ret, nil
 }
 
-// MakeRawSocket creates a socket that can be passed to unix.Sendto.
-func MakeRawSocket() (int, error) {
+// makeRawSocket creates a socket that can be passed to unix.Sendto.
+func makeRawSocket() (int, error) {
 	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_RAW, unix.IPPROTO_RAW)
 	if err != nil {
 		return fd, err
@@ -102,15 +102,11 @@ func MakeRawSocket() (int, error) {
 // MakeBroadcastSocket creates a socket that can be passed to unix.Sendto
 // that will send packets out to the broadcast address.
 func MakeBroadcastSocket(ifname string) (int, error) {
-	fd, err := MakeRawSocket()
+	fd, err := makeRawSocket()
 	if err != nil {
 		return fd, err
 	}
 	err = unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_BROADCAST, 1)
-	if err != nil {
-		return fd, err
-	}
-	err = BindToInterface(fd, ifname)
 	if err != nil {
 		return fd, err
 	}
@@ -120,7 +116,7 @@ func MakeBroadcastSocket(ifname string) (int, error) {
 // MakeUnicastSocket creates a socket that can be passed to unix.Sendto
 // that will send packets to a single address
 func MakeUnicastSocket(ifname string) (int, error) {
-	fd, err := MakeRawSocket()
+	fd, err := makeRawSocket()
 	if err != nil {
 		return fd, err
 	}

--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -166,7 +166,7 @@ func (c *Client) getLocalUDPAddr() (*net.UDPAddr, error) {
 
 func (c *Client) getRemoteUDPAddr() (*net.UDPAddr, error) {
 	defaultRemoteAddr := &net.UDPAddr{IP: net.IPv4bcast, Port: ServerPort}
-	raddr, err := toUDPAddr(c.LocalAddr, defaultRemoteAddr)
+	raddr, err := toUDPAddr(c.RemoteAddr, defaultRemoteAddr)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid remote address: %s", err)
 	}

--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -115,20 +115,6 @@ func MakeBroadcastSocket(ifname string) (int, error) {
 	return fd, nil
 }
 
-// MakeUnicastSocket creates a socket that can be passed to unix.Sendto
-// that will send packets to a single address
-func MakeUnicastSocket(ifname string) (int, error) {
-	fd, err := makeRawSocket()
-	if err != nil {
-		return fd, err
-	}
-	err = BindToInterface(fd, ifname)
-	if err != nil {
-		return fd, err
-	}
-	return fd, nil
-}
-
 // MakeListeningSocket creates a listening socket on 0.0.0.0 for the DHCP client
 // port and returns it.
 func MakeListeningSocket(ifname string) (int, error) {
@@ -192,7 +178,7 @@ func (c *Client) Exchange(ifname string, discover *DHCPv4, modifiers ...Modifier
 	// TODO: we should check the IP is actually not a broadcast address for the
 	// subnet here.
 	if c.RemoteAddr != nil {
-		sfd, err = MakeUnicastSocket(ifname)
+		sfd, err = makeRawSocket()
 	} else {
 		sfd, err = MakeBroadcastSocket(ifname)
 	}

--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -162,26 +162,21 @@ func MakeListeningSocket(ifname string) (int, error) {
 	return fd, nil
 }
 
-// Exchange is a shortcut for ExchangeWithOptions when you want to use the default
-// option set.
-func (c *Client) Exchange(ifname string, discover *DHCPv4, modifiers ...Modifier) ([]*DHCPv4, error) {
-	return c.ExchangeWithOptions(ifname, discover, &ClientExchangeOptions{}, modifiers...)
-}
-
-
-// ExchangeWithOptions runs a full DORA transaction: Discover, Offer, Request, Acknowledge,
+// Exchange runs a full DORA transaction: Discover, Offer, Request, Acknowledge,
 // over UDP. Does not retry in case of failures. Returns a list of DHCPv4
 // structures representing the exchange. It can contain up to four elements,
 // ordered as Discovery, Offer, Request and Acknowledge. In case of errors, an
 // error is returned, and the list of DHCPv4 objects will be shorted than 4,
 // containing all the sent and received DHCPv4 messages.
-func (c *Client) ExchangeWithOptions(ifname string, discover *DHCPv4, options *ClientExchangeOptions, modifiers ...Modifier) ([]*DHCPv4, error) {
+func (c *Client) Exchange(ifname string, discover *DHCPv4, modifiers ...Modifier) ([]*DHCPv4, error) {
 	conversation := make([]*DHCPv4, 0)
 	var err error
 
 	// Get our file descriptor for the raw socket we need.
 	var sfd int
-	if options.UnicastSocket {
+	// TODO: we should check the IP is actually not a broadcast address for the
+	// subnet here.
+	if c.RemoteAddr != nil {
 		sfd, err = MakeUnicastSocket(ifname)
 	} else {
 		sfd, err = MakeBroadcastSocket(ifname)

--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -149,6 +149,9 @@ func toUDPAddr(addr net.Addr, defaultAddr *net.UDPAddr) (*net.UDPAddr, error) {
 			return nil, fmt.Errorf("could not convert to net.UDPAddr, got %v instead", reflect.TypeOf(addr))
 		}
 	}
+	if uaddr.IP.To4() == nil {
+		return nil, fmt.Errorf("'%s' is not a valid IPv4 address", uaddr.IP)
+	}
 	return uaddr, nil
 }
 

--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -321,6 +321,7 @@ func (c *Client) sendReceive(sendFd, recvFd int, packet *DHCPv4, messageType Mes
 // response up to some read timeout value. If the message type is not
 // MessageTypeNone, it will wait for a specific message type
 func BroadcastSendReceive(sendFd, recvFd int, packet *DHCPv4, readTimeout, writeTimeout time.Duration, messageType MessageType) (*DHCPv4, error) {
+	log.Printf("Warning: dhcpv4.BroadcastSendAndReceive() is deprecated and will be removed. You should use dhcpv4.client.Exchange() instead.")
 	packetBytes, err := MakeRawBroadcastPacket(packet.ToBytes())
 	if err != nil {
 		return nil, err

--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 	"fmt"
 	"reflect"
+	"log"
 
 	"golang.org/x/net/ipv4"
 	"golang.org/x/sys/unix"

--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -43,7 +43,7 @@ type ClientExchangeOptions struct {
 type Client struct {
 	ReadTimeout, WriteTimeout time.Duration
 	RemoteAddr   *net.UDPAddr
-	LocalAddr 	 *net.UDPAddr
+	LocalAddr    *net.UDPAddr
 }
 
 // NewClient generates a new client to perform a DHCP exchange with, setting the
@@ -92,7 +92,7 @@ func MakeRawPacket(payload []byte, serverAddr, clientAddr *net.UDPAddr) ([]byte,
 
 // MakeRawSocket creates a socket that can be passed to unix.Sendto.
 func MakeRawSocket() (int, error) {
-	d, err := unix.Socket(unix.AF_INET, unix.SOCK_RAW, unix.IPPROTO_RAW)
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_RAW, unix.IPPROTO_RAW)
 	if err != nil {
 		return fd, err
 	}

--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -219,7 +219,7 @@ func (c *Client) Exchange(ifname string, discover *DHCPv4, modifiers ...Modifier
 	conversation = append(conversation, discover)
 
 	// Offer
-	offer, err := c.SendReceive(sfd, rfd, discover, MessageTypeOffer)
+	offer, err := c.sendReceive(sfd, rfd, discover, MessageTypeOffer)
 	if err != nil {
 		return conversation, err
 	}
@@ -233,7 +233,7 @@ func (c *Client) Exchange(ifname string, discover *DHCPv4, modifiers ...Modifier
 	conversation = append(conversation, request)
 
 	// Ack
-	ack, err := c.SendReceive(sfd, rfd, request, MessageTypeAck)
+	ack, err := c.sendReceive(sfd, rfd, request, MessageTypeAck)
 	if err != nil {
 		return conversation, err
 	}
@@ -244,7 +244,7 @@ func (c *Client) Exchange(ifname string, discover *DHCPv4, modifiers ...Modifier
 // SendReceive sends a packet (with some write timeout) and waits for a
 // response up to some read timeout value. If the message type is not
 // MessageTypeNone, it will wait for a specific message type
-func (c *Client) SendReceive(sendFd, recvFd int, packet *DHCPv4, messageType MessageType) (*DHCPv4, error) {
+func (c *Client) sendReceive(sendFd, recvFd int, packet *DHCPv4, messageType MessageType) (*DHCPv4, error) {
 	raddr, laddr, err := c.getAddresses()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The current DHCPv4 client does not have the ability to specify remote/local addresses/ports. This small patch adds that.

`BroadcastSendReceive()` and `MakeRawBroadcastPacket()` are not used anymore, I did not remove them (since they're public) for backward compatibility.