### PR TITLE
Add missing error check in GenerateTransactionID

### DIFF
--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -39,15 +39,18 @@ func GenerateTransactionID() (*uint32, error) {
 	for {
 		tidBytes := make([]byte, 4)
 		n, err := rand.Read(tidBytes)
+		if err != nil {
+			return nil, err
+		}
 		if n != 4 {
-			return nil, fmt.Errorf("Invalid random sequence: shorter than 4 bytes")
+			return nil, fmt.Errorf("invalid random sequence: shorter than 4 bytes")
 		}
 		tid, err = BytesToTransactionID(tidBytes)
 		if err != nil {
 			return nil, err
 		}
 		if tid == nil {
-			return nil, fmt.Errorf("Error: got a nil Transaction ID")
+			return nil, fmt.Errorf("got a nil Transaction ID")
 		}
 		// retry until != 0
 		// TODO add retry limit


### PR DESCRIPTION
Added missing error check, which might return more descriptive error to the user when generation error occurs (alternatively we can change the `Read` line to avoid ineffectual assignment)

```go
n, _ := rand.Read(tidBytes)
```

Additionally fixed the tests to work on both LE and BE (previously a BE was assumed).