### PR TITLE
dhcpv4: run on unconfigured interfaces

### DIFF
--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -340,7 +340,6 @@ func (c *Client) sendReceive(sendFd, recvFd int, packet *DHCPv4, messageType Mes
 
 			response, innerErr = FromBytes(payload)
 			if innerErr != nil {
-				log.Print(payload)
 				errs <- innerErr
 				return
 			}

--- a/netboot/netconf.go
+++ b/netboot/netconf.go
@@ -208,7 +208,9 @@ func ConfigureInterface(ifname string, netconf *NetConf) error {
 	for _, ns := range netconf.DNSServers {
 		resolvconf += fmt.Sprintf("nameserver %s\n", ns)
 	}
-	resolvconf += fmt.Sprintf("search %s\n", strings.Join(netconf.DNSSearchList, " "))
+	if len(netconf.DNSSearchList) > 0 {
+		resolvconf += fmt.Sprintf("search %s\n", strings.Join(netconf.DNSSearchList, " "))
+	}
 	if err = ioutil.WriteFile("/etc/resolv.conf", []byte(resolvconf), 0644); err != nil {
 		return fmt.Errorf("could not write resolv.conf file %v", err)
 	}

--- a/rfc1035label/label.go
+++ b/rfc1035label/label.go
@@ -26,7 +26,7 @@ func LabelsFromBytes(buf []byte) ([]string, error) {
 			label = ""
 		}
 		if len(buf)-pos < length {
-			return nil, fmt.Errorf("DomainNamesFromBytes: invalid short label length: %v", buf)
+			return nil, fmt.Errorf("DomainNamesFromBytes: invalid short label length")
 		}
 		if label != "" {
 			label += "."

--- a/rfc1035label/label.go
+++ b/rfc1035label/label.go
@@ -26,7 +26,7 @@ func LabelsFromBytes(buf []byte) ([]string, error) {
 			label = ""
 		}
 		if len(buf)-pos < length {
-			return nil, fmt.Errorf("DomainNamesFromBytes: invalid short label length")
+			return nil, fmt.Errorf("DomainNamesFromBytes: invalid short label length: %v", buf)
 		}
 		if label != "" {
 			label += "."


### PR DESCRIPTION
Fixes #184

Tested using u-root and qemu. Also tested on a linux container in a chromebook, see tshark's output at the end.

Build u-root with the dhclient command from https://github.com/insomniacslk/exdhcp (the name clashes with u-root's dhclient, so only building the minimum commands to test):
```
$ go build && ./u-root -build=bb github.com/u-root/u-root/cmds/{init,ip,elvish} github.com/insomniacslk/exdhcp/dhclient
2018/11/18 00:42:59 Disabling CGO for u-root...
2018/11/18 00:42:59 Build environment: GOARCH=amd64 GOOS=linux GOROOT=/home/insomniac/.gvm/gos/go1.10 GOPATH=/home/insomniac/.gvm/pkgsets/go1.10/global CGO_ENABLED=0
2018/11/18 00:42:59 Filename is /tmp/initramfs.linux_amd64.cpio
2018/11/18 00:43:08 Successfully wrote initramfs.
```

Then run it using qemu with `-initramfs` pointing to the generated cpio:
```
~/> ip a
1: lo: <LOOPBACK> mtu 65536 state DOWN
    link/loopback 
2: eth0: <BROADCAST,MULTICAST> mtu 1500 state DOWN
    link/ether 52:54:00:12:34:56
3: sit0: <0> mtu 1480 state DOWN
    link/sit 
~/> dhclient -d -v 4
2018/11/18 00:44:03 OperState: down
2018/11/18 00:44:03 OperState: up
2018/11/18 00:44:04 DHCPv4
  opcode=BootRequest
  hwtype=Ethernet
  hwaddrlen=6
  hopcount=0
  transactionid=0x3710bdf5
  numseconds=0
  flags=Broadcast (0x8000)
  clientipaddr=0.0.0.0
  youripaddr=0.0.0.0
  serveripaddr=0.0.0.0
  gatewayipaddr=0.0.0.0
  clienthwaddr=52:54:00:12:34:56
  serverhostname=
  bootfilename=
  options=
    DHCP Message Type -> DISCOVER
    Parameter Request List -> [Subnet Mask, Router, Domain Name, Domain Name Server]
    End -> []
2018/11/18 00:44:04 DHCPv4
  opcode=BootReply
  hwtype=Ethernet
  hwaddrlen=6
  hopcount=0
  transactionid=0x3710bdf5
  numseconds=0
  flags=Unicast (0x00)
  clientipaddr=0.0.0.0
  youripaddr=10.0.2.15
  serveripaddr=10.0.2.2
  gatewayipaddr=0.0.0.0
  clienthwaddr=52:54:00:12:34:56
  serverhostname=
  bootfilename=
  options=
    DHCP Message Type -> OFFER
    Server Identifier -> 10.0.2.2
    Subnet Mask -> ffffff00
    Routers -> 10.0.2.2
    Domain Name Servers -> 10.0.2.3
    IP Addresses Lease Time -> 86400
    End -> []
2018/11/18 00:44:04 DHCPv4
  opcode=BootRequest
  hwtype=Ethernet
  hwaddrlen=6
  hopcount=0
  transactionid=0x3710bdf5
  numseconds=0
  flags=Unicast (0x00)
  clientipaddr=0.0.0.0
  youripaddr=0.0.0.0
  serveripaddr=10.0.2.2
  gatewayipaddr=0.0.0.0
  clienthwaddr=52:54:00:12:34:56
  serverhostname=
  bootfilename=
  options=
    DHCP Message Type -> REQUEST
    Requested IP Address -> 10.0.2.15
    Server Identifier -> 10.0.2.2
    End -> []
2018/11/18 00:44:04 DHCPv4
  opcode=BootReply
  hwtype=Ethernet
  hwaddrlen=6
  hopcount=0
  transactionid=0x3710bdf5
  numseconds=0
  flags=Unicast (0x00)
  clientipaddr=0.0.0.0
  youripaddr=10.0.2.15
  serveripaddr=10.0.2.2
  gatewayipaddr=0.0.0.0
  clienthwaddr=52:54:00:12:34:56
  serverhostname=
  bootfilename=
  options=
    DHCP Message Type -> ACK
    Server Identifier -> 10.0.2.2
    Subnet Mask -> ffffff00
    Routers -> 10.0.2.2
    Domain Name Servers -> 10.0.2.3
    IP Addresses Lease Time -> 86400
    End -> []
2018/11/18 00:44:04 Setting network configuration:
2018/11/18 00:44:04 &{Addresses:[{IPNet:{IP:10.0.2.15 Mask:ffffff00} PreferredLifetime:0 ValidLifetime:86400}] DNSServers:[10.0.2.3] DNSSearchList:[] Routers:[10.0.2.2]}
~/> ip a
1: lo: <LOOPBACK> mtu 65536 state DOWN
    link/loopback 
2: eth0: <UP,BROADCAST,MULTICAST> mtu 1500 state UP
    link/ether 52:54:00:12:34:56
    inet 10.0.2.15 brd 10.0.2.255 scope global eth0
       valid_lft 86398sec preferred_lft 0sec
    inet6 fec0::5054:ff:fe12:3456 scope site 
       valid_lft 86398sec preferred_lft 14398sec
    inet6 fe80::5054:ff:fe12:3456 scope link 
       valid_lft forever preferred_lft forever
3: sit0: <0> mtu 1480 state DOWN
    link/sit 
~/>
```

Tshark's output on a Linux container on a Chromebook:
```
    1 0.000000000      0.0.0.0 → 255.255.255.255 DHCP 292 DHCP Discover - Transaction ID 0x52241924
    2 0.001236417 100.115.92.193 → 255.255.255.255 DHCP 342 DHCP Offer    - Transaction ID 0x52241924
    3 0.003651125      0.0.0.0 → 255.255.255.255 DHCP 298 DHCP Request  - Transaction ID 0x52241924
    4 0.059609709 100.115.92.193 → 255.255.255.255 DHCP 348 DHCP ACK      - Transaction ID 0x52241924
```