### PR TITLE
OptIAForPrefixDelegation: make fields public

### DIFF
--- a/dhcpv6/option_prefixdelegation.go
+++ b/dhcpv6/option_prefixdelegation.go
@@ -38,6 +38,7 @@ func (op *OptIAForPrefixDelegation) ToBytes() []byte {
 func (op *OptIAForPrefixDelegation) T1() uint32 {
 	return op.t1
 }
+
 // SetT1 sets the T1 timer for this option
 func (op *OptIAForPrefixDelegation) SetT1(t1 uint32) {
 	op.t1 = t1
@@ -47,6 +48,7 @@ func (op *OptIAForPrefixDelegation) SetT1(t1 uint32) {
 func (op *OptIAForPrefixDelegation) T2() uint32 {
 	return op.t2
 }
+
 // SetT2 sets the T2 timer for this option
 func (op *OptIAForPrefixDelegation) SetT2(t2 uint32) {
 	op.t2 = t2

--- a/dhcpv6/option_prefixdelegation.go
+++ b/dhcpv6/option_prefixdelegation.go
@@ -10,8 +10,8 @@ import (
 
 type OptIAForPrefixDelegation struct {
 	IaId    [4]byte
-	T1      uint32
-	T2      uint32
+	t1      uint32
+	t2      uint32
 	Options []Option
 }
 
@@ -26,12 +26,30 @@ func (op *OptIAForPrefixDelegation) ToBytes() []byte {
 	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionIAPD))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	copy(buf[4:8], op.IaId[:])
-	binary.BigEndian.PutUint32(buf[8:12], op.T1)
-	binary.BigEndian.PutUint32(buf[12:16], op.T2)
+	binary.BigEndian.PutUint32(buf[8:12], op.t1)
+	binary.BigEndian.PutUint32(buf[12:16], op.t2)
 	for _, opt := range op.Options {
 		buf = append(buf, opt.ToBytes()...)
 	}
 	return buf
+}
+
+// T1 returns the T1 timer for this option
+func (op *OptIAForPrefixDelegation) T1() uint32 {
+	return op.t1
+}
+// SetT1 sets the T1 timer for this option
+func (op *OptIAForPrefixDelegation) SetT1(t1 uint32) {
+	op.t1 = t1
+}
+
+// T2 returns the T2 timer for this option
+func (op *OptIAForPrefixDelegation) T2() uint32 {
+	return op.t2
+}
+// SetT2 sets the T2 timer for this option
+func (op *OptIAForPrefixDelegation) SetT2(t2 uint32) {
+	op.t2 = t2
 }
 
 // Length returns the option length
@@ -46,7 +64,7 @@ func (op *OptIAForPrefixDelegation) Length() int {
 // String returns a string representation of the OptIAForPrefixDelegation data
 func (op *OptIAForPrefixDelegation) String() string {
 	return fmt.Sprintf("OptIAForPrefixDelegation{IAID=%v, t1=%v, t2=%v, options=%v}",
-		op.IaId, op.T1, op.T2, op.Options)
+		op.IaId, op.t1, op.t2, op.Options)
 }
 
 // GetOneOption will get an option of the give type from the Options field, if
@@ -69,8 +87,8 @@ func ParseOptIAForPrefixDelegation(data []byte) (*OptIAForPrefixDelegation, erro
 		return nil, fmt.Errorf("Invalid IA for Prefix Delegation data length. Expected at least 12 bytes, got %v", len(data))
 	}
 	copy(opt.IaId[:], data[:4])
-	opt.T1 = binary.BigEndian.Uint32(data[4:8])
-	opt.T2 = binary.BigEndian.Uint32(data[8:12])
+	opt.t1 = binary.BigEndian.Uint32(data[4:8])
+	opt.t2 = binary.BigEndian.Uint32(data[8:12])
 	opt.Options, err = OptionsFromBytes(data[12:])
 	if err != nil {
 		return nil, err

--- a/dhcpv6/option_prefixdelegation.go
+++ b/dhcpv6/option_prefixdelegation.go
@@ -10,8 +10,8 @@ import (
 
 type OptIAForPrefixDelegation struct {
 	IaId    [4]byte
-	t1      uint32
-	t2      uint32
+	T1      uint32
+	T2      uint32
 	Options []Option
 }
 
@@ -26,32 +26,12 @@ func (op *OptIAForPrefixDelegation) ToBytes() []byte {
 	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionIAPD))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
 	copy(buf[4:8], op.IaId[:])
-	binary.BigEndian.PutUint32(buf[8:12], op.t1)
-	binary.BigEndian.PutUint32(buf[12:16], op.t2)
+	binary.BigEndian.PutUint32(buf[8:12], op.T1)
+	binary.BigEndian.PutUint32(buf[12:16], op.T2)
 	for _, opt := range op.Options {
 		buf = append(buf, opt.ToBytes()...)
 	}
 	return buf
-}
-
-// T1 returns the T1 timer for this option
-func (op *OptIAForPrefixDelegation) T1() uint32 {
-	return op.t1
-}
-
-// SetT1 sets the T1 timer for this option
-func (op *OptIAForPrefixDelegation) SetT1(t1 uint32) {
-	op.t1 = t1
-}
-
-// T2 returns the T2 timer for this option
-func (op *OptIAForPrefixDelegation) T2() uint32 {
-	return op.t2
-}
-
-// SetT2 sets the T2 timer for this option
-func (op *OptIAForPrefixDelegation) SetT2(t2 uint32) {
-	op.t2 = t2
 }
 
 // Length returns the option length
@@ -66,7 +46,7 @@ func (op *OptIAForPrefixDelegation) Length() int {
 // String returns a string representation of the OptIAForPrefixDelegation data
 func (op *OptIAForPrefixDelegation) String() string {
 	return fmt.Sprintf("OptIAForPrefixDelegation{IAID=%v, t1=%v, t2=%v, options=%v}",
-		op.IaId, op.t1, op.t2, op.Options)
+		op.IaId, op.T1, op.T2, op.Options)
 }
 
 // GetOneOption will get an option of the give type from the Options field, if
@@ -89,8 +69,8 @@ func ParseOptIAForPrefixDelegation(data []byte) (*OptIAForPrefixDelegation, erro
 		return nil, fmt.Errorf("Invalid IA for Prefix Delegation data length. Expected at least 12 bytes, got %v", len(data))
 	}
 	copy(opt.IaId[:], data[:4])
-	opt.t1 = binary.BigEndian.Uint32(data[4:8])
-	opt.t2 = binary.BigEndian.Uint32(data[8:12])
+	opt.T1 = binary.BigEndian.Uint32(data[4:8])
+	opt.T2 = binary.BigEndian.Uint32(data[8:12])
 	opt.Options, err = OptionsFromBytes(data[12:])
 	if err != nil {
 		return nil, err

--- a/dhcpv6/option_prefixdelegation.go
+++ b/dhcpv6/option_prefixdelegation.go
@@ -6,14 +6,13 @@ package dhcpv6
 import (
 	"encoding/binary"
 	"fmt"
-	"log"
 )
 
 type OptIAForPrefixDelegation struct {
-	iaId    [4]byte
-	t1      uint32
-	t2      uint32
-	options []Option
+	IaId    [4]byte
+	T1      uint32
+	T2      uint32
+	Options []Option
 }
 
 // Code returns the option code
@@ -26,66 +25,19 @@ func (op *OptIAForPrefixDelegation) ToBytes() []byte {
 	buf := make([]byte, 16)
 	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionIAPD))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
-	copy(buf[4:8], op.iaId[:])
-	binary.BigEndian.PutUint32(buf[8:12], op.t1)
-	binary.BigEndian.PutUint32(buf[12:16], op.t2)
-	for _, opt := range op.options {
+	copy(buf[4:8], op.IaId[:])
+	binary.BigEndian.PutUint32(buf[8:12], op.T1)
+	binary.BigEndian.PutUint32(buf[12:16], op.T2)
+	for _, opt := range op.Options {
 		buf = append(buf, opt.ToBytes()...)
 	}
 	return buf
 }
 
-// IAID returns the identity association identifier for this option
-func (op *OptIAForPrefixDelegation) IAID() []byte {
-	return op.iaId[:]
-}
-
-// SetIAID sets the identity association identifier for this option
-func (op *OptIAForPrefixDelegation) SetIAID(iaId [4]byte) {
-	op.iaId = iaId
-}
-
-// T1 returns the T1 timer for this option
-func (op *OptIAForPrefixDelegation) T1() uint32 {
-	return op.t1
-}
-
-// SetT1 sets the T1 timer for this option
-func (op *OptIAForPrefixDelegation) SetT1(t1 uint32) {
-	op.t1 = t1
-}
-
-// T2 returns the T2 timer for this option
-func (op *OptIAForPrefixDelegation) T2() uint32 {
-	return op.t2
-}
-
-// SetT2 sets the T2 timer for this option
-func (op *OptIAForPrefixDelegation) SetT2(t2 uint32) {
-	op.t2 = t2
-}
-
-// Options serializes the options and returns them as a sequence of bytes
-func (op *OptIAForPrefixDelegation) Options() []byte {
-	log.Printf("Warning: OptIAForPrefixDelegation.Options() is deprecated and will be changed to a public field")
-	buf := op.ToBytes()
-	return buf[16:]
-}
-
-// SetOptions sets the options as a sequence of bytes
-func (op *OptIAForPrefixDelegation) SetOptions(options []byte) error {
-	var err error
-	op.options, err = OptionsFromBytes(options)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // Length returns the option length
 func (op *OptIAForPrefixDelegation) Length() int {
 	l := 12
-	for _, opt := range op.options {
+	for _, opt := range op.Options {
 		l += 4 + opt.Length()
 	}
 	return l
@@ -94,18 +46,18 @@ func (op *OptIAForPrefixDelegation) Length() int {
 // String returns a string representation of the OptIAForPrefixDelegation data
 func (op *OptIAForPrefixDelegation) String() string {
 	return fmt.Sprintf("OptIAForPrefixDelegation{IAID=%v, t1=%v, t2=%v, options=%v}",
-		op.iaId, op.t1, op.t2, op.options)
+		op.IaId, op.T1, op.T2, op.Options)
 }
 
 // GetOneOption will get an option of the give type from the Options field, if
 // it is present. It will return `nil` otherwise
 func (op *OptIAForPrefixDelegation) GetOneOption(code OptionCode) Option {
-	return getOption(op.options, code)
+	return getOption(op.Options, code)
 }
 
 // DelOption will remove all the options that match a Option code.
 func (op *OptIAForPrefixDelegation) DelOption(code OptionCode) {
-	op.options = delOption(op.options, code)
+	op.Options = delOption(op.Options, code)
 }
 
 // build an OptIAForPrefixDelegation structure from a sequence of bytes.
@@ -116,10 +68,10 @@ func ParseOptIAForPrefixDelegation(data []byte) (*OptIAForPrefixDelegation, erro
 	if len(data) < 12 {
 		return nil, fmt.Errorf("Invalid IA for Prefix Delegation data length. Expected at least 12 bytes, got %v", len(data))
 	}
-	copy(opt.iaId[:], data[:4])
-	opt.t1 = binary.BigEndian.Uint32(data[4:8])
-	opt.t2 = binary.BigEndian.Uint32(data[8:12])
-	opt.options, err = OptionsFromBytes(data[12:])
+	copy(opt.IaId[:], data[:4])
+	opt.T1 = binary.BigEndian.Uint32(data[4:8])
+	opt.T2 = binary.BigEndian.Uint32(data[8:12])
+	opt.Options, err = OptionsFromBytes(data[12:])
 	if err != nil {
 		return nil, err
 	}

--- a/dhcpv6/option_prefixdelegation_test.go
+++ b/dhcpv6/option_prefixdelegation_test.go
@@ -22,8 +22,8 @@ func TestOptIAForPrefixDelegationParseOptIAForPrefixDelegation(t *testing.T) {
 	require.Equal(t, len(data), opt.Length())
 	require.Equal(t, OptionIAPD, opt.Code())
 	require.Equal(t, [4]byte{1, 0, 0, 0}, opt.IaId)
-	require.Equal(t, uint32(1), opt.T1())
-	require.Equal(t, uint32(2), opt.T2())
+	require.Equal(t, uint32(1), opt.T1)
+	require.Equal(t, uint32(2), opt.T2)
 }
 
 func TestOptIAForPrefixDelegationParseOptIAForPrefixDelegationInvalidLength(t *testing.T) {
@@ -113,8 +113,8 @@ func TestOptIAForPrefixDelegationToBytes(t *testing.T) {
 
 	opt := OptIAForPrefixDelegation{}
 	opt.IaId = [4]byte{1, 2, 3, 4}
-	opt.SetT1(12345)
-	opt.SetT2(54321)
+	opt.T1 = 12345
+	opt.T2 = 54321
 	opt.Options = append(opt.Options, &oaddr)
 
 	expected := []byte{

--- a/dhcpv6/option_prefixdelegation_test.go
+++ b/dhcpv6/option_prefixdelegation_test.go
@@ -22,8 +22,8 @@ func TestOptIAForPrefixDelegationParseOptIAForPrefixDelegation(t *testing.T) {
 	require.Equal(t, len(data), opt.Length())
 	require.Equal(t, OptionIAPD, opt.Code())
 	require.Equal(t, [4]byte{1, 0, 0, 0}, opt.IaId)
-	require.Equal(t, uint32(1), opt.T1)
-	require.Equal(t, uint32(2), opt.T2)
+	require.Equal(t, uint32(1), opt.T1())
+	require.Equal(t, uint32(2), opt.T2())
 }
 
 func TestOptIAForPrefixDelegationParseOptIAForPrefixDelegationInvalidLength(t *testing.T) {
@@ -113,8 +113,8 @@ func TestOptIAForPrefixDelegationToBytes(t *testing.T) {
 
 	opt := OptIAForPrefixDelegation{}
 	opt.IaId = [4]byte{1, 2, 3, 4}
-	opt.T1 = 12345
-	opt.T2 = 54321
+	opt.SetT1(12345)
+	opt.SetT2(54321)
 	opt.Options = append(opt.Options, &oaddr)
 
 	expected := []byte{


### PR DESCRIPTION
Make the fields of OptIAForPrefixDelegation public. This will make it more consistent with what was done for OptIANA in: https://github.com/insomniacslk/dhcp/commit/bdb0bf25259985b962e230fbac5265a7623afd05

It was not possible to do it in PR #166 because at that point it was going to break router7.

However, this was fixed in https://github.com/rtr7/router7/pull/9.

cc @davebarrau 
