### PR TITLE
simplify client interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ func main() {
 	// A default Solicit packet will be used during the "conversation",
 	// which can be manipulated by using modifiers.
 	conversation, err := client.Exchange("eth0")
-	
+
 	// Summary() prints a verbose representation of the exchanged packets.
 	for _, packet := range conversation {
 		log.Print(packet.Summary())

--- a/README.md
+++ b/README.md
@@ -59,10 +59,8 @@ func main() {
 	// return a non-empty packet list even if there is an error. This is
 	// intended, because the transaction may fail at any point, and we
 	// still want to know what packets were exchanged until then.
-	// The `nil` argument indicates that we want to use a default Solicit
-	// packet, instead of specifying a custom one ourselves.
-	conversation, err := client.Exchange("eth0", nil)
-
+	conversation, err := client.Exchange("eth0")
+	
 	// Summary() prints a verbose representation of the exchanged packets.
 	for _, packet := range conversation {
 		log.Print(packet.Summary())

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ func main() {
 	// return a non-empty packet list even if there is an error. This is
 	// intended, because the transaction may fail at any point, and we
 	// still want to know what packets were exchanged until then.
+	// A default Solicit packet will be used during the "conversation",
+	// which can be manipulated by using modifiers.
 	conversation, err := client.Exchange("eth0")
 	
 	// Summary() prints a verbose representation of the exchanged packets.

--- a/dhcpv4/bsdp/client.go
+++ b/dhcpv4/bsdp/client.go
@@ -34,7 +34,7 @@ func castVendorOpt(ack *dhcpv4.DHCPv4) {
 
 // Exchange runs a full BSDP exchange (Inform[list], Ack, Inform[select],
 // Ack). Returns a list of DHCPv4 structures representing the exchange.
-func (c *Client) Exchange(ifname string, informList *dhcpv4.DHCPv4) ([]*dhcpv4.DHCPv4, error) {
+func (c *Client) Exchange(ifname string) ([]*dhcpv4.DHCPv4, error) {
 	conversation := make([]*dhcpv4.DHCPv4, 0)
 
 	// Get our file descriptor for the broadcast socket.
@@ -48,11 +48,9 @@ func (c *Client) Exchange(ifname string, informList *dhcpv4.DHCPv4) ([]*dhcpv4.D
 	}
 
 	// INFORM[LIST]
-	if informList == nil {
-		informList, err = NewInformListForInterface(ifname, dhcpv4.ClientPort)
-		if err != nil {
-			return conversation, err
-		}
+	informList, err := NewInformListForInterface(ifname, dhcpv4.ClientPort)
+	if err != nil {
+		return conversation, err
 	}
 	conversation = append(conversation, informList)
 

--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -179,7 +179,7 @@ func (c *Client) getRemoteUDPAddr() (*net.UDPAddr, error) {
 // ordered as Discovery, Offer, Request and Acknowledge. In case of errors, an
 // error is returned, and the list of DHCPv4 objects will be shorted than 4,
 // containing all the sent and received DHCPv4 messages.
-func (c *Client) Exchange(ifname string, discover *DHCPv4, modifiers ...Modifier) ([]*DHCPv4, error) {
+func (c *Client) Exchange(ifname string, modifiers ...Modifier) ([]*DHCPv4, error) {
 	conversation := make([]*DHCPv4, 0)
 	raddr, err := c.getRemoteUDPAddr()
 	if err != nil {
@@ -220,11 +220,9 @@ func (c *Client) Exchange(ifname string, discover *DHCPv4, modifiers ...Modifier
 	}()
 
 	// Discover
-	if discover == nil {
-		discover, err = NewDiscoveryForInterface(ifname)
-		if err != nil {
-			return conversation, err
-		}
+	discover, err := NewDiscoveryForInterface(ifname)
+	if err != nil {
+		return conversation, err
 	}
 	for _, mod := range modifiers {
 		discover = mod(discover)

--- a/dhcpv4/server_test.go
+++ b/dhcpv4/server_test.go
@@ -136,7 +136,7 @@ func TestServerActivateAndServe(t *testing.T) {
 		WithHwAddr(hwaddr[:]),
 	}
 
-	conv, err := c.Exchange(lo, nil, modifiers...)
+	conv, err := c.Exchange(lo, modifiers...)
 	require.NoError(t, err)
 	require.Equal(t, 4, len(conv))
 	for _, p := range conv {

--- a/dhcpv6/client.go
+++ b/dhcpv6/client.go
@@ -185,7 +185,7 @@ func (c *Client) sendReceive(ifname string, packet DHCPv6, expectedType MessageT
 	return adv, nil
 }
 
-// Solicit sends a Solicit, return the Solicit, an Advertise (if not nil), and
+// Solicit sends a Solicit, returns the Solicit, an Advertise (if not nil), and
 // an error if any. The modifiers will be applied to the Solicit before sending
 // it, see modifiers.go
 func (c *Client) Solicit(ifname string, modifiers ...Modifier) (DHCPv6, DHCPv6, error) {

--- a/dhcpv6/client.go
+++ b/dhcpv6/client.go
@@ -37,15 +37,19 @@ func NewClient() *Client {
 	}
 }
 
-// Exchange executes a 4-way DHCPv6 request (SOLICIT, ADVERTISE, REQUEST,
-// REPLY).
+// Exchange executes a 4-way DHCPv6 request (Solicit, Advertise, Request,
+// Reply). The modifiers will be applied to the Solicit and Request packets.
+// A common use is to make sure that the Solicit packet has the right options,
+// see modifiers.go
 func (c *Client) Exchange(ifname string, modifiers ...Modifier) ([]DHCPv6, error) {
 	conversation := make([]DHCPv6, 0)
 	var err error
 
 	// Solicit
 	solicit, advertise, err := c.Solicit(ifname, modifiers...)
-	conversation = append(conversation, solicit)
+	if solicit != nil {
+		conversation = append(conversation, solicit)
+	}
 	if err != nil {
 		return conversation, err
 	}
@@ -181,8 +185,9 @@ func (c *Client) sendReceive(ifname string, packet DHCPv6, expectedType MessageT
 	return adv, nil
 }
 
-// Solicit sends a SOLICIT, return the solicit, an ADVERTISE (if not nil), and
-// an error if any
+// Solicit sends a Solicit, return the Solicit, an Advertise (if not nil), and
+// an error if any. The modifiers will be applied to the Solicit before sending
+// it, see modifiers.go
 func (c *Client) Solicit(ifname string, modifiers ...Modifier) (DHCPv6, DHCPv6, error) {
 	solicit, err := NewSolicitForInterface(ifname)
 	if err != nil {
@@ -195,8 +200,9 @@ func (c *Client) Solicit(ifname string, modifiers ...Modifier) (DHCPv6, DHCPv6, 
 	return solicit, advertise, err
 }
 
-// Request sends a REQUEST built from an ADVERTISE.
-// It returns the request, a reply if not nil, and an error if any
+// Request sends a Request built from an Advertise. It returns the Request, a
+// Reply (if not nil), and an error if any. The modifiers will be applied to
+// the Request before sending it, see modifiers.go
 func (c *Client) Request(ifname string, advertise DHCPv6, modifiers ...Modifier) (DHCPv6, DHCPv6, error) {
 	request, err := NewRequestFromAdvertise(advertise)
 	if err != nil {

--- a/dhcpv6/server_test.go
+++ b/dhcpv6/server_test.go
@@ -88,6 +88,6 @@ func TestServerActivateAndServe(t *testing.T) {
 	iface, err := getLoopbackInterface()
 	require.NoError(t, err)
 
-	_, _, err = c.Solicit(iface, nil)
+	_, _, err = c.Solicit(iface)
 	require.NoError(t, err)
 }

--- a/netboot/netboot.go
+++ b/netboot/netboot.go
@@ -59,7 +59,7 @@ func RequestNetbootv4(ifname string, timeout time.Duration, retries int, modifie
 		log.Printf("sending request, attempt #%d", i+1)
 		client := dhcpv4.NewClient()
 		client.ReadTimeout = timeout
-		conversation, err = client.Exchange(ifname, nil, modifiers...)
+		conversation, err = client.Exchange(ifname, modifiers...)
 		if err != nil {
 			log.Printf("Client.Exchange failed: %v", err)
 			log.Printf("sleeping %v before retrying", delay)

--- a/netboot/netboot.go
+++ b/netboot/netboot.go
@@ -19,21 +19,18 @@ var sleeper = func(d time.Duration) {
 func RequestNetbootv6(ifname string, timeout time.Duration, retries int, modifiers ...dhcpv6.Modifier) ([]dhcpv6.DHCPv6, error) {
 	var (
 		conversation []dhcpv6.DHCPv6
+		err error
 	)
 	delay := 2 * time.Second
 	for i := 0; i <= retries; i++ {
 		log.Printf("sending request, attempt #%d", i+1)
-		solicit, err := dhcpv6.NewSolicitForInterface(ifname, modifiers...)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create SOLICIT for interface %s: %v", ifname, err)
-		}
 
 		client := dhcpv6.NewClient()
 		client.ReadTimeout = timeout
 		// WithNetboot is added only later, to avoid applying it twice (one
 		// here and one in the above call to NewSolicitForInterface)
 		modifiers = append(modifiers, dhcpv6.WithNetboot)
-		conversation, err = client.Exchange(ifname, solicit, modifiers...)
+		conversation, err = client.Exchange(ifname, modifiers...)
 		if err != nil {
 			log.Printf("Client.Exchange failed: %v", err)
 			log.Printf("sleeping %v before retrying", delay)

--- a/netboot/netboot.go
+++ b/netboot/netboot.go
@@ -21,15 +21,13 @@ func RequestNetbootv6(ifname string, timeout time.Duration, retries int, modifie
 		conversation []dhcpv6.DHCPv6
 		err error
 	)
+	modifiers = append(modifiers, dhcpv6.WithNetboot)
 	delay := 2 * time.Second
 	for i := 0; i <= retries; i++ {
 		log.Printf("sending request, attempt #%d", i+1)
 
 		client := dhcpv6.NewClient()
 		client.ReadTimeout = timeout
-		// WithNetboot is added only later, to avoid applying it twice (one
-		// here and one in the above call to NewSolicitForInterface)
-		modifiers = append(modifiers, dhcpv6.WithNetboot)
 		conversation, err = client.Exchange(ifname, modifiers...)
 		if err != nil {
 			log.Printf("Client.Exchange failed: %v", err)


### PR DESCRIPTION
All calls to Exchange(), Solicit() and Request() that I have seen are passing a nil packet.

I think it would be a good idea to simplify this by not passing the packet we want to send and always creating a new one.

The modifiers can completely modify the created packet if needed.