### PR TITLE
rfc1035label: using a structure to hold original data

### DIFF
--- a/dhcpv4/option_domain_search_test.go
+++ b/dhcpv4/option_domain_search_test.go
@@ -3,6 +3,7 @@ package dhcpv4
 import (
 	"testing"
 
+	"github.com/insomniacslk/dhcp/rfc1035label"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,9 +16,11 @@ func TestParseOptDomainSearch(t *testing.T) {
 	}
 	opt, err := ParseOptDomainSearch(data)
 	require.NoError(t, err)
-	require.Equal(t, len(opt.DomainSearch), 2)
-	require.Equal(t, opt.DomainSearch[0], "example.com")
-	require.Equal(t, opt.DomainSearch[1], "subnet.example.org")
+	require.Equal(t, 2, len(opt.DomainSearch.Labels))
+	require.Equal(t, data[2:], opt.DomainSearch.ToBytes())
+	require.Equal(t, len(data[2:]), opt.DomainSearch.Length())
+	require.Equal(t, opt.DomainSearch.Labels[0], "example.com")
+	require.Equal(t, opt.DomainSearch.Labels[1], "subnet.example.org")
 }
 
 func TestOptDomainSearchToBytes(t *testing.T) {
@@ -28,9 +31,11 @@ func TestOptDomainSearchToBytes(t *testing.T) {
 		6, 's', 'u', 'b', 'n', 'e', 't', 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'o', 'r', 'g', 0,
 	}
 	opt := OptDomainSearch{
-		DomainSearch: []string{
-			"example.com",
-			"subnet.example.org",
+		DomainSearch: &rfc1035label.Labels{
+			Labels: []string{
+				"example.com",
+				"subnet.example.org",
+			},
 		},
 	}
 	require.Equal(t, opt.ToBytes(), expected)

--- a/dhcpv6/option_domainsearchlist.go
+++ b/dhcpv6/option_domainsearchlist.go
@@ -12,7 +12,7 @@ import (
 
 // OptDomainSearchList list implements a OptionDomainSearchList option
 type OptDomainSearchList struct {
-	DomainSearchList []string
+	DomainSearchList *rfc1035label.Labels
 }
 
 func (op *OptDomainSearchList) Code() OptionCode {
@@ -23,30 +23,30 @@ func (op *OptDomainSearchList) ToBytes() []byte {
 	buf := make([]byte, 4)
 	binary.BigEndian.PutUint16(buf[0:2], uint16(OptionDomainSearchList))
 	binary.BigEndian.PutUint16(buf[2:4], uint16(op.Length()))
-	buf = append(buf, rfc1035label.LabelsToBytes(op.DomainSearchList)...)
+	buf = append(buf, op.DomainSearchList.ToBytes()...)
 	return buf
 }
 
 func (op *OptDomainSearchList) Length() int {
 	var length int
-	for _, label := range op.DomainSearchList {
+	for _, label := range op.DomainSearchList.Labels {
 		length += len(label) + 2 // add the first and the last length bytes
 	}
 	return length
 }
 
 func (op *OptDomainSearchList) String() string {
-	return fmt.Sprintf("OptDomainSearchList{searchlist=%v}", op.DomainSearchList)
+	return fmt.Sprintf("OptDomainSearchList{searchlist=%v}", op.DomainSearchList.Labels)
 }
 
-// build an OptDomainSearchList structure from a sequence of bytes.
-// The input data does not include option code and length bytes.
+// ParseOptDomainSearchList builds an OptDomainSearchList structure from a sequence
+// of bytes. The input data does not include option code and length bytes.
 func ParseOptDomainSearchList(data []byte) (*OptDomainSearchList, error) {
 	opt := OptDomainSearchList{}
-	var err error
-	opt.DomainSearchList, err = rfc1035label.LabelsFromBytes(data)
+	labels, err := rfc1035label.FromBytes(data)
 	if err != nil {
 		return nil, err
 	}
+	opt.DomainSearchList = labels
 	return &opt, nil
 }

--- a/dhcpv6/option_domainsearchlist_test.go
+++ b/dhcpv6/option_domainsearchlist_test.go
@@ -3,6 +3,7 @@ package dhcpv6
 import (
 	"testing"
 
+	"github.com/insomniacslk/dhcp/rfc1035label"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,9 +15,10 @@ func TestParseOptDomainSearchList(t *testing.T) {
 	opt, err := ParseOptDomainSearchList(data)
 	require.NoError(t, err)
 	require.Equal(t, OptionDomainSearchList, opt.Code())
-	require.Equal(t, 2, len(opt.DomainSearchList))
-	require.Equal(t, "example.com", opt.DomainSearchList[0])
-	require.Equal(t, "subnet.example.org", opt.DomainSearchList[1])
+	require.Equal(t, 2, len(opt.DomainSearchList.Labels))
+	require.Equal(t, len(data), opt.DomainSearchList.Length())
+	require.Equal(t, "example.com", opt.DomainSearchList.Labels[0])
+	require.Equal(t, "subnet.example.org", opt.DomainSearchList.Labels[1])
 	require.Contains(t, opt.String(), "searchlist=[example.com subnet.example.org]", "String() should contain the correct domain search output")
 }
 
@@ -28,9 +30,11 @@ func TestOptDomainSearchListToBytes(t *testing.T) {
 		6, 's', 'u', 'b', 'n', 'e', 't', 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'o', 'r', 'g', 0,
 	}
 	opt := OptDomainSearchList{
-		DomainSearchList: []string{
-			"example.com",
-			"subnet.example.org",
+		DomainSearchList: &rfc1035label.Labels{
+			Labels: []string{
+				"example.com",
+				"subnet.example.org",
+			},
 		},
 	}
 	require.Equal(t, expected, opt.ToBytes())

--- a/netboot/netconf.go
+++ b/netboot/netconf.go
@@ -69,7 +69,7 @@ func GetNetConfFromPacketv6(d *dhcpv6.DHCPv6Message) (*NetConf, error) {
 	if opt != nil {
 		odomains := opt.(*dhcpv6.OptDomainSearchList)
 		// TODO should this be copied?
-		netconf.DNSSearchList = odomains.DomainSearchList
+		netconf.DNSSearchList = odomains.DomainSearchList.Labels
 	}
 
 	return &netconf, nil
@@ -134,10 +134,10 @@ func GetNetConfFromPacketv4(d *dhcpv4.DHCPv4) (*NetConf, error) {
 	dnsDomainSearchListOption := d.GetOneOption(dhcpv4.OptionDNSDomainSearchList)
 	if dnsDomainSearchListOption != nil {
 		dnsSearchList := dnsDomainSearchListOption.(*dhcpv4.OptDomainSearch).DomainSearch
-		if len(dnsSearchList) == 0 {
+		if len(dnsSearchList.Labels) == 0 {
 			return nil, errors.New("dns search list is empty")
 		}
-		netconf.DNSSearchList = dnsSearchList
+		netconf.DNSSearchList = dnsSearchList.Labels
 	}
 
 	// get default gateway


### PR DESCRIPTION
rfc1035label now is implemented on top of a `Labels` struct that contains the original data in case no changes are made. This is required to parse responses from DHCP servers that use label compression.