### PR TITLE
Test TransactionID generation

### DIFF
--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -34,11 +34,13 @@ func BytesToTransactionID(data []byte) (*uint32, error) {
 	return &tid, nil
 }
 
+var randomRead = rand.Read
+
 func GenerateTransactionID() (*uint32, error) {
 	var tid *uint32
 	for {
 		tidBytes := make([]byte, 4)
-		n, err := rand.Read(tidBytes)
+		n, err := randomRead(tidBytes)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Allow for mocking a `"crypto/rand"` function in dhcpv6 and improve unit tests.

`randomReadMock` is a standalone function without `mock.Mock` from the testify suite due to multiple errors of `testify/mock` library not properly supporting type aliases (`byte = uint8`) https://github.com/stretchr/testify/issues/692, and the same occurs when using `mock.Anything` (for `[]byte`).