### PR TITLE
bsdp: Fix client to not use deprecated functions

### DIFF
--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -225,7 +225,7 @@ func (c *Client) Exchange(ifname string, discover *DHCPv4, modifiers ...Modifier
 	conversation = append(conversation, discover)
 
 	// Offer
-	offer, err := c.sendReceive(sfd, rfd, discover, MessageTypeOffer)
+	offer, err := c.SendReceive(sfd, rfd, discover, MessageTypeOffer)
 	if err != nil {
 		return conversation, err
 	}
@@ -239,7 +239,7 @@ func (c *Client) Exchange(ifname string, discover *DHCPv4, modifiers ...Modifier
 	conversation = append(conversation, request)
 
 	// Ack
-	ack, err := c.sendReceive(sfd, rfd, request, MessageTypeAck)
+	ack, err := c.SendReceive(sfd, rfd, request, MessageTypeAck)
 	if err != nil {
 		return conversation, err
 	}
@@ -247,10 +247,10 @@ func (c *Client) Exchange(ifname string, discover *DHCPv4, modifiers ...Modifier
 	return conversation, nil
 }
 
-// sendReceive sends a packet (with some write timeout) and waits for a
+// SendReceive sends a packet (with some write timeout) and waits for a
 // response up to some read timeout value. If the message type is not
 // MessageTypeNone, it will wait for a specific message type
-func (c *Client) sendReceive(sendFd, recvFd int, packet *DHCPv4, messageType MessageType) (*DHCPv4, error) {
+func (c *Client) SendReceive(sendFd, recvFd int, packet *DHCPv4, messageType MessageType) (*DHCPv4, error) {
 	raddr, err := c.getRemoteUDPAddr()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes the bsdp client to not use deprecated functionality; instead,
reuse parts of dhcpv4.Client and implement only the BDSP transaction
logic (effectively overloading the client.Exchange method).