### PR TITLE
Add netboot/netconf support for DHCPv4

### DIFF
--- a/netboot/netboot.go
+++ b/netboot/netboot.go
@@ -10,6 +10,10 @@ import (
 	"github.com/insomniacslk/dhcp/dhcpv6"
 )
 
+var sleeper = func(d time.Duration) {
+	time.Sleep(d)
+}
+
 // RequestNetbootv6 sends a netboot request via DHCPv6 and returns the exchanged packets. Additional modifiers
 // can be passed to manipulate both solicit and advertise packets.
 func RequestNetbootv6(ifname string, timeout time.Duration, retries int, modifiers ...dhcpv6.Modifier) ([]dhcpv6.DHCPv6, error) {
@@ -37,7 +41,7 @@ func RequestNetbootv6(ifname string, timeout time.Duration, retries int, modifie
 				// don't wait at the end of the last attempt
 				break
 			}
-			time.Sleep(delay)
+			sleeper(delay)
 			// TODO add random splay
 			delay = delay * 2
 			continue
@@ -68,7 +72,7 @@ func RequestNetbootv4(ifname string, timeout time.Duration, retries int, modifie
 				// don't wait at the end of the last attempt
 				break
 			}
-			time.Sleep(delay)
+			sleeper(delay)
 			// TODO add random splay
 			delay = delay * 2
 			continue

--- a/netboot/netboot.go
+++ b/netboot/netboot.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
 )
 
@@ -29,6 +30,37 @@ func RequestNetbootv6(ifname string, timeout time.Duration, retries int, modifie
 		// here and one in the above call to NewSolicitForInterface)
 		modifiers = append(modifiers, dhcpv6.WithNetboot)
 		conversation, err = client.Exchange(ifname, solicit, modifiers...)
+		if err != nil {
+			log.Printf("Client.Exchange failed: %v", err)
+			log.Printf("sleeping %v before retrying", delay)
+			if i >= retries {
+				// don't wait at the end of the last attempt
+				break
+			}
+			time.Sleep(delay)
+			// TODO add random splay
+			delay = delay * 2
+			continue
+		}
+		break
+	}
+	return conversation, nil
+}
+
+// RequestNetbootv4 sends a netboot request via DHCPv4 and returns the exchanged packets. Additional modifiers
+// can be passed to manipulate both the discover and offer packets.
+func RequestNetbootv4(ifname string, timeout time.Duration, retries int, modifiers ...dhcpv4.Modifier) ([]*dhcpv4.DHCPv4, error) {
+	var (
+		conversation []*dhcpv4.DHCPv4
+		err          error
+	)
+	delay := 2 * time.Second
+	for i := 0; i <= retries; i++ {
+		log.Printf("sending request, attempt #%d", i+1)
+		modifiers = append(modifiers, dhcpv4.WithNetboot)
+		client := dhcpv4.NewClient()
+		client.ReadTimeout = timeout
+		conversation, err = client.Exchange(ifname, nil, modifiers...)
 		if err != nil {
 			log.Printf("Client.Exchange failed: %v", err)
 			log.Printf("sleeping %v before retrying", delay)
@@ -94,4 +126,29 @@ func ConversationToNetconf(conversation []dhcpv6.DHCPv6) (*NetConf, string, erro
 		bootfile = string(obf.BootFileURL)
 	}
 	return netconf, bootfile, nil
+}
+
+// ConversationToNetconfv4 extracts network configuration and boot file URL from a
+// DHCPv4 4-way conversation and returns them, or an error if any.
+func ConversationToNetconfv4(conversation []*dhcpv4.DHCPv4) (*NetConf, string, error) {
+	var reply *dhcpv4.DHCPv4
+	var bootFileUrl string
+	for _, m := range conversation {
+		// look for a BootReply packet of type Offer containing the bootfile URL.
+		// Normally both packets with Message Type OFFER or ACK do contain
+		// the bootfile URL.
+		if m.Opcode() == dhcpv4.OpcodeBootReply && *m.MessageType() == dhcpv4.MessageTypeOffer {
+			bootFileUrl = m.BootFileNameToString()
+			reply = m
+			break
+		}
+	}
+	if reply == nil {
+		return nil, "", errors.New("no OFFER with valid bootfile URL received")
+	}
+	netconf, err := GetNetConfFromPacketv4(reply)
+	if err != nil {
+		return nil, "", fmt.Errorf("could not get netconf: %v", err)
+	}
+	return netconf, bootFileUrl, nil
 }

--- a/netboot/netboot.go
+++ b/netboot/netboot.go
@@ -55,9 +55,9 @@ func RequestNetbootv4(ifname string, timeout time.Duration, retries int, modifie
 		err          error
 	)
 	delay := 2 * time.Second
+	modifiers = append(modifiers, dhcpv4.WithNetboot)
 	for i := 0; i <= retries; i++ {
 		log.Printf("sending request, attempt #%d", i+1)
-		modifiers = append(modifiers, dhcpv4.WithNetboot)
 		client := dhcpv4.NewClient()
 		client.ReadTimeout = timeout
 		conversation, err = client.Exchange(ifname, nil, modifiers...)

--- a/netboot/netconf.go
+++ b/netboot/netconf.go
@@ -220,14 +220,13 @@ func ConfigureInterface(ifname string, netconf *NetConf) error {
 		return fmt.Errorf("could not write resolv.conf file %v", err)
 	}
 
-	iface, err = netlink.LinkByName(ifname)
-	if err != nil {
-		return fmt.Errorf("could not obtain interface when adding default route: %v", err)
-	}
-
 	// add default route information for v4 space. only one default route is allowed
 	// so ignore the others if there are multiple ones
 	if len(netconf.Routers) > 0 {
+		iface, err = netlink.LinkByName(ifname)
+		if err != nil {
+			return fmt.Errorf("could not obtain interface when adding default route: %v", err)
+		}
 		// if there is a default v4 route, remove it, as we want to add the one we just got during
 		// the dhcp transaction. if the route is not present, which is the final state we want,
 		// an error is returned so ignore it


### PR DESCRIPTION
Adds support for `RequestNetbootv4`. The main problem with this implementation is explained in issue #184. If a default route is not added before calling `RequestNetbootv4`, the transaction fails.

