### PR TITLE
[ztpv4] make it consistent with ztpv6

### DIFF
--- a/dhcpv4/ztpv4/ztp.go
+++ b/dhcpv4/ztpv4/ztp.go
@@ -10,9 +10,7 @@ import (
 // VendorData is optional data a particular vendor may or may not include
 // in the Vendor Class options.
 type VendorData struct {
-	VendorName string
-	Model      string
-	Serial     string
+	VendorName, Model, Serial string
 }
 
 var errVendorOptionMalformed = errors.New("malformed vendor option")
@@ -22,7 +20,7 @@ var errVendorOptionMalformed = errors.New("malformed vendor option")
 func ParseVendorData(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 	opt := packet.GetOneOption(dhcpv4.OptionClassIdentifier)
 	if opt == nil {
-		return nil, nil
+		return nil, errors.New("vendor options not found")
 	}
 	vc := opt.(*dhcpv4.OptClassIdentifier).Identifier
 	vd := &VendorData{}
@@ -76,5 +74,5 @@ func ParseVendorData(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 	}
 
 	// We didn't match anything.
-	return nil, nil
+	return nil, errors.New("failed to parse vendor option data")
 }

--- a/dhcpv4/ztpv4/ztp.go
+++ b/dhcpv4/ztpv4/ztp.go
@@ -74,5 +74,5 @@ func ParseVendorData(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 	}
 
 	// We didn't match anything.
-	return nil, errors.New("failed to parse vendor option data")
+	return nil, errors.New("no known ZTP vendor found")
 }

--- a/dhcpv4/ztpv4/ztp_test.go
+++ b/dhcpv4/ztpv4/ztp_test.go
@@ -53,9 +53,11 @@ func TestParseV4VendorClass(t *testing.T) {
 				t.Fatalf("failed to creat dhcpv4 packet object: %v", err)
 			}
 
-			packet.AddOption(&dhcpv4.OptClassIdentifier{
-				Identifier: tc.vc,
-			})
+			if tc.vc != "" {
+				packet.AddOption(&dhcpv4.OptClassIdentifier{
+					Identifier: tc.vc,
+				})
+			}
 
 			if tc.hostname != "" {
 				packet.AddOption(&dhcpv4.OptHostName{

--- a/dhcpv4/ztpv4/ztp_test.go
+++ b/dhcpv4/ztpv4/ztp_test.go
@@ -14,8 +14,8 @@ func TestParseV4VendorClass(t *testing.T) {
 		want         *VendorData
 		fail         bool
 	}{
-		{name: "empty"},
-		{name: "unknownVendor", vc: "VendorX;BFR10K;XX12345"},
+		{name: "empty", fail: true},
+		{name: "unknownVendor", vc: "VendorX;BFR10K;XX12345", fail: true},
 		{name: "truncatedVendor", vc: "Arista;1234", fail: true},
 		{
 			name: "arista",


### PR DESCRIPTION
* Rename the directory from `ztp` to `ztpv4` to match the package name
* Return an error when calling `ParseVendorData` and no vendor data is found