### PR TITLE
Removed ineffective assignment

### DIFF
--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -83,7 +83,7 @@ func (s *GenerateTransactionIDTestSuite) TestErrors() {
 
 	// Less than 4 bytes are generated
 	randomRead = randomReadMock(s.random, 3, nil)
-	tid, err = GenerateTransactionID()
+	_, err = GenerateTransactionID()
 	s.Assert().EqualError(err, "invalid random sequence: shorter than 4 bytes")
 }
 


### PR DESCRIPTION
As the title says. I used `ineffassign` to catch it