### PR TITLE
[ztpv4] add Opt60 (vc) parsing

### DIFF
--- a/dhcpv4/ztp/ztp.go
+++ b/dhcpv4/ztp/ztp.go
@@ -1,0 +1,139 @@
+package ztpv4
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/insomniacslk/dhcp/dhcpv4"
+)
+
+// VendorData is optional data a particular vendor may or may not include
+// in the Vendor Class options.  All values are optional and will be zero
+// values if not found.
+type VendorData struct {
+	VendorName string
+	Model      string
+	Serial     string
+}
+
+var errVendorOptionMalformed = errors.New("malformed vendor option")
+
+// VendorDataV4 will try to parse dhcp4 options data looking for more specific
+// vendor data (like model, serial number, etc).  If the options are missing
+func VendorDataV4(packet *dhcpv4.DHCPv4) VendorData {
+	vd := VendorData{}
+
+	if err := parseV4VendorClass(&vd, packet); err != nil {
+		glog.Errorf("failed to parse vendor data from vendor class: %v", err)
+	}
+
+	if err := parseV4VIVC(&vd, packet); err != nil {
+		glog.Errorf("failed to parse vendor data from vendor-idenitifying vendor class: %v", err)
+	}
+
+	return vd
+}
+
+// parseV4Opt60 will attempt to look at the Vendor Class option (Option 60) on
+// DHCPv4.  The option is formatted as a string with the content being specific
+// for the vendor, usually using a deliminator to separate the values.
+// See: https://tools.ietf.org/html/rfc1533#section-9.11
+func parseV4VendorClass(vd *VendorData, packet *dhcpv4.DHCPv4) error {
+	opt := packet.GetOneOption(dhcpv4.OptionClassIdentifier)
+	if opt == nil {
+		return nil
+	}
+	vc := opt.(*dhcpv4.OptClassIdentifier).Identifier
+
+	switch {
+	// Arista;DCS-7050S-64;01.23;JPE12221671
+	case strings.HasPrefix(vc, "Arista;"):
+		p := strings.Split(vc, ";")
+		if len(p) < 4 {
+			return errVendorOptionMalformed
+		}
+
+		vd.VendorName = p[0]
+		vd.Model = p[1]
+		vd.Serial = p[3]
+		return nil
+
+	// ZPESystems:NSC:002251623
+	case strings.HasPrefix(vc, "ZPESystems:"):
+		p := strings.Split(vc, ":")
+		if len(p) < 3 {
+			return errVendorOptionMalformed
+		}
+
+		vd.VendorName = p[0]
+		vd.Model = p[1]
+		vd.Serial = p[2]
+		return nil
+
+	// Juniper option 60 parsing is a bit more nuanced.  The following are all
+	// "valid" indetifing stings for Juniper:
+	//    Juniper-ptx1000-DD576      <vendor>-<model>-<serial
+	//    Juniper-qfx10008           <vendor>-<model> (serial in hostname option)
+	//    Juniper-qfx10002-361-DN817 <vendor>-<model>-<serial> (model has a dash in it!)
+	case strings.HasPrefix(vc, "Juniper-"):
+		// strip of the prefix
+		vc := vc[len("Juniper-"):]
+		vd.VendorName = "Juniper"
+
+		sepIdx := strings.LastIndex(vc, "-")
+		if sepIdx == -1 {
+			// No separator was found. Attempt serial number from the hostname
+			if opt := packet.GetOneOption(dhcpv4.OptionHostName); opt != nil {
+				vd.Serial = opt.(*dhcpv4.OptHostName).HostName
+			}
+		} else {
+			vd.Serial = vc[sepIdx+1:]
+			vc = vc[:sepIdx]
+		}
+		vd.Model = vc
+
+		return nil
+	}
+
+	// We didn't match anything, just return an empty vendor data.
+	return nil
+}
+
+const entIDCiscoSystems = 0x9
+
+// parseV4Opt124 will attempt to read the Vendor-Identifying Vendor Class
+// (Option 124) on a DHCPv4 packet.  The data is represented in a length/value
+// format with an indentifying enterprise number.
+//
+// See: https://tools.ietf.org/html/rfc3925
+func parseV4VIVC(vd *VendorData, packet *dhcpv4.DHCPv4) error {
+	opt := packet.GetOneOption(dhcpv4.OptionVendorIdentifyingVendorClass)
+	if opt == nil {
+		return nil
+	}
+	ids := opt.(*dhcpv4.OptVIVC).Identifiers
+
+	for _, id := range ids {
+		if id.EntID == entIDCiscoSystems {
+			vd.VendorName = "Cisco Systems"
+
+			//SN:0;PID:R-IOSXRV9000-CC
+			for _, f := range bytes.Split(id.Data, []byte(";")) {
+				p := bytes.SplitN(f, []byte(":"), 2)
+				if len(p) != 2 {
+					return errVendorOptionMalformed
+				}
+
+				switch string(p[0]) {
+				case "SN":
+					vd.Serial = string(p[1])
+				case "PID":
+					vd.Model = string(p[1])
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/dhcpv4/ztp/ztp.go
+++ b/dhcpv4/ztp/ztp.go
@@ -33,7 +33,7 @@ func parseV4VendorClass(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 
 	opt := packet.GetOneOption(dhcpv4.OptionClassIdentifier)
 	if opt == nil {
-		return vd, nil
+		return nil, nil
 	}
 	vc := opt.(*dhcpv4.OptClassIdentifier).Identifier
 
@@ -87,6 +87,6 @@ func parseV4VendorClass(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 		return vd, nil
 	}
 
-	// We didn't match anything, just return an empty vendor data.
-	return vd, nil
+	// We didn't match anything.
+	return nil, nil
 }

--- a/dhcpv4/ztp/ztp.go
+++ b/dhcpv4/ztp/ztp.go
@@ -42,7 +42,7 @@ func parseV4VendorClass(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 	case strings.HasPrefix(vc, "Arista;"):
 		p := strings.Split(vc, ";")
 		if len(p) < 4 {
-			return vd, errVendorOptionMalformed
+			return nil, errVendorOptionMalformed
 		}
 
 		vd.VendorName = p[0]
@@ -54,7 +54,7 @@ func parseV4VendorClass(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 	case strings.HasPrefix(vc, "ZPESystems:"):
 		p := strings.Split(vc, ":")
 		if len(p) < 3 {
-			return vd, errVendorOptionMalformed
+			return nil, errVendorOptionMalformed
 		}
 
 		vd.VendorName = p[0]
@@ -77,6 +77,8 @@ func parseV4VendorClass(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 			// No separator was found. Attempt serial number from the hostname
 			if opt := packet.GetOneOption(dhcpv4.OptionHostName); opt != nil {
 				vd.Serial = opt.(*dhcpv4.OptHostName).HostName
+			} else {
+				return nil, errVendorOptionMalformed
 			}
 		} else {
 			vd.Serial = vc[sepIdx+1:]

--- a/dhcpv4/ztp/ztp.go
+++ b/dhcpv4/ztp/ztp.go
@@ -79,6 +79,9 @@ func parseV4VendorClass(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 				return nil, errVendorOptionMalformed
 			}
 		} else {
+			if len(vc) == sepIdx+1 {
+				return nil, errVendorOptionMalformed
+			}
 			vd.Serial = vc[sepIdx+1:]
 			vc = vc[:sepIdx]
 		}

--- a/dhcpv4/ztp/ztp.go
+++ b/dhcpv4/ztp/ztp.go
@@ -63,7 +63,7 @@ func parseV4VendorClass(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 		return vd, nil
 
 	// Juniper option 60 parsing is a bit more nuanced.  The following are all
-	// "valid" indetifing stings for Juniper:
+	// "valid" identifying stings for Juniper:
 	//    Juniper-ptx1000-DD576      <vendor>-<model>-<serial
 	//    Juniper-qfx10008           <vendor>-<model> (serial in hostname option)
 	//    Juniper-qfx10002-361-DN817 <vendor>-<model>-<serial> (model has a dash in it!)

--- a/dhcpv4/ztp/ztp.go
+++ b/dhcpv4/ztp/ztp.go
@@ -8,8 +8,7 @@ import (
 )
 
 // VendorData is optional data a particular vendor may or may not include
-// in the Vendor Class options.  All values are optional and will be zero
-// values if not found.
+// in the Vendor Class options.
 type VendorData struct {
 	VendorName string
 	Model      string
@@ -29,13 +28,12 @@ func ParseVendorData(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 // for the vendor, usually using a delimitator to separate the values.
 // See: https://tools.ietf.org/html/rfc1533#section-9.11
 func parseV4VendorClass(packet *dhcpv4.DHCPv4) (*VendorData, error) {
-	vd := &VendorData{}
-
 	opt := packet.GetOneOption(dhcpv4.OptionClassIdentifier)
 	if opt == nil {
 		return nil, nil
 	}
 	vc := opt.(*dhcpv4.OptClassIdentifier).Identifier
+	vd := &VendorData{}
 
 	switch {
 	// Arista;DCS-7050S-64;01.23;JPE12221671

--- a/dhcpv4/ztp/ztp.go
+++ b/dhcpv4/ztp/ztp.go
@@ -26,7 +26,7 @@ func ParseVendorData(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 
 // parseV4Opt60 will attempt to look at the Vendor Class option (Option 60) on
 // DHCPv4.  The option is formatted as a string with the content being specific
-// for the vendor, usually using a deliminator to separate the values.
+// for the vendor, usually using a delimitator to separate the values.
 // See: https://tools.ietf.org/html/rfc1533#section-9.11
 func parseV4VendorClass(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 	vd := &VendorData{}

--- a/dhcpv4/ztp/ztp_test.go
+++ b/dhcpv4/ztp/ztp_test.go
@@ -3,15 +3,15 @@ package ztpv4
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseV4VendorClass(t *testing.T) {
 	tt := []struct {
 		name         string
 		vc, hostname string
-		want         VendorData
+		want         *VendorData
 		fail         bool
 	}{
 		{name: "empty", fail: true},
@@ -20,44 +20,44 @@ func TestParseV4VendorClass(t *testing.T) {
 		{
 			name: "arista",
 			vc:   "Arista;DCS-7050S-64;01.23;JPE12345678",
-			want: VendorData{
+			want: &VendorData{
 				VendorName: "Arista", Model: "DCS-7050S-64", Serial: "JPE12345678"},
 		},
 		{
 			name: "juniper",
 			vc:   "Juniper-ptx1000-DD123",
-			want: VendorData{VendorName: "Juniper", Model: "ptx1000", Serial: "DD123"},
+			want: &VendorData{VendorName: "Juniper", Model: "ptx1000", Serial: "DD123"},
 		},
 		{
 			name: "juniperModelDash",
 			vc:   "Juniper-qfx10002-36q-DN817",
-			want: VendorData{VendorName: "Juniper", Model: "qfx10002-36q", Serial: "DN817"},
+			want: &VendorData{VendorName: "Juniper", Model: "qfx10002-36q", Serial: "DN817"},
 		},
 		{
 			name:     "juniperHostnameSerial",
 			vc:       "Juniper-qfx10008",
 			hostname: "DE123",
-			want:     VendorData{VendorName: "Juniper", Model: "qfx10008", Serial: "DE123"},
+			want:     &VendorData{VendorName: "Juniper", Model: "qfx10008", Serial: "DE123"},
 		},
 		{
 			name: "juniperNoSerial",
 			vc:   "Juniper-qfx10008",
-			want: VendorData{VendorName: "Juniper", Model: "qfx10008", Serial: ""},
+			want: &VendorData{VendorName: "Juniper", Model: "qfx10008", Serial: ""},
 		},
 		{
 			name: "juniperInvalid",
 			vc:   "Juniper-",
-			want: VendorData{VendorName: "Juniper", Model: "", Serial: ""},
+			want: &VendorData{VendorName: "Juniper", Model: "", Serial: ""},
 		},
 		{
 			name: "juniperInvalid2",
 			vc:   "Juniper-qfx99999-",
-			want: VendorData{VendorName: "Juniper", Model: "qfx99999", Serial: ""},
+			want: &VendorData{VendorName: "Juniper", Model: "qfx99999", Serial: ""},
 		},
 		{
 			name: "zpe",
 			vc:   "ZPESystems:NSC:001234567",
-			want: VendorData{VendorName: "ZPESystems", Model: "NSC", Serial: "001234567"},
+			want: &VendorData{VendorName: "ZPESystems", Model: "NSC", Serial: "001234567"},
 		},
 	}
 
@@ -78,56 +78,10 @@ func TestParseV4VendorClass(t *testing.T) {
 				})
 			}
 
-			vd := VendorData{}
-
-			if err := parseV4VendorClass(&vd, packet); err != nil && !tc.fail {
-				t.Errorf("unexpected failure: %v", err)
-			}
-
-			if !cmp.Equal(tc.want, vd) {
-				t.Errorf("unexpected VendorData:\n%s", cmp.Diff(tc.want, vd))
-			}
-		})
-	}
-}
-
-func TestParseV4VIVC(t *testing.T) {
-	tt := []struct {
-		name  string
-		entID uint32
-		input []byte
-		want  VendorData
-		fail  bool
-	}{
-		{name: "empty", fail: true},
-		{
-			name:  "ciscoIOSXR",
-			entID: 0x09,
-			input: []byte("SN:0;PID:R-IOSXRV9000-CC"),
-			want:  VendorData{VendorName: "Cisco Systems", Model: "R-IOSXRV9000-CC", Serial: "0"},
-		},
-	}
-
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			packet, err := dhcpv4.New()
-			if err != nil {
-				t.Fatalf("failed to creat dhcpv4 packet object: %v", err)
-			}
-			packet.AddOption(&dhcpv4.OptVIVC{
-				Identifiers: []dhcpv4.VIVCIdentifier{
-					{EntID: tc.entID, Data: tc.input},
-				},
-			})
-
-			vd := VendorData{}
-
-			if err := parseV4VIVC(&vd, packet); err != nil && !tc.fail {
-				t.Errorf("unexpected failure: %v", err)
-			}
-
-			if !cmp.Equal(tc.want, vd) {
-				t.Errorf("unexpected VendorData:\n%s", cmp.Diff(tc.want, vd))
+			vd, err := parseV4VendorClass(packet)
+			if !tc.fail {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, vd)
 			}
 		})
 	}

--- a/dhcpv4/ztp/ztp_test.go
+++ b/dhcpv4/ztp/ztp_test.go
@@ -14,14 +14,13 @@ func TestParseV4VendorClass(t *testing.T) {
 		want         *VendorData
 		fail         bool
 	}{
-		{name: "empty", fail: true},
-		{name: "unknownVendor", vc: "VendorX;BFR10K;XX12345", fail: true},
+		{name: "empty"},
+		{name: "unknownVendor", vc: "VendorX;BFR10K;XX12345"},
 		{name: "truncatedVendor", vc: "Arista;1234", fail: true},
 		{
 			name: "arista",
 			vc:   "Arista;DCS-7050S-64;01.23;JPE12345678",
-			want: &VendorData{
-				VendorName: "Arista", Model: "DCS-7050S-64", Serial: "JPE12345678"},
+			want: &VendorData{VendorName: "Arista", Model: "DCS-7050S-64", Serial: "JPE12345678"},
 		},
 		{
 			name: "juniper",
@@ -39,21 +38,8 @@ func TestParseV4VendorClass(t *testing.T) {
 			hostname: "DE123",
 			want:     &VendorData{VendorName: "Juniper", Model: "qfx10008", Serial: "DE123"},
 		},
-		{
-			name: "juniperNoSerial",
-			vc:   "Juniper-qfx10008",
-			want: &VendorData{VendorName: "Juniper", Model: "qfx10008", Serial: ""},
-		},
-		{
-			name: "juniperInvalid",
-			vc:   "Juniper-",
-			want: &VendorData{VendorName: "Juniper", Model: "", Serial: ""},
-		},
-		{
-			name: "juniperInvalid2",
-			vc:   "Juniper-qfx99999-",
-			want: &VendorData{VendorName: "Juniper", Model: "qfx99999", Serial: ""},
-		},
+		{name: "juniperNoSerial", vc: "Juniper-qfx10008", fail: true},
+		{name: "juniperInvalid", vc: "Juniper-", fail: true},
 		{
 			name: "zpe",
 			vc:   "ZPESystems:NSC:001234567",
@@ -79,7 +65,9 @@ func TestParseV4VendorClass(t *testing.T) {
 			}
 
 			vd, err := parseV4VendorClass(packet)
-			if !tc.fail {
+			if tc.fail {
+				require.Error(t, err)
+			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.want, vd)
 			}

--- a/dhcpv4/ztp/ztp_test.go
+++ b/dhcpv4/ztp/ztp_test.go
@@ -39,8 +39,6 @@ func TestParseV4VendorClass(t *testing.T) {
 			want:     &VendorData{VendorName: "Juniper", Model: "qfx10008", Serial: "DE123"},
 		},
 		{name: "juniperNoSerial", vc: "Juniper-qfx10008", fail: true},
-		{name: "juniperInvalid", vc: "Juniper-", fail: true},
-		{name: "juniperInvalid2", vc: "Juniper-qfx99999-", fail: true},
 		{
 			name: "zpe",
 			vc:   "ZPESystems:NSC:001234567",
@@ -65,7 +63,7 @@ func TestParseV4VendorClass(t *testing.T) {
 				})
 			}
 
-			vd, err := parseV4VendorClass(packet)
+			vd, err := ParseVendorData(packet)
 			if tc.fail {
 				require.Error(t, err)
 			} else {

--- a/dhcpv4/ztp/ztp_test.go
+++ b/dhcpv4/ztp/ztp_test.go
@@ -1,0 +1,134 @@
+package ztpv4
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/insomniacslk/dhcp/dhcpv4"
+)
+
+func TestParseV4VendorClass(t *testing.T) {
+	tt := []struct {
+		name         string
+		vc, hostname string
+		want         VendorData
+		fail         bool
+	}{
+		{name: "empty", fail: true},
+		{name: "unknownVendor", vc: "VendorX;BFR10K;XX12345", fail: true},
+		{name: "truncatedVendor", vc: "Arista;1234", fail: true},
+		{
+			name: "arista",
+			vc:   "Arista;DCS-7050S-64;01.23;JPE12345678",
+			want: VendorData{
+				VendorName: "Arista", Model: "DCS-7050S-64", Serial: "JPE12345678"},
+		},
+		{
+			name: "juniper",
+			vc:   "Juniper-ptx1000-DD123",
+			want: VendorData{VendorName: "Juniper", Model: "ptx1000", Serial: "DD123"},
+		},
+		{
+			name: "juniperModelDash",
+			vc:   "Juniper-qfx10002-36q-DN817",
+			want: VendorData{VendorName: "Juniper", Model: "qfx10002-36q", Serial: "DN817"},
+		},
+		{
+			name:     "juniperHostnameSerial",
+			vc:       "Juniper-qfx10008",
+			hostname: "DE123",
+			want:     VendorData{VendorName: "Juniper", Model: "qfx10008", Serial: "DE123"},
+		},
+		{
+			name: "juniperNoSerial",
+			vc:   "Juniper-qfx10008",
+			want: VendorData{VendorName: "Juniper", Model: "qfx10008", Serial: ""},
+		},
+		{
+			name: "juniperInvalid",
+			vc:   "Juniper-",
+			want: VendorData{VendorName: "Juniper", Model: "", Serial: ""},
+		},
+		{
+			name: "juniperInvalid2",
+			vc:   "Juniper-qfx99999-",
+			want: VendorData{VendorName: "Juniper", Model: "qfx99999", Serial: ""},
+		},
+		{
+			name: "zpe",
+			vc:   "ZPESystems:NSC:001234567",
+			want: VendorData{VendorName: "ZPESystems", Model: "NSC", Serial: "001234567"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			packet, err := dhcpv4.New()
+			if err != nil {
+				t.Fatalf("failed to creat dhcpv4 packet object: %v", err)
+			}
+
+			packet.AddOption(&dhcpv4.OptClassIdentifier{
+				Identifier: tc.vc,
+			})
+
+			if tc.hostname != "" {
+				packet.AddOption(&dhcpv4.OptHostName{
+					HostName: tc.hostname,
+				})
+			}
+
+			vd := VendorData{}
+
+			if err := parseV4VendorClass(&vd, packet); err != nil && !tc.fail {
+				t.Errorf("unexpected failure: %v", err)
+			}
+
+			if !cmp.Equal(tc.want, vd) {
+				t.Errorf("unexpected VendorData:\n%s", cmp.Diff(tc.want, vd))
+			}
+		})
+	}
+}
+
+func TestParseV4VIVC(t *testing.T) {
+	tt := []struct {
+		name  string
+		entID uint32
+		input []byte
+		want  VendorData
+		fail  bool
+	}{
+		{name: "empty", fail: true},
+		{
+			name:  "ciscoIOSXR",
+			entID: 0x09,
+			input: []byte("SN:0;PID:R-IOSXRV9000-CC"),
+			want:  VendorData{VendorName: "Cisco Systems", Model: "R-IOSXRV9000-CC", Serial: "0"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			packet, err := dhcpv4.New()
+			if err != nil {
+				t.Fatalf("failed to creat dhcpv4 packet object: %v", err)
+			}
+			packet.AddOption(&dhcpv4.OptVIVC{
+				Identifiers: []dhcpv4.VIVCIdentifier{
+					{EntID: tc.entID, Data: tc.input},
+				},
+			})
+
+			vd := VendorData{}
+
+			if err := parseV4VIVC(&vd, packet); err != nil && !tc.fail {
+				t.Errorf("unexpected failure: %v", err)
+			}
+
+			if !cmp.Equal(tc.want, vd) {
+				t.Errorf("unexpected VendorData:\n%s", cmp.Diff(tc.want, vd))
+			}
+		})
+	}
+}

--- a/dhcpv4/ztp/ztp_test.go
+++ b/dhcpv4/ztp/ztp_test.go
@@ -40,6 +40,7 @@ func TestParseV4VendorClass(t *testing.T) {
 		},
 		{name: "juniperNoSerial", vc: "Juniper-qfx10008", fail: true},
 		{name: "juniperInvalid", vc: "Juniper-", fail: true},
+		{name: "juniperInvalid2", vc: "Juniper-qfx99999-", fail: true},
 		{
 			name: "zpe",
 			vc:   "ZPESystems:NSC:001234567",


### PR DESCRIPTION
How about moving the parsing to extract vendor, model and serial from https://github.com/facebookincubator/dhcplb/blob/master/lib/handler.go#L418 to the library.