### PR TITLE
Removed unreachable code, fixed misspelling

### DIFF
--- a/dhcpv4/option_tftp_server_name.go
+++ b/dhcpv4/option_tftp_server_name.go
@@ -31,7 +31,7 @@ func (op *OptTFTPServerName) String() string {
 	return fmt.Sprintf("TFTP Server Name -> %s", op.TFTPServerName)
 }
 
-// ParseOptTFTPServerName returns a new OptTFTPServerName fomr a byte stream or error if any
+// ParseOptTFTPServerName returns a new OptTFTPServerName from a byte stream or error if any
 func ParseOptTFTPServerName(data []byte) (*OptTFTPServerName, error) {
 	if len(data) < 3 {
 		return nil, ErrShortByteStream

--- a/dhcpv4/server.go
+++ b/dhcpv4/server.go
@@ -136,7 +136,6 @@ func (s *Server) ActivateAndServe() error {
 		}
 		go s.Handler(pc, peer, m)
 	}
-	return nil
 }
 
 // Close sends a termination request to the server, and closes the UDP listener

--- a/dhcpv4/types.go
+++ b/dhcpv4/types.go
@@ -9,7 +9,7 @@ type MessageType byte
 // DHCP message types
 const (
 	// MessageTypeNone is not a real message type, it is used by certain
-	// functions to signal that no explict message type is requested
+	// functions to signal that no explicit message type is requested
 	MessageTypeNone     MessageType = 0
 	MessageTypeDiscover MessageType = 1
 	MessageTypeOffer    MessageType = 2

--- a/dhcpv6/iputils_test.go
+++ b/dhcpv6/iputils_test.go
@@ -52,7 +52,7 @@ func (s *MatchingAddressTestSuite) SetupTest() {
 }
 
 func (s *MatchingAddressTestSuite) TestGetMatchingAddr() {
-	// Check if error from InterfaceAddresses immidately returns error
+	// Check if error from InterfaceAddresses immediately returns error
 	s.m.On("InterfaceAddresses", "eth0").Return(nil, ErrDummy).Once()
 	_, err := getMatchingAddr("eth0", s.Match)
 	s.Assert().Equal(ErrDummy, err)

--- a/dhcpv6/option_vendor_opts.go
+++ b/dhcpv6/option_vendor_opts.go
@@ -90,7 +90,7 @@ func ParseOptVendorOpts(data []byte) (*OptVendorOpts, error) {
 }
 
 // vendParseOption builds a GenericOption from a slice of bytes
-// We cannot use the exisitng ParseOption function in options.go because the
+// We cannot use the existing ParseOption function in options.go because the
 // sub-options include codes specific to each vendor. There are overlaps in these
 // codes with RFC standard codes.
 func vendParseOption(dataStart []byte) (Option, error) {

--- a/dhcpv6/server.go
+++ b/dhcpv6/server.go
@@ -136,7 +136,6 @@ func (s *Server) ActivateAndServe() error {
 		}
 		go s.Handler(pc, peer, m)
 	}
-	return nil
 }
 
 // Close sends a termination request to the server, and closes the UDP listener


### PR DESCRIPTION
Removed unreachable code as per `go vet`