### PR TITLE
Added String methods for types

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -327,11 +327,7 @@ func (d *DHCPv4) HwType() iana.HwTypeType {
 // HwTypeToString returns the mnemonic name for the hardware type, e.g.
 // "Ethernet". If the type is unknown, it returns "Unknown".
 func (d *DHCPv4) HwTypeToString() string {
-	hwtype, ok := iana.HwTypeToString[d.hwType]
-	if !ok {
-		hwtype = "Invalid"
-	}
-	return hwtype
+	return d.hwType.String()
 }
 
 // SetHwType returns the hardware type as defined by IANA.

--- a/dhcpv4/option_archtype.go
+++ b/dhcpv4/option_archtype.go
@@ -42,8 +42,7 @@ func (o *OptClientArchType) Length() int {
 func (o *OptClientArchType) String() string {
 	var archTypes string
 	for idx, at := range o.ArchTypes {
-		name := iana.ArchTypeToString(at)
-		archTypes += name
+		archTypes += at.String()
 		if idx < len(o.ArchTypes)-1 {
 			archTypes += ", "
 		}

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -252,7 +252,7 @@ func (d *DHCPv6Message) SetMessage(messageType MessageType) {
 }
 
 func (d *DHCPv6Message) MessageTypeToString() string {
-	return MessageTypeToString(d.messageType)
+	return d.messageType.String()
 }
 
 func (d *DHCPv6Message) TransactionID() uint32 {

--- a/dhcpv6/dhcpv6relay.go
+++ b/dhcpv6/dhcpv6relay.go
@@ -3,7 +3,6 @@ package dhcpv6
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net"
 )
 
@@ -22,7 +21,7 @@ func (r *DHCPv6Relay) Type() MessageType {
 }
 
 func (r *DHCPv6Relay) MessageTypeToString() string {
-	return MessageTypeToString(r.messageType)
+	return r.messageType.String()
 }
 
 func (r *DHCPv6Relay) String() string {
@@ -61,11 +60,6 @@ func (r *DHCPv6Relay) ToBytes() []byte {
 	}
 
 	return ret
-}
-
-func (r *DHCPv6Relay) MessageType() MessageType {
-	log.Printf("Warning: DHCPv6Relay.MessageType() is deprecated and will be removed, use DHCPv6Relay.Type() instead")
-	return r.messageType
 }
 
 func (r *DHCPv6Relay) SetMessageType(messageType MessageType) {

--- a/dhcpv6/duid.go
+++ b/dhcpv6/duid.go
@@ -26,11 +26,10 @@ var DuidTypeToString = map[DuidType]string{
 }
 
 func (d DuidType) String() string {
-	dtype := DuidTypeToString[d]
-	if dtype == "" {
-		dtype = "Unknown"
+	if dtype, ok := DuidTypeToString[d]; ok {
+		return dtype
 	}
-	return dtype
+	return "Unknown"
 }
 
 type Duid struct {

--- a/dhcpv6/duid.go
+++ b/dhcpv6/duid.go
@@ -25,6 +25,14 @@ var DuidTypeToString = map[DuidType]string{
 	DUID_UUID: "DUID-UUID",
 }
 
+func (d DuidType) String() string {
+	dtype := DuidTypeToString[d]
+	if dtype == "" {
+		dtype = "Unknown"
+	}
+	return dtype
+}
+
 type Duid struct {
 	Type                 DuidType
 	HwType               iana.HwTypeType // for DUID-LLT and DUID-LL. Ignored otherwise. RFC 826
@@ -79,14 +87,6 @@ func (d *Duid) ToBytes() []byte {
 }
 
 func (d *Duid) String() string {
-	dtype := DuidTypeToString[d.Type]
-	if dtype == "" {
-		dtype = "Unknown"
-	}
-	hwtype := iana.HwTypeToString[d.HwType]
-	if hwtype == "" {
-		hwtype = "Unknown"
-	}
 	var hwaddr string
 	if d.HwType == iana.HwTypeEthernet {
 		for _, b := range d.LinkLayerAddr {
@@ -96,7 +96,7 @@ func (d *Duid) String() string {
 			hwaddr = hwaddr[:len(hwaddr)-1]
 		}
 	}
-	return fmt.Sprintf("DUID{type=%v hwtype=%v hwaddr=%v}", dtype, hwtype, hwaddr)
+	return fmt.Sprintf("DUID{type=%v hwtype=%v hwaddr=%v}", d.Type.String(), d.HwType.String(), hwaddr)
 }
 
 func DuidFromBytes(data []byte) (*Duid, error) {

--- a/dhcpv6/option_archtype.go
+++ b/dhcpv6/option_archtype.go
@@ -39,8 +39,7 @@ func (op *OptClientArchType) Length() int {
 func (op *OptClientArchType) String() string {
 	atStrings := make([]string, 0)
 	for _, at := range op.ArchTypes {
-		name := iana.ArchTypeToString(at)
-		atStrings = append(atStrings, name)
+		atStrings = append(atStrings, at.String())
 	}
 	return fmt.Sprintf("OptClientArchType{archtype=%v}", strings.Join(atStrings, ", "))
 }

--- a/dhcpv6/option_statuscode.go
+++ b/dhcpv6/option_statuscode.go
@@ -38,7 +38,7 @@ func (op *OptStatusCode) Length() int {
 
 func (op *OptStatusCode) String() string {
 	return fmt.Sprintf("OptStatusCode{code=%s (%d), message=%v}",
-		iana.StatusCodeToString(op.StatusCode), op.StatusCode,
+		op.StatusCode.String(), op.StatusCode,
 		string(op.StatusMessage))
 }
 

--- a/dhcpv6/types.go
+++ b/dhcpv6/types.go
@@ -1,9 +1,5 @@
 package dhcpv6
 
-import (
-	"log"
-)
-
 // from http://www.networksorcery.com/enp/protocol/dhcpv6.htm
 
 // MessageType represents the kind of DHCPv6 message.
@@ -37,13 +33,6 @@ func (m MessageType) String() string {
 		return s
 	}
 	return "Unknown"
-}
-
-// MessageTypeToString converts a MessageType to a human-readable string
-// representation.
-func MessageTypeToString(t MessageType) string {
-	log.Printf("Warning: MessageTypeToString is deprecated and will be removed, use MessageType.String() instead")
-	return t.String()
 }
 
 // MessageTypeToStringMap contains the mapping of MessageTypes to human-readable

--- a/iana/archtype.go
+++ b/iana/archtype.go
@@ -32,8 +32,8 @@ var ArchTypeToStringMap = map[ArchType]string{
 }
 
 
-// ArchTypeToString returns a mnemonic name for a given architecture type
-func ArchTypeToString(a ArchType) string {
+// String returns a mnemonic name for a given architecture type
+func (a ArchType) String() string {
 	if at := ArchTypeToStringMap[a]; at != "" {
 		return at
 	}

--- a/iana/hwtypes.go
+++ b/iana/hwtypes.go
@@ -78,3 +78,11 @@ var HwTypeToString = map[HwTypeType]string{
 	HwTypeWiegandInterface:     "Wiegand Interface",
 	HwTypePureIP:               "Pure IP",
 }
+
+func (h HwTypeType) String() string {
+	hwtype := HwTypeToString[h]
+	if hwtype == "" {
+		hwtype = "Invalid"
+	}
+	return hwtype
+}

--- a/iana/statuscodes.go
+++ b/iana/statuscodes.go
@@ -38,8 +38,8 @@ const (
 	StatusExcessiveTimeSkew          StatusCode = 22
 )
 
-// StatusCodeToString returns a mnemonic name for a given status code
-func StatusCodeToString(s StatusCode) string {
+// String returns a mnemonic name for a given status code
+func (s StatusCode) String() string {
 	if sc := StatusCodeToStringMap[s]; sc != "" {
 		return sc
 	}


### PR DESCRIPTION
Added string method for:
* DuidType
* ArchType
* HwTypeType

This makes it more consistent with PR #140.

Also remove deprecated method MessageType() and function MessageTypeToString().