### PR TITLE
Added netconf v4 tests and required modifiers

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -612,6 +612,20 @@ func (d *DHCPv4) AddOption(option Option) {
 	}
 }
 
+// UpdateOption updates the existing options with the passed option, adding it
+// at the end if not present already
+func (d *DHCPv4) UpdateOption(option Option) {
+	for idx, opt := range d.options {
+		if opt.Code() == option.Code() {
+			d.options[idx] = option
+			// don't look further
+			return
+		}
+	}
+	// if not found, add it
+	d.AddOption(option)
+}
+
 // MessageType returns the message type, trying to extract it from the
 // OptMessageType option. It returns nil if the message type cannot be extracted
 func (d *DHCPv4) MessageType() *MessageType {

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -347,9 +347,7 @@ func TestGetOption(t *testing.T) {
 
 func TestAddOption(t *testing.T) {
 	d, err := New()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	hostnameOpt := &OptionGeneric{OptionCode: OptionHostName, Data: []byte("darkstar")}
 	bootFileOpt1 := &OptionGeneric{OptionCode: OptionBootfileName, Data: []byte("boot.img")}
@@ -361,6 +359,23 @@ func TestAddOption(t *testing.T) {
 	options := d.Options()
 	require.Equal(t, len(options), 4)
 	require.Equal(t, options[3].Code(), OptionEnd)
+}
+
+func TestUpdateOption(t *testing.T) {
+	d, err := New()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(d.options))
+	require.Equal(t, OptionEnd, d.options[0].Code())
+	// test that it will add the option since it's missing
+	d.UpdateOption(&OptDomainName{DomainName: "slackware.it"})
+	require.Equal(t, 2, len(d.options))
+	require.Equal(t, OptionDomainName, d.options[0].Code())
+	require.Equal(t, OptionEnd, d.options[1].Code())
+	// test that it won't add another option of the same type
+	d.UpdateOption(&OptDomainName{DomainName: "slackware.it"})
+	require.Equal(t, 2, len(d.options))
+	require.Equal(t, OptionDomainName, d.options[0].Code())
+	require.Equal(t, OptionEnd, d.options[1].Code())
 }
 
 func TestStrippedOptions(t *testing.T) {

--- a/dhcpv4/modifiers.go
+++ b/dhcpv4/modifiers.go
@@ -2,6 +2,8 @@ package dhcpv4
 
 import (
 	"net"
+
+	"github.com/insomniacslk/dhcp/rfc1035label"
 )
 
 // WithTransactionID sets the Transaction ID for the DHCPv4 packet
@@ -111,6 +113,58 @@ func WithRelay(ip net.IP) Modifier {
 		d.SetUnicast()
 		d.SetGatewayIPAddr(ip)
 		d.SetHopCount(1)
+		return d
+	}
+}
+
+// WithNetmask adds or updates an OptSubnetMask
+func WithNetmask(mask net.IPMask) Modifier {
+	return func(d *DHCPv4) *DHCPv4 {
+		osm := OptSubnetMask{
+			SubnetMask: mask,
+		}
+		d.UpdateOption(&osm)
+		return d
+	}
+}
+
+// WithLeaseTime adds or updates an OptIPAddressLeaseTime
+func WithLeaseTime(leaseTime uint32) Modifier {
+	return func(d *DHCPv4) *DHCPv4 {
+		olt := OptIPAddressLeaseTime{
+			LeaseTime: leaseTime,
+		}
+		d.UpdateOption(&olt)
+		return d
+	}
+}
+
+// WithDNS adds or updates an OptionDomainNameServer
+func WithDNS(dnses ...net.IP) Modifier {
+	return func(d *DHCPv4) *DHCPv4 {
+		odns := OptDomainNameServer{NameServers: dnses}
+		d.UpdateOption(&odns)
+		return d
+	}
+}
+
+// WithDomainSearchList adds or updates an OptionDomainSearch
+func WithDomainSearchList(searchList ...string) Modifier {
+	return func(d *DHCPv4) *DHCPv4 {
+		labels := rfc1035label.Labels{
+			Labels: searchList,
+		}
+		odsl := OptDomainSearch{DomainSearch: &labels}
+		d.UpdateOption(&odsl)
+		return d
+	}
+}
+
+// WithRouter adds or updates an OptionRouter
+func WithRouter(routers ...net.IP) Modifier {
+	return func(d *DHCPv4) *DHCPv4 {
+		ortr := OptRouter{Routers: routers}
+		d.UpdateOption(&ortr)
 		return d
 	}
 }

--- a/dhcpv4/option_domain_search.go
+++ b/dhcpv4/option_domain_search.go
@@ -9,6 +9,9 @@ import (
 	"github.com/insomniacslk/dhcp/rfc1035label"
 )
 
+// FIXME rename OptDomainSearch to OptDomainSearchList, and DomainSearch to
+// SearchList, for consistency with the equivalent v6 option
+
 // OptDomainSearch represents an option encapsulating a domain search list.
 type OptDomainSearch struct {
 	DomainSearch *rfc1035label.Labels

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -280,6 +280,8 @@ func (d *DHCPv6Message) AddOption(option Option) {
 	d.options = append(d.options, option)
 }
 
+// UpdateOption updates the existing options with the passed option, adding it
+// at the end if not present already
 func (d *DHCPv6Message) UpdateOption(option Option) {
 	for idx, opt := range d.options {
 		if opt.Code() == option.Code() {

--- a/dhcpv6/modifiers.go
+++ b/dhcpv6/modifiers.go
@@ -69,7 +69,11 @@ func WithArchType(at iana.ArchType) Modifier {
 // options
 func WithIANA(addrs ...OptIAAddress) Modifier {
 	return func(d DHCPv6) DHCPv6 {
-		iaNa := &OptIANA{}
+		opt := d.GetOneOption(OptionIANA)
+		if opt == nil {
+			opt = &OptIANA{}
+		}
+		iaNa := opt.(*OptIANA)
 		for _, addr := range addrs {
 			iaNa.AddOption(&addr)
 		}

--- a/dhcpv6/modifiers.go
+++ b/dhcpv6/modifiers.go
@@ -69,11 +69,7 @@ func WithArchType(at iana.ArchType) Modifier {
 // options
 func WithIANA(addrs ...OptIAAddress) Modifier {
 	return func(d DHCPv6) DHCPv6 {
-		opt := d.GetOneOption(OptionIANA)
-		if opt == nil {
-			opt = &OptIANA{}
-		}
-		iaNa := opt.(*OptIANA)
+		iaNa := &OptIANA{}
 		for _, addr := range addrs {
 			iaNa.AddOption(&addr)
 		}
@@ -85,13 +81,10 @@ func WithIANA(addrs ...OptIAAddress) Modifier {
 // WithDNS adds or updates an OptDNSRecursiveNameServer
 func WithDNS(dnses ...net.IP) Modifier {
 	return func(d DHCPv6) DHCPv6 {
-		opt := d.GetOneOption(OptionDNSRecursiveNameServer)
-		if opt == nil {
-			opt = &OptDNSRecursiveNameServer{}
+		odns := OptDNSRecursiveNameServer{
+			NameServers: append([]net.IP{}, dnses[:]...),
 		}
-		odns := opt.(*OptDNSRecursiveNameServer)
-		odns.NameServers = append(odns.NameServers, dnses[:]...)
-		d.UpdateOption(odns)
+		d.UpdateOption(&odns)
 		return d
 	}
 }
@@ -99,16 +92,12 @@ func WithDNS(dnses ...net.IP) Modifier {
 // WithDomainSearchList adds or updates an OptDomainSearchList
 func WithDomainSearchList(searchlist ...string) Modifier {
 	return func(d DHCPv6) DHCPv6 {
-		opt := d.GetOneOption(OptionDomainSearchList)
-		if opt == nil {
-			opt = &OptDomainSearchList{}
+		osl := OptDomainSearchList{
+			DomainSearchList: &rfc1035label.Labels{
+				Labels: searchlist,
+			},
 		}
-		osl := opt.(*OptDomainSearchList)
-		labels := rfc1035label.Labels{
-			Labels: searchlist,
-		}
-		osl.DomainSearchList = &labels
-		d.UpdateOption(osl)
+		d.UpdateOption(&osl)
 		return d
 	}
 }

--- a/netboot/netconf.go
+++ b/netboot/netconf.go
@@ -106,10 +106,6 @@ func GetNetConfFromPacketv4(d *dhcpv4.DHCPv4) (*NetConf, error) {
 		leaseTime = leaseTimeOption.(*dhcpv4.OptIPAddressLeaseTime).LeaseTime
 	}
 
-	if int(leaseTime) < 0 {
-		return nil, fmt.Errorf("lease time overflow, Original lease time: %d", leaseTime)
-	}
-
 	netconf.Addresses = append(netconf.Addresses, AddrConf{
 		IPNet: net.IPNet{
 			IP:   ipAddr,


### PR DESCRIPTION
Same as https://github.com/insomniacslk/dhcp/pull/218 , but for DHCPv4.

I have also simplified the corresponding v6 modifiers, they were unnecessarily complex in #218.