### PR TITLE
netboot: domain search list not mandatory

### DIFF
--- a/netboot/netconf.go
+++ b/netboot/netconf.go
@@ -66,12 +66,11 @@ func GetNetConfFromPacketv6(d *dhcpv6.DHCPv6Message) (*NetConf, error) {
 	netconf.DNSServers = odnsserv.NameServers
 
 	opt = d.GetOneOption(dhcpv6.OptionDomainSearchList)
-	if opt == nil {
-		return nil, errors.New("No option DNS Domain Search List found")
+	if opt != nil {
+		odomains := opt.(*dhcpv6.OptDomainSearchList)
+		// TODO should this be copied?
+		netconf.DNSSearchList = odomains.DomainSearchList
 	}
-	odomains := opt.(*dhcpv6.OptDomainSearchList)
-	// TODO should this be copied?
-	netconf.DNSSearchList = odomains.DomainSearchList
 
 	return &netconf, nil
 }
@@ -133,15 +132,13 @@ func GetNetConfFromPacketv4(d *dhcpv4.DHCPv4) (*NetConf, error) {
 
 	// get domain search list
 	dnsDomainSearchListOption := d.GetOneOption(dhcpv4.OptionDNSDomainSearchList)
-	if dnsDomainSearchListOption == nil {
-		return nil, errors.New("no domain search list option in response packet")
-
+	if dnsDomainSearchListOption != nil {
+		dnsSearchList := dnsDomainSearchListOption.(*dhcpv4.OptDomainSearch).DomainSearch
+		if len(dnsSearchList) == 0 {
+			return nil, errors.New("dns search list is empty")
+		}
+		netconf.DNSSearchList = dnsSearchList
 	}
-	dnsSearchList := dnsDomainSearchListOption.(*dhcpv4.OptDomainSearch).DomainSearch
-	if len(dnsSearchList) == 0 {
-		return nil, errors.New("dns search list is empty")
-	}
-	netconf.DNSSearchList = dnsSearchList
 
 	// get default gateway
 	routerOption := d.GetOneOption(dhcpv4.OptionRouter)


### PR DESCRIPTION
It is valid to return an empty domain search list