### PR TITLE
server: do not skip network errors in ActivateAndServe

### DIFF
--- a/dhcpv4/server.go
+++ b/dhcpv4/server.go
@@ -115,7 +115,10 @@ func (s *Server) ActivateAndServe() error {
 		if err != nil {
 			switch err.(type) {
 			case net.Error:
-				// silently skip and continue
+				if err.(net.Error).Timeout() {
+					return err
+				}
+				// if timeout, silently skip and continue
 			default:
 				// complain and continue
 				log.Printf("Error reading from packet conn: %v", err)

--- a/dhcpv6/server.go
+++ b/dhcpv6/server.go
@@ -117,7 +117,10 @@ func (s *Server) ActivateAndServe() error {
 		if err != nil {
 			switch err.(type) {
 			case net.Error:
-				// silently skip and continue
+				if !err.(net.Error).Timeout() {
+					return err
+				}
+				// if timeout, silently skip and continue
 			default:
 				//complain and continue
 				log.Printf("Error reading from packet conn: %v", err)


### PR DESCRIPTION
Not sure why net.Error was being skipped entirely. However that's wrong, only timeouts should be skipped in that code.