### PR TITLE
dhcpv4: nicer parsing of messages.

### DIFF
--- a/dhcpv4/async/client.go
+++ b/dhcpv4/async/client.go
@@ -34,7 +34,7 @@ type Client struct {
 	receiveQueue chan *dhcpv4.DHCPv4
 	sendQueue    chan *dhcpv4.DHCPv4
 	packetsLock  sync.Mutex
-	packets      map[[4]byte]*promise.Promise
+	packets      map[dhcpv4.TransactionID]*promise.Promise
 	errors       chan error
 }
 
@@ -69,7 +69,7 @@ func (c *Client) Open(bufferSize int) error {
 	c.stopping = new(sync.WaitGroup)
 	c.sendQueue = make(chan *dhcpv4.DHCPv4, bufferSize)
 	c.receiveQueue = make(chan *dhcpv4.DHCPv4, bufferSize)
-	c.packets = make(map[[4]byte]*promise.Promise)
+	c.packets = make(map[dhcpv4.TransactionID]*promise.Promise)
 	c.packetsLock = sync.Mutex{}
 	c.errors = make(chan error)
 

--- a/dhcpv4/async/client_test.go
+++ b/dhcpv4/async/client_test.go
@@ -121,5 +121,5 @@ func TestSend(t *testing.T) {
 	require.True(t, ok)
 	require.False(t, timeout)
 	require.NoError(t, err)
-	require.Equal(t, m.TransactionID(), r.TransactionID())
+	require.Equal(t, m.TransactionID, r.TransactionID)
 }

--- a/dhcpv4/bsdp/bsdp.go
+++ b/dhcpv4/bsdp/bsdp.go
@@ -143,12 +143,10 @@ func InformSelectForAck(ack dhcpv4.DHCPv4, replyPort uint16, selectedImage BootI
 	if needsReplyPort(replyPort) && replyPort >= 1024 {
 		return nil, errors.New("replyPort must be a privileged port")
 	}
-	d.SetOpcode(dhcpv4.OpcodeBootRequest)
-	d.SetHwType(ack.HwType())
-	d.SetHwAddrLen(ack.HwAddrLen())
-	clientHwAddr := ack.ClientHwAddr()
-	d.SetClientHwAddr(clientHwAddr[:])
-	d.SetTransactionID(ack.TransactionID())
+	d.OpCode = dhcpv4.OpcodeBootRequest
+	d.HWType = ack.HWType
+	d.ClientHWAddr = ack.ClientHWAddr
+	d.TransactionID = ack.TransactionID
 	if ack.IsBroadcast() {
 		d.SetBroadcast()
 	} else {
@@ -209,11 +207,10 @@ func NewReplyForInformList(inform *dhcpv4.DHCPv4, config ReplyConfig) (*dhcpv4.D
 	if err != nil {
 		return nil, err
 	}
-	reply.SetClientIPAddr(inform.ClientIPAddr())
-	reply.SetYourIPAddr(net.IPv4zero)
-	reply.SetGatewayIPAddr(inform.GatewayIPAddr())
-	reply.SetServerIPAddr(config.ServerIP)
-	reply.SetServerHostName([]byte(config.ServerHostname))
+	reply.ClientIPAddr = inform.ClientIPAddr
+	reply.GatewayIPAddr = inform.GatewayIPAddr
+	reply.ServerIPAddr = config.ServerIP
+	reply.ServerHostName = config.ServerHostname
 
 	reply.AddOption(&dhcpv4.OptMessageType{MessageType: dhcpv4.MessageTypeAck})
 	reply.AddOption(&dhcpv4.OptServerIdentifier{ServerID: config.ServerIP})
@@ -249,12 +246,11 @@ func NewReplyForInformSelect(inform *dhcpv4.DHCPv4, config ReplyConfig) (*dhcpv4
 		return nil, err
 	}
 
-	reply.SetClientIPAddr(inform.ClientIPAddr())
-	reply.SetYourIPAddr(net.IPv4zero)
-	reply.SetGatewayIPAddr(inform.GatewayIPAddr())
-	reply.SetServerIPAddr(config.ServerIP)
-	reply.SetServerHostName([]byte(config.ServerHostname))
-	reply.SetBootFileName([]byte(config.BootFileName))
+	reply.ClientIPAddr = inform.ClientIPAddr
+	reply.GatewayIPAddr = inform.GatewayIPAddr
+	reply.ServerIPAddr = config.ServerIP
+	reply.ServerHostName = config.ServerHostname
+	reply.BootFileName = config.BootFileName
 
 	reply.AddOption(&dhcpv4.OptMessageType{MessageType: dhcpv4.MessageTypeAck})
 	reply.AddOption(&dhcpv4.OptServerIdentifier{ServerID: config.ServerIP})

--- a/dhcpv4/bsdp/client.go
+++ b/dhcpv4/bsdp/client.go
@@ -19,7 +19,7 @@ func NewClient() *Client {
 }
 
 func castVendorOpt(ack *dhcpv4.DHCPv4) {
-	opts := ack.Options()
+	opts := ack.Options
 	for i := 0; i < len(opts); i++ {
 		if opts[i].Code() == dhcpv4.OptionVendorSpecificInformation {
 			vendorOpt, err := ParseOptVendorSpecificInformation(opts[i].ToBytes())

--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -331,11 +331,11 @@ func (c *Client) SendReceive(sendFd, recvFd int, packet *DHCPv4, messageType Mes
 				return
 			}
 			// check that this is a response to our message
-			if response.TransactionID() != packet.TransactionID() {
+			if response.TransactionID != packet.TransactionID {
 				continue
 			}
 			// wait for a response message
-			if response.Opcode() != OpcodeBootReply {
+			if response.OpCode != OpcodeBootReply {
 				continue
 			}
 			// if we are not requested to wait for a specific message type,
@@ -344,7 +344,7 @@ func (c *Client) SendReceive(sendFd, recvFd int, packet *DHCPv4, messageType Mes
 				break
 			}
 			// break if it's a reply of the desired type, continue otherwise
-			if response.MessageType() != nil && *response.MessageType() == messageType {
+			if response.MessageType() == messageType {
 				break
 			}
 		}

--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -100,7 +100,7 @@ func GenerateTransactionID() (*TransactionID, error) {
 	var b TransactionID
 	n, err := rand.Read(b[:])
 	if n != 4 {
-		return nil, fmt.Errorf("invalid random sequence: smaller than 32 bits")
+		return nil, errors.New("invalid random sequence: smaller than 32 bits")
 	}
 	if err != nil {
 		return nil, err

--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -38,7 +38,7 @@ type DHCPv4 struct {
 	OpCode         OpcodeType
 	HWType         iana.HwTypeType
 	HopCount       uint8
-	TransactionID  [4]byte
+	TransactionID  TransactionID
 	NumSeconds     uint16
 	Flags          uint16
 	ClientIPAddr   net.IP
@@ -96,8 +96,8 @@ func GetExternalIPv4Addrs(addrs []net.Addr) ([]net.IP, error) {
 
 // GenerateTransactionID generates a random 32-bits number suitable for use as
 // TransactionID
-func GenerateTransactionID() (*[4]byte, error) {
-	var b [4]byte
+func GenerateTransactionID() (*TransactionID, error) {
+	var b TransactionID
 	n, err := rand.Read(b[:])
 	if n != 4 {
 		return nil, fmt.Errorf("invalid random sequence: smaller than 32 bits")

--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -48,7 +48,7 @@ type DHCPv4 struct {
 	ClientHWAddr   net.HardwareAddr
 	ServerHostName string
 	BootFileName   string
-	Options        []Option
+	Options        Options
 }
 
 // Modifier defines the signature for functions that can modify DHCPv4
@@ -371,9 +371,32 @@ func (d *DHCPv4) SetUnicast() {
 // GetOption will attempt to get all options that match a DHCPv4 option
 // from its OptionCode.  If the option was not found it will return an
 // empty list.
+//
+// According to RFC 3396, options that are specified more than once are
+// concatenated, and hence this should always just return one option.
 func (d *DHCPv4) GetOption(code OptionCode) []Option {
+	return d.Options.GetOption(code)
+}
+
+// GetOneOption will attempt to get an  option that match a Option code.
+// If there are multiple options with the same OptionCode it will only return
+// the first one found.  If no matching option is found nil will be returned.
+func (d *DHCPv4) GetOneOption(code OptionCode) Option {
+	return d.Options.GetOneOption(code)
+}
+
+// Options is a collection of options.
+type Options []Option
+
+// GetOption will attempt to get all options that match a DHCPv4 option
+// from its OptionCode.  If the option was not found it will return an
+// empty list.
+//
+// According to RFC 3396, options that are specified more than once are
+// concatenated, and hence this should always just return one option.
+func (o Options) GetOption(code OptionCode) []Option {
 	opts := []Option{}
-	for _, opt := range d.Options {
+	for _, opt := range o {
 		if opt.Code() == code {
 			opts = append(opts, opt)
 		}
@@ -384,28 +407,13 @@ func (d *DHCPv4) GetOption(code OptionCode) []Option {
 // GetOneOption will attempt to get an  option that match a Option code.
 // If there are multiple options with the same OptionCode it will only return
 // the first one found.  If no matching option is found nil will be returned.
-func (d *DHCPv4) GetOneOption(code OptionCode) Option {
-	for _, opt := range d.Options {
+func (o Options) GetOneOption(code OptionCode) Option {
+	for _, opt := range o {
 		if opt.Code() == code {
 			return opt
 		}
 	}
 	return nil
-}
-
-// StrippedOptions works like Options, but it does not return anything after the
-// End option.
-func (d *DHCPv4) StrippedOptions() []Option {
-	// differently from Options() this function strips away anything coming
-	// after the End option (normally just Pad options).
-	strippedOptions := []Option{}
-	for _, opt := range d.Options {
-		strippedOptions = append(strippedOptions, opt)
-		if opt.Code() == OptionEnd {
-			break
-		}
-	}
-	return strippedOptions
 }
 
 // AddOption appends an option to the existing ones. If the last option is an

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -65,7 +65,7 @@ func TestFromBytes(t *testing.T) {
 	require.Equal(t, d.OpCode, OpcodeBootRequest)
 	require.Equal(t, d.HWType, iana.HwTypeEthernet)
 	require.Equal(t, d.HopCount, byte(3))
-	require.Equal(t, d.TransactionID, [4]byte{0xaa, 0xbb, 0xcc, 0xdd})
+	require.Equal(t, d.TransactionID, TransactionID{0xaa, 0xbb, 0xcc, 0xdd})
 	require.Equal(t, d.NumSeconds, uint16(3))
 	require.Equal(t, d.Flags, uint16(1))
 	require.True(t, d.ClientIPAddr.Equal(net.IPv4zero))
@@ -168,7 +168,7 @@ func TestNewToBytes(t *testing.T) {
 	require.NoError(t, err)
 	// fix TransactionID to match the expected one, since it's randomly
 	// generated in New()
-	d.TransactionID = [4]byte{0x11, 0x22, 0x33, 0x44}
+	d.TransactionID = TransactionID{0x11, 0x22, 0x33, 0x44}
 	got := d.ToBytes()
 	require.Equal(t, expected, got)
 }

--- a/dhcpv4/modifiers.go
+++ b/dhcpv4/modifiers.go
@@ -7,9 +7,9 @@ import (
 )
 
 // WithTransactionID sets the Transaction ID for the DHCPv4 packet
-func WithTransactionID(xid uint32) Modifier {
+func WithTransactionID(xid [4]byte) Modifier {
 	return func(d *DHCPv4) *DHCPv4 {
-		d.SetTransactionID(xid)
+		d.TransactionID = xid
 		return d
 	}
 }
@@ -27,9 +27,9 @@ func WithBroadcast(broadcast bool) Modifier {
 }
 
 // WithHwAddr sets the hardware address for a packet
-func WithHwAddr(hwaddr []byte) Modifier {
+func WithHwAddr(hwaddr net.HardwareAddr) Modifier {
 	return func(d *DHCPv4) *DHCPv4 {
-		d.SetClientHwAddr(hwaddr)
+		d.ClientHWAddr = hwaddr
 		return d
 	}
 }
@@ -111,8 +111,8 @@ func WithRequestedOptions(optionCodes ...OptionCode) Modifier {
 func WithRelay(ip net.IP) Modifier {
 	return func(d *DHCPv4) *DHCPv4 {
 		d.SetUnicast()
-		d.SetGatewayIPAddr(ip)
-		d.SetHopCount(1)
+		d.GatewayIPAddr = ip
+		d.HopCount = 1
 		return d
 	}
 }

--- a/dhcpv4/modifiers.go
+++ b/dhcpv4/modifiers.go
@@ -7,7 +7,7 @@ import (
 )
 
 // WithTransactionID sets the Transaction ID for the DHCPv4 packet
-func WithTransactionID(xid [4]byte) Modifier {
+func WithTransactionID(xid TransactionID) Modifier {
 	return func(d *DHCPv4) *DHCPv4 {
 		d.TransactionID = xid
 		return d

--- a/dhcpv4/modifiers_test.go
+++ b/dhcpv4/modifiers_test.go
@@ -10,8 +10,8 @@ import (
 func TestTransactionIDModifier(t *testing.T) {
 	d, err := New()
 	require.NoError(t, err)
-	d = WithTransactionID([4]byte{0xdd, 0xcc, 0xbb, 0xaa})(d)
-	require.Equal(t, [4]byte{0xdd, 0xcc, 0xbb, 0xaa}, d.TransactionID)
+	d = WithTransactionID(TransactionID{0xdd, 0xcc, 0xbb, 0xaa})(d)
+	require.Equal(t, TransactionID{0xdd, 0xcc, 0xbb, 0xaa}, d.TransactionID)
 }
 
 func TestBroadcastModifier(t *testing.T) {

--- a/dhcpv4/modifiers_test.go
+++ b/dhcpv4/modifiers_test.go
@@ -10,8 +10,8 @@ import (
 func TestTransactionIDModifier(t *testing.T) {
 	d, err := New()
 	require.NoError(t, err)
-	d = WithTransactionID(0xddccbbaa)(d)
-	require.Equal(t, uint32(0xddccbbaa), d.TransactionID())
+	d = WithTransactionID([4]byte{0xdd, 0xcc, 0xbb, 0xaa})(d)
+	require.Equal(t, [4]byte{0xdd, 0xcc, 0xbb, 0xaa}, d.TransactionID)
 }
 
 func TestBroadcastModifier(t *testing.T) {
@@ -28,9 +28,9 @@ func TestBroadcastModifier(t *testing.T) {
 func TestHwAddrModifier(t *testing.T) {
 	d, err := New()
 	require.NoError(t, err)
-	hwaddr := [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
+	hwaddr := net.HardwareAddr{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
 	d = WithHwAddr(hwaddr[:])(d)
-	require.Equal(t, hwaddr, d.ClientHwAddr())
+	require.Equal(t, hwaddr, d.ClientHWAddr)
 }
 
 func TestWithOptionModifier(t *testing.T) {
@@ -53,8 +53,8 @@ func TestUserClassModifier(t *testing.T) {
 		9,  // length
 		'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
-	require.Equal(t, "User Class Information -> linuxboot", d.options[0].String())
-	require.Equal(t, expected, d.options[0].ToBytes())
+	require.Equal(t, "User Class Information -> linuxboot", d.Options[0].String())
+	require.Equal(t, expected, d.Options[0].ToBytes())
 }
 
 func TestUserClassModifierRFC(t *testing.T) {
@@ -66,14 +66,14 @@ func TestUserClassModifierRFC(t *testing.T) {
 		10, // length
 		9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
-	require.Equal(t, "User Class Information -> linuxboot", d.options[0].String())
-	require.Equal(t, expected, d.options[0].ToBytes())
+	require.Equal(t, "User Class Information -> linuxboot", d.Options[0].String())
+	require.Equal(t, expected, d.Options[0].ToBytes())
 }
 
 func TestWithNetboot(t *testing.T) {
 	d, _ := New()
 	d = WithNetboot(d)
-	require.Equal(t, "Parameter Request List -> [TFTP Server Name, Bootfile Name]", d.options[0].String())
+	require.Equal(t, "Parameter Request List -> [TFTP Server Name, Bootfile Name]", d.Options[0].String())
 }
 
 func TestWithNetbootExistingTFTP(t *testing.T) {
@@ -83,7 +83,7 @@ func TestWithNetbootExistingTFTP(t *testing.T) {
 	}
 	d.AddOption(OptParams)
 	d = WithNetboot(d)
-	require.Equal(t, "Parameter Request List -> [TFTP Server Name, Bootfile Name]", d.options[0].String())
+	require.Equal(t, "Parameter Request List -> [TFTP Server Name, Bootfile Name]", d.Options[0].String())
 }
 
 func TestWithNetbootExistingBootfileName(t *testing.T) {
@@ -93,7 +93,7 @@ func TestWithNetbootExistingBootfileName(t *testing.T) {
 	}
 	d.AddOption(OptParams)
 	d = WithNetboot(d)
-	require.Equal(t, "Parameter Request List -> [Bootfile Name, TFTP Server Name]", d.options[0].String())
+	require.Equal(t, "Parameter Request List -> [Bootfile Name, TFTP Server Name]", d.Options[0].String())
 }
 
 func TestWithNetbootExistingBoth(t *testing.T) {
@@ -103,7 +103,7 @@ func TestWithNetbootExistingBoth(t *testing.T) {
 	}
 	d.AddOption(OptParams)
 	d = WithNetboot(d)
-	require.Equal(t, "Parameter Request List -> [Bootfile Name, TFTP Server Name]", d.options[0].String())
+	require.Equal(t, "Parameter Request List -> [Bootfile Name, TFTP Server Name]", d.Options[0].String())
 }
 
 func TestWithRequestedOptions(t *testing.T) {
@@ -133,34 +133,34 @@ func TestWithRelay(t *testing.T) {
 	d = WithRelay(ip)(d)
 	require.NotNil(t, d)
 	require.True(t, d.IsUnicast(), "expected unicast")
-	require.Equal(t, ip, d.GatewayIPAddr())
-	require.Equal(t, uint8(1), d.HopCount())
+	require.Equal(t, ip, d.GatewayIPAddr)
+	require.Equal(t, uint8(1), d.HopCount)
 }
 
 func TestWithNetmask(t *testing.T) {
 	d := &DHCPv4{}
 	d = WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
-	require.Equal(t, 1, len(d.options))
-	require.Equal(t, OptionSubnetMask, d.options[0].Code())
-	osm := d.options[0].(*OptSubnetMask)
+	require.Equal(t, 1, len(d.Options))
+	require.Equal(t, OptionSubnetMask, d.Options[0].Code())
+	osm := d.Options[0].(*OptSubnetMask)
 	require.Equal(t, net.IPv4Mask(255, 255, 255, 0), osm.SubnetMask)
 }
 
 func TestWithLeaseTime(t *testing.T) {
 	d := &DHCPv4{}
 	d = WithLeaseTime(uint32(3600))(d)
-	require.Equal(t, 1, len(d.options))
-	require.Equal(t, OptionIPAddressLeaseTime, d.options[0].Code())
-	olt := d.options[0].(*OptIPAddressLeaseTime)
+	require.Equal(t, 1, len(d.Options))
+	require.Equal(t, OptionIPAddressLeaseTime, d.Options[0].Code())
+	olt := d.Options[0].(*OptIPAddressLeaseTime)
 	require.Equal(t, uint32(3600), olt.LeaseTime)
 }
 
 func TestWithDNS(t *testing.T) {
 	d := &DHCPv4{}
 	d = WithDNS(net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.2"))(d)
-	require.Equal(t, 1, len(d.options))
-	require.Equal(t, OptionDomainNameServer, d.options[0].Code())
-	olt := d.options[0].(*OptDomainNameServer)
+	require.Equal(t, 1, len(d.Options))
+	require.Equal(t, OptionDomainNameServer, d.Options[0].Code())
+	olt := d.Options[0].(*OptDomainNameServer)
 	require.Equal(t, 2, len(olt.NameServers))
 	require.Equal(t, net.ParseIP("10.0.0.1"), olt.NameServers[0])
 	require.Equal(t, net.ParseIP("10.0.0.2"), olt.NameServers[1])
@@ -170,8 +170,8 @@ func TestWithDNS(t *testing.T) {
 func TestWithDomainSearchList(t *testing.T) {
 	d := &DHCPv4{}
 	d = WithDomainSearchList("slackware.it", "dhcp.slackware.it")(d)
-	require.Equal(t, 1, len(d.options))
-	osl := d.options[0].(*OptDomainSearch)
+	require.Equal(t, 1, len(d.Options))
+	osl := d.Options[0].(*OptDomainSearch)
 	require.Equal(t, OptionDNSDomainSearchList, osl.Code())
 	require.NotNil(t, osl.DomainSearch)
 	require.Equal(t, 2, len(osl.DomainSearch.Labels))
@@ -183,8 +183,8 @@ func TestWithRouter(t *testing.T) {
 	d := &DHCPv4{}
 	rtr := net.ParseIP("10.0.0.254")
 	d = WithRouter(rtr)(d)
-	require.Equal(t, 1, len(d.options))
-	ortr := d.options[0].(*OptRouter)
+	require.Equal(t, 1, len(d.Options))
+	ortr := d.Options[0].(*OptRouter)
 	require.Equal(t, OptionRouter, ortr.Code())
 	require.Equal(t, 1, len(ortr.Routers))
 	require.Equal(t, rtr, ortr.Routers[0])

--- a/dhcpv4/option_archtype.go
+++ b/dhcpv4/option_archtype.go
@@ -55,6 +55,9 @@ func (o *OptClientArchType) String() string {
 // or error if any.
 func ParseOptClientArchType(data []byte) (*OptClientArchType, error) {
 	buf := uio.NewBigEndianBuffer(data)
+	if buf.Len() == 0 {
+		return nil, fmt.Errorf("must have at least one archtype if option is present")
+	}
 
 	archTypes := make([]iana.ArchType, 0, buf.Len()/2)
 	for buf.Has(2) {

--- a/dhcpv4/option_archtype.go
+++ b/dhcpv4/option_archtype.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/insomniacslk/dhcp/iana"
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 // OptClientArchType represents an option encapsulating the Client System
@@ -35,7 +36,7 @@ func (o *OptClientArchType) ToBytes() []byte {
 // Length returns the length of the data portion (excluding option code an byte
 // length).
 func (o *OptClientArchType) Length() int {
-	return 2*len(o.ArchTypes)
+	return 2 * len(o.ArchTypes)
 }
 
 // String returns a human-readable string.
@@ -53,24 +54,11 @@ func (o *OptClientArchType) String() string {
 // ParseOptClientArchType returns a new OptClientArchType from a byte stream,
 // or error if any.
 func ParseOptClientArchType(data []byte) (*OptClientArchType, error) {
-	if len(data) < 2 {
-		return nil, ErrShortByteStream
+	buf := uio.NewBigEndianBuffer(data)
+
+	archTypes := make([]iana.ArchType, 0, buf.Len()/2)
+	for buf.Has(2) {
+		archTypes = append(archTypes, iana.ArchType(buf.Read16()))
 	}
-	code := OptionCode(data[0])
-	if code != OptionClientSystemArchitectureType {
-		return nil, fmt.Errorf("expected code %v, got %v", OptionClientSystemArchitectureType, code)
-	}
-	length := int(data[1])
-	if length == 0 || length%2 != 0 {
-		return nil, fmt.Errorf("Invalid length: expected multiple of 2 larger than 2, got %v", length)
-	}
-	if len(data) < 2+length {
-		return nil, ErrShortByteStream
-	}
-	archTypes := make([]iana.ArchType, 0, length%2)
-	for idx := 0; idx < length; idx += 2 {
-		b := data[2+idx : 2+idx+2]
-		archTypes = append(archTypes, iana.ArchType(binary.BigEndian.Uint16(b)))
-	}
-	return &OptClientArchType{ArchTypes: archTypes}, nil
+	return &OptClientArchType{ArchTypes: archTypes}, buf.FinError()
 }

--- a/dhcpv4/option_archtype_test.go
+++ b/dhcpv4/option_archtype_test.go
@@ -13,7 +13,7 @@ func TestParseOptClientArchType(t *testing.T) {
 		2,    // Length
 		0, 6, // EFI_IA32
 	}
-	opt, err := ParseOptClientArchType(data)
+	opt, err := ParseOptClientArchType(data[2:])
 	require.NoError(t, err)
 	require.Equal(t, opt.ArchTypes[0], iana.EFI_IA32)
 }
@@ -25,7 +25,7 @@ func TestParseOptClientArchTypeMultiple(t *testing.T) {
 		0, 6, // EFI_IA32
 		0, 2, // EFI_ITANIUM
 	}
-	opt, err := ParseOptClientArchType(data)
+	opt, err := ParseOptClientArchType(data[2:])
 	require.NoError(t, err)
 	require.Equal(t, opt.ArchTypes[0], iana.EFI_IA32)
 	require.Equal(t, opt.ArchTypes[1], iana.EFI_ITANIUM)
@@ -43,7 +43,7 @@ func TestOptClientArchTypeParseAndToBytes(t *testing.T) {
 		2,    // Length
 		0, 8, // EFI_XSCALE
 	}
-	opt, err := ParseOptClientArchType(data)
+	opt, err := ParseOptClientArchType(data[2:])
 	require.NoError(t, err)
 	require.Equal(t, opt.ToBytes(), data)
 }
@@ -55,7 +55,7 @@ func TestOptClientArchTypeParseAndToBytesMultiple(t *testing.T) {
 		0, 8, // EFI_XSCALE
 		0, 6, // EFI_IA32
 	}
-	opt, err := ParseOptClientArchType(data)
+	opt, err := ParseOptClientArchType(data[2:])
 	require.NoError(t, err)
 	require.Equal(t, opt.ToBytes(), data)
 }

--- a/dhcpv4/option_bootfile_name.go
+++ b/dhcpv4/option_bootfile_name.go
@@ -9,7 +9,7 @@ import (
 
 // OptBootfileName implements the BootFile Name option
 type OptBootfileName struct {
-	BootfileName []byte
+	BootfileName string
 }
 
 // Code returns the option code
@@ -19,7 +19,7 @@ func (op *OptBootfileName) Code() OptionCode {
 
 // ToBytes serializes the option and returns it as a sequence of bytes
 func (op *OptBootfileName) ToBytes() []byte {
-	return append([]byte{byte(op.Code()), byte(op.Length())}, op.BootfileName...)
+	return append([]byte{byte(op.Code()), byte(op.Length())}, []byte(op.BootfileName)...)
 }
 
 // Length returns the option length in bytes
@@ -34,21 +34,5 @@ func (op *OptBootfileName) String() string {
 
 // ParseOptBootfileName returns a new OptBootfile from a byte stream or error if any
 func ParseOptBootfileName(data []byte) (*OptBootfileName, error) {
-	if len(data) < 3 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	if code != OptionBootfileName {
-		return nil, fmt.Errorf("ParseOptBootfileName: invalid code: %v; want %v", code, OptionBootfileName)
-	}
-	length := int(data[1])
-	if length < 1 {
-		return nil, fmt.Errorf("Bootfile name has invalid length of %d", length)
-	}
-	bootFileNameData := data[2:]
-	if len(bootFileNameData) < length {
-		return nil, fmt.Errorf("ParseOptBootfileName: short data: %d bytes; want %d",
-			len(bootFileNameData), length)
-	}
-	return &OptBootfileName{BootfileName: bootFileNameData[:length]}, nil
+	return &OptBootfileName{BootfileName: string(data)}, nil
 }

--- a/dhcpv4/option_bootfile_name_test.go
+++ b/dhcpv4/option_bootfile_name_test.go
@@ -13,7 +13,7 @@ func TestOptBootfileNameCode(t *testing.T) {
 
 func TestOptBootfileNameToBytes(t *testing.T) {
 	opt := OptBootfileName{
-		BootfileName: []byte("linuxboot"),
+		BootfileName: "linuxboot",
 	}
 	data := opt.ToBytes()
 	expected := []byte{
@@ -26,40 +26,15 @@ func TestOptBootfileNameToBytes(t *testing.T) {
 
 func TestParseOptBootfileName(t *testing.T) {
 	expected := []byte{
-		67, 9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
+		'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
 	opt, err := ParseOptBootfileName(expected)
 	require.NoError(t, err)
 	require.Equal(t, 9, opt.Length())
-	require.Equal(t, "linuxboot", string(opt.BootfileName))
-}
-
-func TestParseOptBootfileNameZeroLength(t *testing.T) {
-	expected := []byte{
-		67, 0,
-	}
-	_, err := ParseOptBootfileName(expected)
-	require.Error(t, err)
-}
-
-func TestParseOptBootfileNameInvalidLength(t *testing.T) {
-	expected := []byte{
-		67, 9, 'l', 'i', 'n', 'u', 'x', 'b',
-	}
-	_, err := ParseOptBootfileName(expected)
-	require.Error(t, err)
-}
-
-func TestParseOptBootfileNameShortLength(t *testing.T) {
-	expected := []byte{
-		67, 4, 'l', 'i', 'n', 'u', 'x',
-	}
-	opt, err := ParseOptBootfileName(expected)
-	require.NoError(t, err)
-	require.Equal(t, []byte("linu"), opt.BootfileName)
+	require.Equal(t, "linuxboot", opt.BootfileName)
 }
 
 func TestOptBootfileNameString(t *testing.T) {
-	o := OptBootfileName{BootfileName: []byte("testy test")}
+	o := OptBootfileName{BootfileName: "testy test"}
 	require.Equal(t, "Bootfile Name -> testy test", o.String())
 }

--- a/dhcpv4/option_broadcast_address.go
+++ b/dhcpv4/option_broadcast_address.go
@@ -3,6 +3,8 @@ package dhcpv4
 import (
 	"fmt"
 	"net"
+
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 // This option implements the server identifier option
@@ -16,21 +18,8 @@ type OptBroadcastAddress struct {
 // ParseOptBroadcastAddress returns a new OptBroadcastAddress from a byte
 // stream, or error if any.
 func ParseOptBroadcastAddress(data []byte) (*OptBroadcastAddress, error) {
-	if len(data) < 2 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	if code != OptionBroadcastAddress {
-		return nil, fmt.Errorf("expected code %v, got %v", OptionBroadcastAddress, code)
-	}
-	length := int(data[1])
-	if length != 4 {
-		return nil, fmt.Errorf("unexepcted length: expected 4, got %v", length)
-	}
-	if len(data) < 6 {
-		return nil, ErrShortByteStream
-	}
-	return &OptBroadcastAddress{BroadcastAddress: net.IP(data[2 : 2+length])}, nil
+	buf := uio.NewBigEndianBuffer(data)
+	return &OptBroadcastAddress{BroadcastAddress: net.IP(buf.CopyN(net.IPv4len))}, buf.FinError()
 }
 
 // Code returns the option code.

--- a/dhcpv4/option_broadcast_address_test.go
+++ b/dhcpv4/option_broadcast_address_test.go
@@ -29,16 +29,10 @@ func TestParseOptBroadcastAddress(t *testing.T) {
 	o, err = ParseOptBroadcastAddress([]byte{})
 	require.Error(t, err, "empty byte stream")
 
-	o, err = ParseOptBroadcastAddress([]byte{byte(OptionBroadcastAddress), 4, 192})
-	require.Error(t, err, "short byte stream")
-
-	o, err = ParseOptBroadcastAddress([]byte{byte(OptionBroadcastAddress), 3, 192, 168, 0, 1})
+	o, err = ParseOptBroadcastAddress([]byte{192, 168, 0})
 	require.Error(t, err, "wrong IP length")
 
-	o, err = ParseOptBroadcastAddress([]byte{53, 4, 192, 168, 1})
-	require.Error(t, err, "wrong option code")
-
-	o, err = ParseOptBroadcastAddress([]byte{byte(OptionBroadcastAddress), 4, 192, 168, 0, 1})
+	o, err = ParseOptBroadcastAddress([]byte{192, 168, 0, 1})
 	require.NoError(t, err)
 	require.Equal(t, net.IP{192, 168, 0, 1}, o.BroadcastAddress)
 }

--- a/dhcpv4/option_class_identifier.go
+++ b/dhcpv4/option_class_identifier.go
@@ -15,19 +15,7 @@ type OptClassIdentifier struct {
 // ParseOptClassIdentifier constructs an OptClassIdentifier struct from a sequence of
 // bytes and returns it, or an error.
 func ParseOptClassIdentifier(data []byte) (*OptClassIdentifier, error) {
-	// Should at least have code and length
-	if len(data) < 2 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	if code != OptionClassIdentifier {
-		return nil, fmt.Errorf("expected option %v, got %v instead", OptionClassIdentifier, code)
-	}
-	length := int(data[1])
-	if len(data) < 2+length {
-		return nil, ErrShortByteStream
-	}
-	return &OptClassIdentifier{Identifier: string(data[2 : 2+length])}, nil
+	return &OptClassIdentifier{Identifier: string(data)}, nil
 }
 
 // Code returns the option code.

--- a/dhcpv4/option_class_identifier_test.go
+++ b/dhcpv4/option_class_identifier_test.go
@@ -14,25 +14,10 @@ func TestOptClassIdentifierInterfaceMethods(t *testing.T) {
 }
 
 func TestParseOptClassIdentifier(t *testing.T) {
-	data := []byte{byte(OptionClassIdentifier), 4, 't', 'e', 's', 't'} // DISCOVER
+	data := []byte{'t', 'e', 's', 't'}
 	o, err := ParseOptClassIdentifier(data)
 	require.NoError(t, err)
 	require.Equal(t, &OptClassIdentifier{Identifier: "test"}, o)
-
-	// Short byte stream
-	data = []byte{byte(OptionClassIdentifier)}
-	_, err = ParseOptClassIdentifier(data)
-	require.Error(t, err, "should get error from short byte stream")
-
-	// Wrong code
-	data = []byte{54, 2, 1, 1}
-	_, err = ParseOptClassIdentifier(data)
-	require.Error(t, err, "should get error from wrong code")
-
-	// Bad length
-	data = []byte{byte(OptionClassIdentifier), 6, 1, 1, 1}
-	_, err = ParseOptClassIdentifier(data)
-	require.Error(t, err, "should get error from bad length")
 }
 
 func TestOptClassIdentifierString(t *testing.T) {

--- a/dhcpv4/option_domain_name.go
+++ b/dhcpv4/option_domain_name.go
@@ -13,18 +13,7 @@ type OptDomainName struct {
 // ParseOptDomainName returns a new OptDomainName from a byte
 // stream, or error if any.
 func ParseOptDomainName(data []byte) (*OptDomainName, error) {
-	if len(data) < 3 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	if code != OptionDomainName {
-		return nil, fmt.Errorf("expected code %v, got %v", OptionDomainName, code)
-	}
-	length := int(data[1])
-	if len(data) < 2+length {
-		return nil, ErrShortByteStream
-	}
-	return &OptDomainName{DomainName: string(data[2 : 2+length])}, nil
+	return &OptDomainName{DomainName: string(data)}, nil
 }
 
 // Code returns the option code.

--- a/dhcpv4/option_domain_name_server.go
+++ b/dhcpv4/option_domain_name_server.go
@@ -17,26 +17,11 @@ type OptDomainNameServer struct {
 // ParseOptDomainNameServer returns a new OptDomainNameServer from a byte
 // stream, or error if any.
 func ParseOptDomainNameServer(data []byte) (*OptDomainNameServer, error) {
-	if len(data) < 2 {
-		return nil, ErrShortByteStream
+	ips, err := ParseIPs(data)
+	if err != nil {
+		return nil, err
 	}
-	code := OptionCode(data[0])
-	if code != OptionDomainNameServer {
-		return nil, fmt.Errorf("expected code %v, got %v", OptionDomainNameServer, code)
-	}
-	length := int(data[1])
-	if length == 0 || length%4 != 0 {
-		return nil, fmt.Errorf("Invalid length: expected multiple of 4 larger than 4, got %v", length)
-	}
-	if len(data) < 2+length {
-		return nil, ErrShortByteStream
-	}
-	nameservers := make([]net.IP, 0, length%4)
-	for idx := 0; idx < length; idx += 4 {
-		b := data[2+idx : 2+idx+4]
-		nameservers = append(nameservers, net.IPv4(b[0], b[1], b[2], b[3]))
-	}
-	return &OptDomainNameServer{NameServers: nameservers}, nil
+	return &OptDomainNameServer{NameServers: ips}, nil
 }
 
 // Code returns the option code.

--- a/dhcpv4/option_domain_name_server_test.go
+++ b/dhcpv4/option_domain_name_server_test.go
@@ -25,37 +25,23 @@ func TestParseOptDomainNameServer(t *testing.T) {
 		192, 168, 0, 10, // DNS #1
 		192, 168, 0, 20, // DNS #2
 	}
-	o, err := ParseOptDomainNameServer(data)
+	o, err := ParseOptDomainNameServer(data[2:])
 	require.NoError(t, err)
 	servers := []net.IP{
-		net.IPv4(192, 168, 0, 10),
-		net.IPv4(192, 168, 0, 20),
+		net.IP{192, 168, 0, 10},
+		net.IP{192, 168, 0, 20},
 	}
 	require.Equal(t, &OptDomainNameServer{NameServers: servers}, o)
 
-	// Short byte stream
-	data = []byte{byte(OptionDomainNameServer)}
-	_, err = ParseOptDomainNameServer(data)
-	require.Error(t, err, "should get error from short byte stream")
-
-	// Wrong code
-	data = []byte{54, 2, 1, 1}
-	_, err = ParseOptDomainNameServer(data)
-	require.Error(t, err, "should get error from wrong code")
-
 	// Bad length
-	data = []byte{byte(OptionDomainNameServer), 6, 1, 1, 1}
+	data = []byte{1, 1, 1}
 	_, err = ParseOptDomainNameServer(data)
 	require.Error(t, err, "should get error from bad length")
 }
 
 func TestParseOptDomainNameServerNoServers(t *testing.T) {
 	// RFC2132 requires that at least one DNS server IP is specified
-	data := []byte{
-		byte(OptionDomainNameServer),
-		0, // Length
-	}
-	_, err := ParseOptDomainNameServer(data)
+	_, err := ParseOptDomainNameServer([]byte{})
 	require.Error(t, err)
 }
 

--- a/dhcpv4/option_domain_name_test.go
+++ b/dhcpv4/option_domain_name_test.go
@@ -14,25 +14,10 @@ func TestOptDomainNameInterfaceMethods(t *testing.T) {
 }
 
 func TestParseOptDomainName(t *testing.T) {
-	data := []byte{byte(OptionDomainName), 4, 't', 'e', 's', 't'} // DISCOVER
+	data := []byte{'t', 'e', 's', 't'}
 	o, err := ParseOptDomainName(data)
 	require.NoError(t, err)
 	require.Equal(t, &OptDomainName{DomainName: "test"}, o)
-
-	// Short byte stream
-	data = []byte{byte(OptionDomainName)}
-	_, err = ParseOptDomainName(data)
-	require.Error(t, err, "should get error from short byte stream")
-
-	// Wrong code
-	data = []byte{54, 2, 1, 1}
-	_, err = ParseOptDomainName(data)
-	require.Error(t, err, "should get error from wrong code")
-
-	// Bad length
-	data = []byte{byte(OptionDomainName), 6, 1, 1, 1}
-	_, err = ParseOptDomainName(data)
-	require.Error(t, err, "should get error from bad length")
 }
 
 func TestOptDomainNameString(t *testing.T) {

--- a/dhcpv4/option_domain_search.go
+++ b/dhcpv4/option_domain_search.go
@@ -43,18 +43,7 @@ func (op *OptDomainSearch) String() string {
 // ParseOptDomainSearch returns a new OptDomainSearch from a byte stream, or
 // error if any.
 func ParseOptDomainSearch(data []byte) (*OptDomainSearch, error) {
-	if len(data) < 2 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	if code != OptionDNSDomainSearchList {
-		return nil, fmt.Errorf("expected code %v, got %v", OptionDNSDomainSearchList, code)
-	}
-	length := int(data[1])
-	if len(data) < 2+length {
-		return nil, ErrShortByteStream
-	}
-	labels, err := rfc1035label.FromBytes(data[2 : length+2])
+	labels, err := rfc1035label.FromBytes(data)
 	if err != nil {
 		return nil, err
 	}

--- a/dhcpv4/option_domain_search_test.go
+++ b/dhcpv4/option_domain_search_test.go
@@ -14,7 +14,7 @@ func TestParseOptDomainSearch(t *testing.T) {
 		7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
 		6, 's', 'u', 'b', 'n', 'e', 't', 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'o', 'r', 'g', 0,
 	}
-	opt, err := ParseOptDomainSearch(data)
+	opt, err := ParseOptDomainSearch(data[2:])
 	require.NoError(t, err)
 	require.Equal(t, 2, len(opt.DomainSearch.Labels))
 	require.Equal(t, data[2:], opt.DomainSearch.ToBytes())

--- a/dhcpv4/option_generic.go
+++ b/dhcpv4/option_generic.go
@@ -15,23 +15,11 @@ type OptionGeneric struct {
 
 // ParseOptionGeneric parses a bytestream and creates a new OptionGeneric from
 // it, or an error.
-func ParseOptionGeneric(data []byte) (*OptionGeneric, error) {
+func ParseOptionGeneric(code OptionCode, data []byte) (Option, error) {
 	if len(data) == 0 {
 		return nil, errors.New("invalid zero-length bytestream")
 	}
-	var (
-		length     int
-		optionData []byte
-	)
-	code := OptionCode(data[0])
-	if code != OptionPad && code != OptionEnd {
-		length = int(data[1])
-		if len(data) < length+2 {
-			return nil, fmt.Errorf("invalid data length: declared %v, actual %v", length, len(data))
-		}
-		optionData = data[2 : length+2]
-	}
-	return &OptionGeneric{OptionCode: code, Data: optionData}, nil
+	return &OptionGeneric{OptionCode: code, Data: data}, nil
 }
 
 // Code returns the generic option code.

--- a/dhcpv4/option_generic_test.go
+++ b/dhcpv4/option_generic_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestParseOptionGeneric(t *testing.T) {
 	// Empty bytestream produces error
-	_, err := ParseOptionGeneric([]byte{})
+	_, err := ParseOptionGeneric(OptionHostName, []byte{})
 	require.Error(t, err, "error from empty bytestream")
 }
 
@@ -18,14 +18,6 @@ func TestOptionGenericCode(t *testing.T) {
 		Data:       []byte{byte(MessageTypeDiscover)},
 	}
 	require.Equal(t, OptionDHCPMessageType, o.Code())
-}
-
-func TestOptionGenericData(t *testing.T) {
-	o := OptionGeneric{
-		OptionCode: OptionNameServer,
-		Data:       []byte{192, 168, 0, 1},
-	}
-	require.Equal(t, []byte{192, 168, 0, 1}, o.Data)
 }
 
 func TestOptionGenericToBytes(t *testing.T) {

--- a/dhcpv4/option_host_name.go
+++ b/dhcpv4/option_host_name.go
@@ -13,18 +13,7 @@ type OptHostName struct {
 // ParseOptHostName returns a new OptHostName from a byte stream, or error if
 // any.
 func ParseOptHostName(data []byte) (*OptHostName, error) {
-	if len(data) < 3 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	if code != OptionHostName {
-		return nil, fmt.Errorf("expected code %v, got %v", OptionHostName, code)
-	}
-	length := int(data[1])
-	if len(data) < 2+length {
-		return nil, ErrShortByteStream
-	}
-	return &OptHostName{HostName: string(data[2 : 2+length])}, nil
+	return &OptHostName{HostName: string(data)}, nil
 }
 
 // Code returns the option code.

--- a/dhcpv4/option_host_name_test.go
+++ b/dhcpv4/option_host_name_test.go
@@ -14,25 +14,10 @@ func TestOptHostNameInterfaceMethods(t *testing.T) {
 }
 
 func TestParseOptHostName(t *testing.T) {
-	data := []byte{byte(OptionHostName), 4, 't', 'e', 's', 't'}
+	data := []byte{'t', 'e', 's', 't'}
 	o, err := ParseOptHostName(data)
 	require.NoError(t, err)
 	require.Equal(t, &OptHostName{HostName: "test"}, o)
-
-	// Short byte stream
-	data = []byte{byte(OptionHostName)}
-	_, err = ParseOptHostName(data)
-	require.Error(t, err, "should get error from short byte stream")
-
-	// Wrong code
-	data = []byte{54, 2, 1, 1}
-	_, err = ParseOptHostName(data)
-	require.Error(t, err, "should get error from wrong code")
-
-	// Bad length
-	data = []byte{byte(OptionHostName), 6, 1, 1, 1}
-	_, err = ParseOptHostName(data)
-	require.Error(t, err, "should get error from bad length")
 }
 
 func TestOptHostNameString(t *testing.T) {

--- a/dhcpv4/option_ip_address_lease_time.go
+++ b/dhcpv4/option_ip_address_lease_time.go
@@ -3,6 +3,8 @@ package dhcpv4
 import (
 	"encoding/binary"
 	"fmt"
+
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 // This option implements the IP Address Lease Time option
@@ -16,20 +18,9 @@ type OptIPAddressLeaseTime struct {
 // ParseOptIPAddressLeaseTime constructs an OptIPAddressLeaseTime struct from a
 // sequence of bytes and returns it, or an error.
 func ParseOptIPAddressLeaseTime(data []byte) (*OptIPAddressLeaseTime, error) {
-	// Should at least have code, length, and lease time.
-	if len(data) < 6 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	if code != OptionIPAddressLeaseTime {
-		return nil, fmt.Errorf("expected option %v, got %v instead", OptionIPAddressLeaseTime, code)
-	}
-	length := int(data[1])
-	if length != 4 {
-		return nil, fmt.Errorf("expected length 4, got %v instead", length)
-	}
-	leaseTime := binary.BigEndian.Uint32(data[2:6])
-	return &OptIPAddressLeaseTime{LeaseTime: leaseTime}, nil
+	buf := uio.NewBigEndianBuffer(data)
+	leaseTime := buf.Read32()
+	return &OptIPAddressLeaseTime{LeaseTime: leaseTime}, buf.FinError()
 }
 
 // Code returns the option code.

--- a/dhcpv4/option_ip_address_lease_time_test.go
+++ b/dhcpv4/option_ip_address_lease_time_test.go
@@ -14,23 +14,18 @@ func TestOptIPAddressLeaseTimeInterfaceMethods(t *testing.T) {
 }
 
 func TestParseOptIPAddressLeaseTime(t *testing.T) {
-	data := []byte{51, 4, 0, 0, 168, 192}
+	data := []byte{0, 0, 168, 192}
 	o, err := ParseOptIPAddressLeaseTime(data)
 	require.NoError(t, err)
 	require.Equal(t, &OptIPAddressLeaseTime{LeaseTime: 43200}, o)
 
 	// Short byte stream
-	data = []byte{51, 4, 168, 192}
+	data = []byte{168, 192}
 	_, err = ParseOptIPAddressLeaseTime(data)
 	require.Error(t, err, "should get error from short byte stream")
 
-	// Wrong code
-	data = []byte{54, 4, 0, 0, 168, 192}
-	_, err = ParseOptIPAddressLeaseTime(data)
-	require.Error(t, err, "should get error from wrong code")
-
 	// Bad length
-	data = []byte{51, 5, 1, 1, 1, 1, 1}
+	data = []byte{1, 1, 1, 1, 1}
 	_, err = ParseOptIPAddressLeaseTime(data)
 	require.Error(t, err, "should get error from bad length")
 }

--- a/dhcpv4/option_maximum_dhcp_message_size.go
+++ b/dhcpv4/option_maximum_dhcp_message_size.go
@@ -3,6 +3,8 @@ package dhcpv4
 import (
 	"encoding/binary"
 	"fmt"
+
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 // This option implements the Maximum DHCP Message size option
@@ -16,20 +18,8 @@ type OptMaximumDHCPMessageSize struct {
 // ParseOptMaximumDHCPMessageSize constructs an OptMaximumDHCPMessageSize struct from a sequence of
 // bytes and returns it, or an error.
 func ParseOptMaximumDHCPMessageSize(data []byte) (*OptMaximumDHCPMessageSize, error) {
-	// Should at least have code, length, and message size.
-	if len(data) < 4 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	if code != OptionMaximumDHCPMessageSize {
-		return nil, fmt.Errorf("expected option %v, got %v instead", OptionMaximumDHCPMessageSize, code)
-	}
-	length := int(data[1])
-	if length != 2 {
-		return nil, fmt.Errorf("expected length 2, got %v instead", length)
-	}
-	msgSize := binary.BigEndian.Uint16(data[2:4])
-	return &OptMaximumDHCPMessageSize{Size: msgSize}, nil
+	buf := uio.NewBigEndianBuffer(data)
+	return &OptMaximumDHCPMessageSize{Size: buf.Read16()}, buf.FinError()
 }
 
 // Code returns the option code.

--- a/dhcpv4/option_maximum_dhcp_message_size_test.go
+++ b/dhcpv4/option_maximum_dhcp_message_size_test.go
@@ -14,23 +14,18 @@ func TestOptMaximumDHCPMessageSizeInterfaceMethods(t *testing.T) {
 }
 
 func TestParseOptMaximumDHCPMessageSize(t *testing.T) {
-	data := []byte{57, 2, 5, 220}
+	data := []byte{5, 220}
 	o, err := ParseOptMaximumDHCPMessageSize(data)
 	require.NoError(t, err)
 	require.Equal(t, &OptMaximumDHCPMessageSize{Size: 1500}, o)
 
 	// Short byte stream
-	data = []byte{57, 2}
+	data = []byte{2}
 	_, err = ParseOptMaximumDHCPMessageSize(data)
 	require.Error(t, err, "should get error from short byte stream")
 
-	// Wrong code
-	data = []byte{54, 2, 1, 1}
-	_, err = ParseOptMaximumDHCPMessageSize(data)
-	require.Error(t, err, "should get error from wrong code")
-
 	// Bad length
-	data = []byte{57, 3, 1, 1, 1}
+	data = []byte{1, 1, 1}
 	_, err = ParseOptMaximumDHCPMessageSize(data)
 	require.Error(t, err, "should get error from bad length")
 }

--- a/dhcpv4/option_message_type.go
+++ b/dhcpv4/option_message_type.go
@@ -2,6 +2,8 @@ package dhcpv4
 
 import (
 	"fmt"
+
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 // This option implements the message type option
@@ -15,20 +17,8 @@ type OptMessageType struct {
 // ParseOptMessageType constructs an OptMessageType struct from a sequence of
 // bytes and returns it, or an error.
 func ParseOptMessageType(data []byte) (*OptMessageType, error) {
-	// Should at least have code, length, and message type.
-	if len(data) < 3 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	if code != OptionDHCPMessageType {
-		return nil, fmt.Errorf("expected option %v, got %v instead", OptionDHCPMessageType, code)
-	}
-	length := int(data[1])
-	if length != 1 {
-		return nil, ErrShortByteStream
-	}
-	messageType := MessageType(data[2])
-	return &OptMessageType{MessageType: messageType}, nil
+	buf := uio.NewBigEndianBuffer(data)
+	return &OptMessageType{MessageType: MessageType(buf.Read8())}, buf.FinError()
 }
 
 // Code returns the option code.

--- a/dhcpv4/option_message_type_test.go
+++ b/dhcpv4/option_message_type_test.go
@@ -20,23 +20,13 @@ func TestOptMessageTypeNew(t *testing.T) {
 }
 
 func TestParseOptMessageType(t *testing.T) {
-	data := []byte{53, 1, 1} // DISCOVER
+	data := []byte{1} // DISCOVER
 	o, err := ParseOptMessageType(data)
 	require.NoError(t, err)
 	require.Equal(t, &OptMessageType{MessageType: MessageTypeDiscover}, o)
 
-	// Short byte stream
-	data = []byte{53, 1}
-	_, err = ParseOptMessageType(data)
-	require.Error(t, err, "should get error from short byte stream")
-
-	// Wrong code
-	data = []byte{54, 1, 1}
-	_, err = ParseOptMessageType(data)
-	require.Error(t, err, "should get error from wrong code")
-
 	// Bad length
-	data = []byte{53, 5, 1}
+	data = []byte{1, 2}
 	_, err = ParseOptMessageType(data)
 	require.Error(t, err, "should get error from bad length")
 }

--- a/dhcpv4/option_ntp_servers.go
+++ b/dhcpv4/option_ntp_servers.go
@@ -15,26 +15,11 @@ type OptNTPServers struct {
 
 // ParseOptNTPServers returns a new OptNTPServers from a byte stream, or error if any.
 func ParseOptNTPServers(data []byte) (*OptNTPServers, error) {
-	if len(data) < 2 {
-		return nil, ErrShortByteStream
+	ips, err := ParseIPs(data)
+	if err != nil {
+		return nil, err
 	}
-	code := OptionCode(data[0])
-	if code != OptionNTPServers {
-		return nil, fmt.Errorf("expected code %v, got %v", OptionNTPServers, code)
-	}
-	length := int(data[1])
-	if length == 0 || length%4 != 0 {
-		return nil, fmt.Errorf("Invalid length: expected multiple of 4 larger than 4, got %v", length)
-	}
-	if len(data) < 2+length {
-		return nil, ErrShortByteStream
-	}
-	ntpServers := make([]net.IP, 0, length%4)
-	for idx := 0; idx < length; idx += 4 {
-		b := data[2+idx : 2+idx+4]
-		ntpServers = append(ntpServers, net.IPv4(b[0], b[1], b[2], b[3]))
-	}
-	return &OptNTPServers{NTPServers: ntpServers}, nil
+	return &OptNTPServers{NTPServers: ips}, nil
 }
 
 // Code returns the option code.

--- a/dhcpv4/option_ntp_servers_test.go
+++ b/dhcpv4/option_ntp_servers_test.go
@@ -25,37 +25,23 @@ func TestParseOptNTPServers(t *testing.T) {
 		192, 168, 0, 10, // NTP server #1
 		192, 168, 0, 20, // NTP server #2
 	}
-	o, err := ParseOptNTPServers(data)
+	o, err := ParseOptNTPServers(data[2:])
 	require.NoError(t, err)
 	ntpServers := []net.IP{
-		net.IPv4(192, 168, 0, 10),
-		net.IPv4(192, 168, 0, 20),
+		net.IP{192, 168, 0, 10},
+		net.IP{192, 168, 0, 20},
 	}
 	require.Equal(t, &OptNTPServers{NTPServers: ntpServers}, o)
 
-	// Short byte stream
-	data = []byte{byte(OptionNTPServers)}
-	_, err = ParseOptNTPServers(data)
-	require.Error(t, err, "should get error from short byte stream")
-
-	// Wrong code
-	data = []byte{54, 2, 1, 1}
-	_, err = ParseOptNTPServers(data)
-	require.Error(t, err, "should get error from wrong code")
-
 	// Bad length
-	data = []byte{byte(OptionNTPServers), 6, 1, 1, 1}
+	data = []byte{1, 1, 1}
 	_, err = ParseOptNTPServers(data)
 	require.Error(t, err, "should get error from bad length")
 }
 
 func TestParseOptNTPserversNoNTPServers(t *testing.T) {
 	// RFC2132 requires that at least one NTP server IP is specified
-	data := []byte{
-		byte(OptionNTPServers),
-		0, // Length
-	}
-	_, err := ParseOptNTPServers(data)
+	_, err := ParseOptNTPServers([]byte{})
 	require.Error(t, err)
 }
 

--- a/dhcpv4/option_parameter_request_list_test.go
+++ b/dhcpv4/option_parameter_request_list_test.go
@@ -23,16 +23,7 @@ func TestParseOptParameterRequestList(t *testing.T) {
 		o   *OptParameterRequestList
 		err error
 	)
-	o, err = ParseOptParameterRequestList([]byte{})
-	require.Error(t, err, "empty byte stream")
-
-	o, err = ParseOptParameterRequestList([]byte{55, 2})
-	require.Error(t, err, "short byte stream")
-
-	o, err = ParseOptParameterRequestList([]byte{53, 2, 1, 1})
-	require.Error(t, err, "wrong option code")
-
-	o, err = ParseOptParameterRequestList([]byte{55, 2, 67, 5})
+	o, err = ParseOptParameterRequestList([]byte{67, 5})
 	require.NoError(t, err)
 	expectedOpts := []OptionCode{OptionBootfileName, OptionNameServer}
 	require.Equal(t, expectedOpts, o.RequestedOpts)

--- a/dhcpv4/option_relay_agent_information.go
+++ b/dhcpv4/option_relay_agent_information.go
@@ -8,40 +8,17 @@ import "fmt"
 // OptRelayAgentInformation is a "container" option for specific agent-supplied
 // sub-options.
 type OptRelayAgentInformation struct {
-	Options []Option
+	Options Options
 }
 
 // ParseOptRelayAgentInformation returns a new OptRelayAgentInformation from a
 // byte stream, or error if any.
 func ParseOptRelayAgentInformation(data []byte) (*OptRelayAgentInformation, error) {
-	if len(data) < 4 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	if code != OptionRelayAgentInformation {
-		return nil, fmt.Errorf("expected code %v, got %v", OptionRelayAgentInformation, code)
-	}
-	length := int(data[1])
-	if len(data) < 2+length {
-		return nil, ErrShortByteStream
-	}
-	options, err := OptionsFromBytesWithParser(data[2:length+2], relayParseOption)
+	options, err := OptionsFromBytesWithParser(data, ParseOptionGeneric, false /* don't check for OptionEnd tag */)
 	if err != nil {
 		return nil, err
 	}
 	return &OptRelayAgentInformation{Options: options}, nil
-}
-
-func relayParseOption(data []byte) (Option, error) {
-	if len(data) < 2 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	length := int(data[1])
-	if len(data) < 2+length {
-		return nil, ErrShortByteStream
-	}
-	return &OptionGeneric{OptionCode: code, Data: data[2:length+2]}, nil
 }
 
 // Code returns the option code.

--- a/dhcpv4/option_relay_agent_information_test.go
+++ b/dhcpv4/option_relay_agent_information_test.go
@@ -14,33 +14,21 @@ func TestParseOptRelayAgentInformation(t *testing.T) {
 		2, 4, 'b', 'o', 'o', 't',
 	}
 
-	// short option bytes
-	opt, err := ParseOptRelayAgentInformation([]byte{})
-	require.Error(t, err)
-
-	// wrong code
-	opt, err = ParseOptRelayAgentInformation([]byte{1, 2, 1, 0})
-	require.Error(t, err)
-
-	// wrong option length
-	opt, err = ParseOptRelayAgentInformation([]byte{82, 3, 1, 0})
-	require.Error(t, err)
-
 	// short sub-option bytes
-	opt, err = ParseOptRelayAgentInformation([]byte{82, 3, 1, 0, 1})
+	opt, err := ParseOptRelayAgentInformation([]byte{1, 0, 1})
 	require.Error(t, err)
 
 	// short sub-option length
-	opt, err = ParseOptRelayAgentInformation([]byte{82, 2, 1, 1})
+	opt, err = ParseOptRelayAgentInformation([]byte{1, 1})
 	require.Error(t, err)
 
-	opt, err = ParseOptRelayAgentInformation(data)
+	opt, err = ParseOptRelayAgentInformation(data[2:])
 	require.NoError(t, err)
 	require.Equal(t, len(opt.Options), 2)
-	circuit, ok := opt.Options[0].(*OptionGeneric)
-	require.True(t, ok)
-	remote, ok := opt.Options[1].(*OptionGeneric)
-	require.True(t, ok)
+	circuit := opt.Options.GetOneOption(1).(*OptionGeneric)
+	require.NoError(t, err)
+	remote := opt.Options.GetOneOption(2).(*OptionGeneric)
+	require.NoError(t, err)
 	require.Equal(t, circuit.Data, []byte("linux"))
 	require.Equal(t, remote.Data, []byte("boot"))
 }

--- a/dhcpv4/option_requested_ip_address.go
+++ b/dhcpv4/option_requested_ip_address.go
@@ -3,6 +3,8 @@ package dhcpv4
 import (
 	"fmt"
 	"net"
+
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 // This option implements the requested IP address option
@@ -17,21 +19,8 @@ type OptRequestedIPAddress struct {
 // ParseOptRequestedIPAddress returns a new OptServerIdentifier from a byte
 // stream, or error if any.
 func ParseOptRequestedIPAddress(data []byte) (*OptRequestedIPAddress, error) {
-	if len(data) < 2 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	if code != OptionRequestedIPAddress {
-		return nil, fmt.Errorf("expected code %v, got %v", OptionRequestedIPAddress, code)
-	}
-	length := int(data[1])
-	if length != 4 {
-		return nil, fmt.Errorf("unexepcted length: expected 4, got %v", length)
-	}
-	if len(data) < 6 {
-		return nil, ErrShortByteStream
-	}
-	return &OptRequestedIPAddress{RequestedAddr: net.IP(data[2 : 2+length])}, nil
+	buf := uio.NewBigEndianBuffer(data)
+	return &OptRequestedIPAddress{RequestedAddr: net.IP(buf.CopyN(net.IPv4len))}, buf.FinError()
 }
 
 // Code returns the option code.

--- a/dhcpv4/option_requested_ip_address_test.go
+++ b/dhcpv4/option_requested_ip_address_test.go
@@ -29,16 +29,10 @@ func TestParseOptRequestedIPAddress(t *testing.T) {
 	o, err = ParseOptRequestedIPAddress([]byte{})
 	require.Error(t, err, "empty byte stream")
 
-	o, err = ParseOptRequestedIPAddress([]byte{byte(OptionRequestedIPAddress), 4, 192})
-	require.Error(t, err, "short byte stream")
-
-	o, err = ParseOptRequestedIPAddress([]byte{byte(OptionRequestedIPAddress), 3, 192, 168, 0, 1})
+	o, err = ParseOptRequestedIPAddress([]byte{192})
 	require.Error(t, err, "wrong IP length")
 
-	o, err = ParseOptRequestedIPAddress([]byte{53, 4, 192, 168, 1})
-	require.Error(t, err, "wrong option code")
-
-	o, err = ParseOptRequestedIPAddress([]byte{byte(OptionRequestedIPAddress), 4, 192, 168, 0, 1})
+	o, err = ParseOptRequestedIPAddress([]byte{192, 168, 0, 1})
 	require.NoError(t, err)
 	require.Equal(t, net.IP{192, 168, 0, 1}, o.RequestedAddr)
 }

--- a/dhcpv4/option_root_path.go
+++ b/dhcpv4/option_root_path.go
@@ -15,19 +15,7 @@ type OptRootPath struct {
 // ParseOptRootPath constructs an OptRootPath struct from a sequence of  bytes
 // and returns it, or an error.
 func ParseOptRootPath(data []byte) (*OptRootPath, error) {
-	// Should at least have code and length
-	if len(data) < 2 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	if code != OptionRootPath {
-		return nil, fmt.Errorf("expected option %v, got %v instead", OptionRootPath, code)
-	}
-	length := int(data[1])
-	if len(data) < 2+length {
-		return nil, ErrShortByteStream
-	}
-	return &OptRootPath{Path: string(data[2 : 2+length])}, nil
+	return &OptRootPath{Path: string(data)}, nil
 }
 
 // Code returns the option code.

--- a/dhcpv4/option_root_path_test.go
+++ b/dhcpv4/option_root_path_test.go
@@ -20,24 +20,9 @@ func TestOptRootPathInterfaceMethods(t *testing.T) {
 
 func TestParseOptRootPath(t *testing.T) {
 	data := []byte{byte(OptionRootPath), 4, '/', 'f', 'o', 'o'}
-	o, err := ParseOptRootPath(data)
+	o, err := ParseOptRootPath(data[2:])
 	require.NoError(t, err)
 	require.Equal(t, &OptRootPath{Path: "/foo"}, o)
-
-	// Short byte stream
-	data = []byte{byte(OptionRootPath)}
-	_, err = ParseOptRootPath(data)
-	require.Error(t, err, "should get error from short byte stream")
-
-	// Wrong code
-	data = []byte{43, 2, 1, 1}
-	_, err = ParseOptRootPath(data)
-	require.Error(t, err, "should get error from wrong code")
-
-	// Bad length
-	data = []byte{byte(OptionRootPath), 6, 1, 1, 1}
-	_, err = ParseOptRootPath(data)
-	require.Error(t, err, "should get error from bad length")
 }
 
 func TestOptRootPathString(t *testing.T) {

--- a/dhcpv4/option_router_test.go
+++ b/dhcpv4/option_router_test.go
@@ -25,11 +25,11 @@ func TestParseOptRouter(t *testing.T) {
 		192, 168, 0, 10, // Router #1
 		192, 168, 0, 20, // Router #2
 	}
-	o, err := ParseOptRouter(data)
+	o, err := ParseOptRouter(data[2:])
 	require.NoError(t, err)
 	routers := []net.IP{
-		net.IPv4(192, 168, 0, 10),
-		net.IPv4(192, 168, 0, 20),
+		net.IP{192, 168, 0, 10},
+		net.IP{192, 168, 0, 20},
 	}
 	require.Equal(t, &OptRouter{Routers: routers}, o)
 
@@ -37,16 +37,6 @@ func TestParseOptRouter(t *testing.T) {
 	data = []byte{byte(OptionRouter)}
 	_, err = ParseOptRouter(data)
 	require.Error(t, err, "should get error from short byte stream")
-
-	// Wrong code
-	data = []byte{54, 2, 1, 1}
-	_, err = ParseOptRouter(data)
-	require.Error(t, err, "should get error from wrong code")
-
-	// Bad length
-	data = []byte{byte(OptionRouter), 6, 1, 1, 1}
-	_, err = ParseOptRouter(data)
-	require.Error(t, err, "should get error from bad length")
 }
 
 func TestParseOptRouterNoRouters(t *testing.T) {
@@ -60,6 +50,6 @@ func TestParseOptRouterNoRouters(t *testing.T) {
 }
 
 func TestOptRouterString(t *testing.T) {
-	o := OptRouter{Routers: []net.IP{net.IPv4(192, 168, 0, 1), net.IPv4(192, 168, 0, 10)}}
+	o := OptRouter{Routers: []net.IP{net.IP{192, 168, 0, 1}, net.IP{192, 168, 0, 10}}}
 	require.Equal(t, "Routers -> 192.168.0.1, 192.168.0.10", o.String())
 }

--- a/dhcpv4/option_server_identifier.go
+++ b/dhcpv4/option_server_identifier.go
@@ -16,21 +16,10 @@ type OptServerIdentifier struct {
 // ParseOptServerIdentifier returns a new OptServerIdentifier from a byte
 // stream, or error if any.
 func ParseOptServerIdentifier(data []byte) (*OptServerIdentifier, error) {
-	if len(data) < 2 {
-		return nil, ErrShortByteStream
+	if len(data) != 4 {
+		return nil, fmt.Errorf("unexepcted length: expected 4, got %v", len(data))
 	}
-	code := OptionCode(data[0])
-	if code != OptionServerIdentifier {
-		return nil, fmt.Errorf("expected code %v, got %v", OptionServerIdentifier, code)
-	}
-	length := int(data[1])
-	if length != 4 {
-		return nil, fmt.Errorf("unexepcted length: expected 4, got %v", length)
-	}
-	if len(data) < 6 {
-		return nil, ErrShortByteStream
-	}
-	return &OptServerIdentifier{ServerID: net.IP(data[2 : 2+length])}, nil
+	return &OptServerIdentifier{ServerID: net.IP(data)}, nil
 }
 
 // Code returns the option code.

--- a/dhcpv4/option_server_identifier_test.go
+++ b/dhcpv4/option_server_identifier_test.go
@@ -29,16 +29,10 @@ func TestParseOptServerIdentifier(t *testing.T) {
 	o, err = ParseOptServerIdentifier([]byte{})
 	require.Error(t, err, "empty byte stream")
 
-	o, err = ParseOptServerIdentifier([]byte{54, 4, 192})
-	require.Error(t, err, "short byte stream")
-
-	o, err = ParseOptServerIdentifier([]byte{54, 3, 192, 168, 0, 1})
+	o, err = ParseOptServerIdentifier([]byte{192, 168, 0})
 	require.Error(t, err, "wrong IP length")
 
-	o, err = ParseOptServerIdentifier([]byte{53, 4, 192, 168, 1})
-	require.Error(t, err, "wrong option code")
-
-	o, err = ParseOptServerIdentifier([]byte{54, 4, 192, 168, 0, 1})
+	o, err = ParseOptServerIdentifier([]byte{192, 168, 0, 1})
 	require.NoError(t, err)
 	require.Equal(t, net.IP{192, 168, 0, 1}, o.ServerID)
 }

--- a/dhcpv4/option_subnet_mask.go
+++ b/dhcpv4/option_subnet_mask.go
@@ -3,6 +3,8 @@ package dhcpv4
 import (
 	"fmt"
 	"net"
+
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 // This option implements the subnet mask option
@@ -16,21 +18,8 @@ type OptSubnetMask struct {
 // ParseOptSubnetMask returns a new OptSubnetMask from a byte
 // stream, or error if any.
 func ParseOptSubnetMask(data []byte) (*OptSubnetMask, error) {
-	if len(data) < 2 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	if code != OptionSubnetMask {
-		return nil, fmt.Errorf("expected code %v, got %v", OptionSubnetMask, code)
-	}
-	length := int(data[1])
-	if length != 4 {
-		return nil, fmt.Errorf("unexepcted length: expected 4, got %v", length)
-	}
-	if len(data) < 6 {
-		return nil, ErrShortByteStream
-	}
-	return &OptSubnetMask{SubnetMask: net.IPMask(data[2 : 2+length])}, nil
+	buf := uio.NewBigEndianBuffer(data)
+	return &OptSubnetMask{SubnetMask: net.IPMask(buf.CopyN(net.IPv4len))}, buf.FinError()
 }
 
 // Code returns the option code.

--- a/dhcpv4/option_subnet_mask_test.go
+++ b/dhcpv4/option_subnet_mask_test.go
@@ -29,16 +29,10 @@ func TestParseOptSubnetMask(t *testing.T) {
 	o, err = ParseOptSubnetMask([]byte{})
 	require.Error(t, err, "empty byte stream")
 
-	o, err = ParseOptSubnetMask([]byte{1, 4, 255})
+	o, err = ParseOptSubnetMask([]byte{255})
 	require.Error(t, err, "short byte stream")
 
-	o, err = ParseOptSubnetMask([]byte{1, 3, 255, 255, 255, 0})
-	require.Error(t, err, "wrong IP length")
-
-	o, err = ParseOptSubnetMask([]byte{2, 4, 255, 255, 255})
-	require.Error(t, err, "wrong option code")
-
-	o, err = ParseOptSubnetMask([]byte{1, 4, 255, 255, 255, 0})
+	o, err = ParseOptSubnetMask([]byte{255, 255, 255, 0})
 	require.NoError(t, err)
 	require.Equal(t, net.IPMask{255, 255, 255, 0}, o.SubnetMask)
 }

--- a/dhcpv4/option_tftp_server_name.go
+++ b/dhcpv4/option_tftp_server_name.go
@@ -9,7 +9,7 @@ import (
 
 // OptTFTPServerName implements the TFTP server name option.
 type OptTFTPServerName struct {
-	TFTPServerName []byte
+	TFTPServerName string
 }
 
 // Code returns the option code
@@ -19,7 +19,7 @@ func (op *OptTFTPServerName) Code() OptionCode {
 
 // ToBytes serializes the option and returns it as a sequence of bytes
 func (op *OptTFTPServerName) ToBytes() []byte {
-	return append([]byte{byte(op.Code()), byte(op.Length())}, op.TFTPServerName...)
+	return append([]byte{byte(op.Code()), byte(op.Length())}, []byte(op.TFTPServerName)...)
 }
 
 // Length returns the option length in bytes
@@ -33,22 +33,5 @@ func (op *OptTFTPServerName) String() string {
 
 // ParseOptTFTPServerName returns a new OptTFTPServerName from a byte stream or error if any
 func ParseOptTFTPServerName(data []byte) (*OptTFTPServerName, error) {
-	if len(data) < 3 {
-		return nil, ErrShortByteStream
-	}
-	code := OptionCode(data[0])
-	if code != OptionTFTPServerName {
-		return nil, fmt.Errorf("ParseOptTFTPServerName: invalid code: %v; want %v",
-			code, OptionTFTPServerName)
-	}
-	length := int(data[1])
-	if length < 1 {
-		return nil, fmt.Errorf("TFTP server name has invalid length of %d", length)
-	}
-	TFTPServerNameData := data[2:]
-	if len(TFTPServerNameData) < length {
-		return nil, fmt.Errorf("ParseOptTFTPServerName: short data: %d bytes; want %d",
-			len(TFTPServerNameData), length)
-	}
-	return &OptTFTPServerName{TFTPServerName: TFTPServerNameData[:length]}, nil
+	return &OptTFTPServerName{TFTPServerName: string(data)}, nil
 }

--- a/dhcpv4/option_tftp_server_name_test.go
+++ b/dhcpv4/option_tftp_server_name_test.go
@@ -13,7 +13,7 @@ func TestOptTFTPServerNameCode(t *testing.T) {
 
 func TestOptTFTPServerNameToBytes(t *testing.T) {
 	opt := OptTFTPServerName{
-		TFTPServerName: []byte("linuxboot"),
+		TFTPServerName: "linuxboot",
 	}
 	data := opt.ToBytes()
 	expected := []byte{
@@ -26,7 +26,7 @@ func TestOptTFTPServerNameToBytes(t *testing.T) {
 
 func TestParseOptTFTPServerName(t *testing.T) {
 	expected := []byte{
-		66, 9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
+		'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
 	opt, err := ParseOptTFTPServerName(expected)
 	require.NoError(t, err)
@@ -34,32 +34,7 @@ func TestParseOptTFTPServerName(t *testing.T) {
 	require.Equal(t, "linuxboot", string(opt.TFTPServerName))
 }
 
-func TestParseOptTFTPServerNameZeroLength(t *testing.T) {
-	expected := []byte{
-		66, 0,
-	}
-	_, err := ParseOptTFTPServerName(expected)
-	require.Error(t, err)
-}
-
-func TestParseOptTFTPServerNameInvalidLength(t *testing.T) {
-	expected := []byte{
-		66, 9, 'l', 'i', 'n', 'u', 'x', 'b',
-	}
-	_, err := ParseOptTFTPServerName(expected)
-	require.Error(t, err)
-}
-
-func TestParseOptTFTPServerNameShortLength(t *testing.T) {
-	expected := []byte{
-		66, 4, 'l', 'i', 'n', 'u', 'x',
-	}
-	opt, err := ParseOptTFTPServerName(expected)
-	require.NoError(t, err)
-	require.Equal(t, []byte("linu"), opt.TFTPServerName)
-}
-
 func TestOptTFTPServerNameString(t *testing.T) {
-	o := OptTFTPServerName{TFTPServerName: []byte("testy test")}
+	o := OptTFTPServerName{TFTPServerName: "testy test"}
 	require.Equal(t, "TFTP Server Name -> testy test", o.String())
 }

--- a/dhcpv4/option_userclass_test.go
+++ b/dhcpv4/option_userclass_test.go
@@ -9,7 +9,7 @@ import (
 func TestOptUserClassToBytes(t *testing.T) {
 	opt := OptUserClass{
 		UserClasses: [][]byte{[]byte("linuxboot")},
-		Rfc3004: true,
+		Rfc3004:     true,
 	}
 	data := opt.ToBytes()
 	expected := []byte{
@@ -35,7 +35,6 @@ func TestOptUserClassMicrosoftToBytes(t *testing.T) {
 
 func TestParseOptUserClassMultiple(t *testing.T) {
 	expected := []byte{
-		77, 15,
 		9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 		4, 't', 'e', 's', 't',
 	}
@@ -54,7 +53,7 @@ func TestParseOptUserClassNone(t *testing.T) {
 
 func TestParseOptUserClassMicrosoft(t *testing.T) {
 	expected := []byte{
-		77, 9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
+		'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
 	opt, err := ParseOptUserClass(expected)
 	require.NoError(t, err)
@@ -64,7 +63,7 @@ func TestParseOptUserClassMicrosoft(t *testing.T) {
 
 func TestParseOptUserClassMicrosoftShort(t *testing.T) {
 	expected := []byte{
-		77, 1, 'l',
+		'l',
 	}
 	opt, err := ParseOptUserClass(expected)
 	require.NoError(t, err)
@@ -72,19 +71,9 @@ func TestParseOptUserClassMicrosoftShort(t *testing.T) {
 	require.Equal(t, []byte("l"), opt.UserClasses[0])
 }
 
-func TestParseOptUserClassMicrosoftLongerThanLength(t *testing.T) {
-	expected := []byte{
-		77, 9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't', 'X',
-	}
-	opt, err := ParseOptUserClass(expected)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(opt.UserClasses))
-	require.Equal(t, []byte("linuxboot"), opt.UserClasses[0])
-}
-
 func TestParseOptUserClass(t *testing.T) {
 	expected := []byte{
-		77, 10, 9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
+		9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
 	opt, err := ParseOptUserClass(expected)
 	require.NoError(t, err)
@@ -110,44 +99,18 @@ func TestOptUserClassToBytesMultiple(t *testing.T) {
 	require.Equal(t, expected, data)
 }
 
-func TestParseOptUserClassLongerThanLength(t *testing.T) {
-	expected := []byte{
-		77, 10, 9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't', 'X',
-	}
-	opt, err := ParseOptUserClass(expected)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(opt.UserClasses))
-	require.Equal(t, []byte("linuxboot"), opt.UserClasses[0])
-}
-
-func TestParseOptUserClassShorterTotalLength(t *testing.T) {
-	expected := []byte{
-		77, 11, 10, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
-	}
-	_, err := ParseOptUserClass(expected)
-	require.Error(t, err)
-}
-
 func TestOptUserClassLength(t *testing.T) {
 	expected := []byte{
-		77, 10, 9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't', 'X',
+		9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't', 'X',
 	}
 	opt, err := ParseOptUserClass(expected)
 	require.NoError(t, err)
-	require.Equal(t, 10, opt.Length())
+	require.Equal(t, 11, opt.Length())
 }
 
 func TestParseOptUserClassZeroLength(t *testing.T) {
 	expected := []byte{
-		77, 1, 0, 0,
-	}
-	_, err := ParseOptUserClass(expected)
-	require.Error(t, err)
-}
-
-func TestParseOptUserClassMultipleWithZeroLength(t *testing.T) {
-	expected := []byte{
-		77, 12, 10, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't', 0,
+		0, 0,
 	}
 	_, err := ParseOptUserClass(expected)
 	require.Error(t, err)

--- a/dhcpv4/option_vivc_test.go
+++ b/dhcpv4/option_vivc_test.go
@@ -31,36 +31,20 @@ func TestOptVIVCInterfaceMethods(t *testing.T) {
 }
 
 func TestParseOptVICO(t *testing.T) {
-	o, err := ParseOptVIVC(sampleVIVCOptRaw)
+	o, err := ParseOptVIVC(sampleVIVCOptRaw[2:])
 	require.NoError(t, err)
 	require.Equal(t, &sampleVIVCOpt, o)
 
-	// Short byte stream
-	data := []byte{byte(OptionVendorIdentifyingVendorClass)}
-	_, err = ParseOptVIVC(data)
-	require.Error(t, err, "should get error from short byte stream")
-
-	// Wrong code
-	data = []byte{54, 2, 1, 1}
-	_, err = ParseOptVIVC(data)
-	require.Error(t, err, "should get error from wrong code")
-
-	// Bad length
-	data = []byte{byte(OptionVendorIdentifyingVendorClass), 6, 1, 1, 1}
-	_, err = ParseOptVIVC(data)
-	require.Error(t, err, "should get error from bad length")
-
 	// Identifier len too long
-	data = make([]byte, len(sampleVIVCOptRaw))
-	copy(data, sampleVIVCOptRaw)
-	data[6] = 40
+	data := make([]byte, len(sampleVIVCOptRaw[2:]))
+	copy(data, sampleVIVCOptRaw[2:])
+	data[4] = 40
 	_, err = ParseOptVIVC(data)
 	require.Error(t, err, "should get error from bad length")
 
 	// Longer than length
-	data[1] = 10
-	data[6] = 5
-	o, err = ParseOptVIVC(data)
+	data[4] = 5
+	o, err = ParseOptVIVC(data[:10])
 	require.NoError(t, err)
 	require.Equal(t, o.Identifiers[0].Data, []byte("Cisco"))
 }

--- a/dhcpv4/options.go
+++ b/dhcpv4/options.go
@@ -1,9 +1,7 @@
 package dhcpv4
 
 import (
-	"bytes"
 	"errors"
-	"fmt"
 )
 
 // ErrShortByteStream is an error that is thrown any time a short byte stream is
@@ -14,9 +12,9 @@ var ErrShortByteStream = errors.New("short byte stream")
 // byte stream is encountered.
 var ErrZeroLengthByteStream = errors.New("zero-length byte stream")
 
-// MagicCookie is the magic 4-byte value at the beginning of the list of options
+// magicCookie is the magic 4-byte value at the beginning of the list of options
 // in a DHCPv4 packet.
-var MagicCookie = []byte{99, 130, 83, 99}
+var magicCookie = [4]byte{99, 130, 83, 99}
 
 // OptionCode is a single byte representing the code for a given Option.
 type OptionCode byte
@@ -91,23 +89,6 @@ func ParseOption(data []byte) (Option, error) {
 		return nil, err
 	}
 	return opt, nil
-}
-
-// OptionsFromBytes parses a sequence of bytes until the end and builds a list
-// of options from it. The sequence must contain the Magic Cookie. Returns an
-// error if any invalid option or length is found.
-func OptionsFromBytes(data []byte) ([]Option, error) {
-	if len(data) < len(MagicCookie) {
-		return nil, errors.New("invalid options: shorter than 4 bytes")
-	}
-	if !bytes.Equal(data[:len(MagicCookie)], MagicCookie) {
-		return nil, fmt.Errorf("invalid magic cookie: %v", data[:len(MagicCookie)])
-	}
-	opts, err := OptionsFromBytesWithoutMagicCookie(data[len(MagicCookie):])
-	if err != nil {
-		return nil, err
-	}
-	return opts, nil
 }
 
 // OptionsFromBytesWithoutMagicCookie parses a sequence of bytes until the end

--- a/dhcpv4/options_test.go
+++ b/dhcpv4/options_test.go
@@ -189,38 +189,3 @@ func TestParseOptionShortOption(t *testing.T) {
 	_, err := ParseOption(option)
 	require.Error(t, err, "should get error from short options")
 }
-
-func TestOptionsFromBytes(t *testing.T) {
-	options := []byte{
-		99, 130, 83, 99, // Magic Cookie
-		5, 4, 192, 168, 1, 1, // DNS
-		255,     // end
-		0, 0, 0, //padding
-	}
-	opts, err := OptionsFromBytes(options)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(opts))
-	require.Equal(t, opts[0].(*OptionGeneric), &OptionGeneric{OptionCode: OptionNameServer, Data: []byte{192, 168, 1, 1}})
-	require.Equal(t, opts[1].(*OptionGeneric), &OptionGeneric{OptionCode: OptionEnd})
-}
-
-func TestOptionsFromBytesZeroLength(t *testing.T) {
-	options := []byte{}
-	_, err := OptionsFromBytes(options)
-	require.Error(t, err)
-}
-
-func TestOptionsFromBytesBadMagicCookie(t *testing.T) {
-	options := []byte{1, 2, 3, 4}
-	_, err := OptionsFromBytes(options)
-	require.Error(t, err)
-}
-
-func TestOptionsFromBytesShortOption(t *testing.T) {
-	options := []byte{
-		99, 130, 83, 99, // Magic Cookie
-		5, 4, 192, 168, // DNS
-	}
-	_, err := OptionsFromBytes(options)
-	require.Error(t, err)
-}

--- a/dhcpv4/options_test.go
+++ b/dhcpv4/options_test.go
@@ -9,7 +9,7 @@ import (
 func TestParseOption(t *testing.T) {
 	// Generic
 	option := []byte{5, 4, 192, 168, 1, 254} // DNS option
-	opt, err := ParseOption(option)
+	opt, err := ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	generic := opt.(*OptionGeneric)
 	require.Equal(t, OptionNameServer, generic.Code())
@@ -19,7 +19,7 @@ func TestParseOption(t *testing.T) {
 
 	// Option subnet mask
 	option = []byte{1, 4, 255, 255, 255, 0}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionSubnetMask, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
@@ -27,7 +27,7 @@ func TestParseOption(t *testing.T) {
 
 	// Option router
 	option = []byte{3, 4, 192, 168, 1, 1}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionRouter, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
@@ -35,7 +35,7 @@ func TestParseOption(t *testing.T) {
 
 	// Option domain name server
 	option = []byte{6, 4, 192, 168, 1, 1}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionDomainNameServer, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
@@ -43,7 +43,7 @@ func TestParseOption(t *testing.T) {
 
 	// Option host name
 	option = []byte{12, 4, 't', 'e', 's', 't'}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionHostName, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
@@ -51,7 +51,7 @@ func TestParseOption(t *testing.T) {
 
 	// Option domain name
 	option = []byte{15, 4, 't', 'e', 's', 't'}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionDomainName, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
@@ -59,7 +59,7 @@ func TestParseOption(t *testing.T) {
 
 	// Option root path
 	option = []byte{17, 4, '/', 'f', 'o', 'o'}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionRootPath, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
@@ -67,7 +67,7 @@ func TestParseOption(t *testing.T) {
 
 	// Option broadcast address
 	option = []byte{28, 4, 255, 255, 255, 255}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionBroadcastAddress, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
@@ -75,7 +75,7 @@ func TestParseOption(t *testing.T) {
 
 	// Option NTP servers
 	option = []byte{42, 4, 10, 10, 10, 10}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionNTPServers, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
@@ -83,7 +83,7 @@ func TestParseOption(t *testing.T) {
 
 	// Requested IP address
 	option = []byte{50, 4, 1, 2, 3, 4}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionRequestedIPAddress, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
@@ -91,7 +91,7 @@ func TestParseOption(t *testing.T) {
 
 	// Requested IP address lease time
 	option = []byte{51, 4, 0, 0, 0, 0}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionIPAddressLeaseTime, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
@@ -99,7 +99,7 @@ func TestParseOption(t *testing.T) {
 
 	// Message type
 	option = []byte{53, 1, 1}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionDHCPMessageType, opt.Code(), "Code")
 	require.Equal(t, 1, opt.Length(), "Length")
@@ -107,7 +107,7 @@ func TestParseOption(t *testing.T) {
 
 	// Option server ID
 	option = []byte{54, 4, 1, 2, 3, 4}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionServerIdentifier, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
@@ -115,7 +115,7 @@ func TestParseOption(t *testing.T) {
 
 	// Parameter request list
 	option = []byte{55, 3, 5, 53, 61}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionParameterRequestList, opt.Code(), "Code")
 	require.Equal(t, 3, opt.Length(), "Length")
@@ -123,7 +123,7 @@ func TestParseOption(t *testing.T) {
 
 	// Option max message size
 	option = []byte{57, 2, 1, 2}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionMaximumDHCPMessageSize, opt.Code(), "Code")
 	require.Equal(t, 2, opt.Length(), "Length")
@@ -131,7 +131,7 @@ func TestParseOption(t *testing.T) {
 
 	// Option class identifier
 	option = []byte{60, 4, 't', 'e', 's', 't'}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionClassIdentifier, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
@@ -139,7 +139,7 @@ func TestParseOption(t *testing.T) {
 
 	// Option TFTP server name
 	option = []byte{66, 4, 't', 'e', 's', 't'}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionTFTPServerName, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
@@ -147,7 +147,7 @@ func TestParseOption(t *testing.T) {
 
 	// Option Bootfile name
 	option = []byte{67, 9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't'}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionBootfileName, opt.Code(), "Code")
 	require.Equal(t, 9, opt.Length(), "Length")
@@ -155,37 +155,25 @@ func TestParseOption(t *testing.T) {
 
 	// Option user class information
 	option = []byte{77, 5, 4, 't', 'e', 's', 't'}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionUserClassInformation, opt.Code(), "Code")
 	require.Equal(t, 5, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option relay agent information
-	option = []byte{82, 2, 1, 0}
-	opt, err = ParseOption(option)
+	option = []byte{82, 6, 1, 4, 129, 168, 0, 1}
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionRelayAgentInformation, opt.Code(), "Code")
-	require.Equal(t, 2, opt.Length(), "Length")
+	require.Equal(t, 6, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option client system architecture type option
 	option = []byte{93, 4, 't', 'e', 's', 't'}
-	opt, err = ParseOption(option)
+	opt, err = ParseOption(OptionCode(option[0]), option[2:])
 	require.NoError(t, err)
 	require.Equal(t, OptionClientSystemArchitectureType, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
-}
-
-func TestParseOptionZeroLength(t *testing.T) {
-	option := []byte{}
-	_, err := ParseOption(option)
-	require.Error(t, err, "should get error from zero-length options")
-}
-
-func TestParseOptionShortOption(t *testing.T) {
-	option := []byte{53, 1}
-	_, err := ParseOption(option)
-	require.Error(t, err, "should get error from short options")
 }

--- a/dhcpv4/server_test.go
+++ b/dhcpv4/server_test.go
@@ -32,7 +32,7 @@ func DORAHandler(conn net.PacketConn, peer net.Addr, m *DHCPv4) {
 		log.Printf("Packet is nil!")
 		return
 	}
-	if m.Opcode() != OpcodeBootRequest {
+	if m.OpCode != OpcodeBootRequest {
 		log.Printf("Not a BootRequest!")
 		return
 	}
@@ -113,19 +113,19 @@ func TestServerActivateAndServe(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, 0, len(ifaces))
 
-	xid := uint32(0xaabbccdd)
-	hwaddr := [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
+	xid := [4]byte{0xaa, 0xbb, 0xcc, 0xdd}
+	hwaddr := net.HardwareAddr{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
 
 	modifiers := []Modifier{
 		WithTransactionID(xid),
-		WithHwAddr(hwaddr[:]),
+		WithHwAddr(hwaddr),
 	}
 
 	conv, err := c.Exchange(ifaces[0].Name, modifiers...)
 	require.NoError(t, err)
 	require.Equal(t, 4, len(conv))
 	for _, p := range conv {
-		require.Equal(t, xid, p.TransactionID())
-		require.Equal(t, [16]byte(hwaddr), p.ClientHwAddr())
+		require.Equal(t, xid, p.TransactionID)
+		require.Equal(t, hwaddr, p.ClientHWAddr)
 	}
 }

--- a/dhcpv4/server_test.go
+++ b/dhcpv4/server_test.go
@@ -113,7 +113,7 @@ func TestServerActivateAndServe(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, 0, len(ifaces))
 
-	xid := [4]byte{0xaa, 0xbb, 0xcc, 0xdd}
+	xid := TransactionID{0xaa, 0xbb, 0xcc, 0xdd}
 	hwaddr := net.HardwareAddr{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
 
 	modifiers := []Modifier{

--- a/dhcpv4/types.go
+++ b/dhcpv4/types.go
@@ -3,6 +3,9 @@ package dhcpv4
 // values from http://www.networksorcery.com/enp/protocol/dhcp.htm and
 // http://www.networksorcery.com/enp/protocol/bootp/options.htm
 
+// TransactionID represents a 4-byte DHCP transaction ID.
+type TransactionID [4]byte
+
 // MessageType represents the possible DHCP message types - DISCOVER, OFFER, etc
 type MessageType byte
 

--- a/dhcpv4/types.go
+++ b/dhcpv4/types.go
@@ -22,14 +22,13 @@ const (
 )
 
 func (m MessageType) String() string {
-	if s, ok := MessageTypeToString[m]; ok {
+	if s, ok := messageTypeToString[m]; ok {
 		return s
 	}
 	return "Unknown"
 }
 
-// MessageTypeToString maps DHCP message types to human-readable strings.
-var MessageTypeToString = map[MessageType]string{
+var messageTypeToString = map[MessageType]string{
 	MessageTypeDiscover: "DISCOVER",
 	MessageTypeOffer:    "OFFER",
 	MessageTypeRequest:  "REQUEST",
@@ -50,14 +49,13 @@ const (
 )
 
 func (o OpcodeType) String() string {
-	if s, ok := OpcodeToString[o]; ok {
+	if s, ok := opcodeToString[o]; ok {
 		return s
 	}
 	return "Unknown"
 }
 
-// OpcodeToString maps an OpcodeType to its mnemonic name
-var OpcodeToString = map[OpcodeType]string{
+var opcodeToString = map[OpcodeType]string{
 	OpcodeBootRequest: "BootRequest",
 	OpcodeBootReply:   "BootReply",
 }
@@ -227,14 +225,13 @@ const (
 )
 
 func (o OptionCode) String() string {
-	if s, ok := OptionCodeToString[o]; ok {
+	if s, ok := optionCodeToString[o]; ok {
 		return s
 	}
 	return "Unknown"
 }
 
-// OptionCodeToString maps an OptionCode to its mnemonic name
-var OptionCodeToString = map[OptionCode]string{
+var optionCodeToString = map[OptionCode]string{
 	OptionPad:                                        "Pad",
 	OptionSubnetMask:                                 "Subnet Mask",
 	OptionTimeOffset:                                 "Time Offset",

--- a/netboot/netboot.go
+++ b/netboot/netboot.go
@@ -19,7 +19,7 @@ var sleeper = func(d time.Duration) {
 func RequestNetbootv6(ifname string, timeout time.Duration, retries int, modifiers ...dhcpv6.Modifier) ([]dhcpv6.DHCPv6, error) {
 	var (
 		conversation []dhcpv6.DHCPv6
-		err error
+		err          error
 	)
 	modifiers = append(modifiers, dhcpv6.WithNetboot)
 	delay := 2 * time.Second
@@ -136,8 +136,8 @@ func ConversationToNetconfv4(conversation []*dhcpv4.DHCPv4) (*NetConf, string, e
 		// look for a BootReply packet of type Offer containing the bootfile URL.
 		// Normally both packets with Message Type OFFER or ACK do contain
 		// the bootfile URL.
-		if m.Opcode() == dhcpv4.OpcodeBootReply && *m.MessageType() == dhcpv4.MessageTypeOffer {
-			bootFileUrl = m.BootFileNameToString()
+		if m.OpCode == dhcpv4.OpcodeBootReply && m.MessageType() == dhcpv4.MessageTypeOffer {
+			bootFileUrl = m.BootFileName
 			reply = m
 			break
 		}

--- a/netboot/netconf.go
+++ b/netboot/netconf.go
@@ -79,8 +79,8 @@ func GetNetConfFromPacketv6(d *dhcpv6.DHCPv6Message) (*NetConf, error) {
 // Reply packet and returns a populated NetConf structure
 func GetNetConfFromPacketv4(d *dhcpv4.DHCPv4) (*NetConf, error) {
 	// extract the address from the DHCPv4 address
-	ipAddr := d.YourIPAddr()
-	if ipAddr.Equal(net.IPv4zero) {
+	ipAddr := d.YourIPAddr
+	if ipAddr == nil || ipAddr.Equal(net.IPv4zero) {
 		return nil, errors.New("ip address is null (0.0.0.0)")
 	}
 	netconf := NetConf{}

--- a/netboot/netconf_test.go
+++ b/netboot/netconf_test.go
@@ -108,21 +108,21 @@ func TestGetNetConfFromPacketv6(t *testing.T) {
 
 func TestGetNetConfFromPacketv4AddrZero(t *testing.T) {
 	d := dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.IPv4zero)
+	d.YourIPAddr = net.IPv4zero
 	_, err := GetNetConfFromPacketv4(&d)
 	require.Error(t, err)
 }
 
 func TestGetNetConfFromPacketv4NoMask(t *testing.T) {
 	d := dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	_, err := GetNetConfFromPacketv4(&d)
 	require.Error(t, err)
 }
 
 func TestGetNetConfFromPacketv4NullMask(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(0, 0, 0, 0))(d)
 	_, err := GetNetConfFromPacketv4(d)
 	require.Error(t, err)
@@ -130,7 +130,7 @@ func TestGetNetConfFromPacketv4NullMask(t *testing.T) {
 
 func TestGetNetConfFromPacketv4NoLeaseTime(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	_, err := GetNetConfFromPacketv4(d)
 	require.Error(t, err)
@@ -138,7 +138,7 @@ func TestGetNetConfFromPacketv4NoLeaseTime(t *testing.T) {
 
 func TestGetNetConfFromPacketv4NoDNS(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	d = dhcpv4.WithLeaseTime(uint32(0))(d)
 	_, err := GetNetConfFromPacketv4(d)
@@ -147,7 +147,7 @@ func TestGetNetConfFromPacketv4NoDNS(t *testing.T) {
 
 func TestGetNetConfFromPacketv4EmptyDNSList(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	d = dhcpv4.WithLeaseTime(uint32(0))(d)
 	d = dhcpv4.WithDNS()(d)
@@ -157,7 +157,7 @@ func TestGetNetConfFromPacketv4EmptyDNSList(t *testing.T) {
 
 func TestGetNetConfFromPacketv4NoSearchList(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	d = dhcpv4.WithLeaseTime(uint32(0))(d)
 	d = dhcpv4.WithDNS(net.ParseIP("10.10.0.1"), net.ParseIP("10.10.0.2"))(d)
@@ -167,7 +167,7 @@ func TestGetNetConfFromPacketv4NoSearchList(t *testing.T) {
 
 func TestGetNetConfFromPacketv4EmptySearchList(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	d = dhcpv4.WithLeaseTime(uint32(0))(d)
 	d = dhcpv4.WithDNS(net.ParseIP("10.10.0.1"), net.ParseIP("10.10.0.2"))(d)
@@ -178,7 +178,7 @@ func TestGetNetConfFromPacketv4EmptySearchList(t *testing.T) {
 
 func TestGetNetConfFromPacketv4NoRouter(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	d = dhcpv4.WithLeaseTime(uint32(0))(d)
 	d = dhcpv4.WithDNS(net.ParseIP("10.10.0.1"), net.ParseIP("10.10.0.2"))(d)
@@ -189,7 +189,7 @@ func TestGetNetConfFromPacketv4NoRouter(t *testing.T) {
 
 func TestGetNetConfFromPacketv4EmptyRouter(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	d = dhcpv4.WithLeaseTime(uint32(0))(d)
 	d = dhcpv4.WithDNS(net.ParseIP("10.10.0.1"), net.ParseIP("10.10.0.2"))(d)
@@ -201,7 +201,7 @@ func TestGetNetConfFromPacketv4EmptyRouter(t *testing.T) {
 
 func TestGetNetConfFromPacketv4(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	d = dhcpv4.WithLeaseTime(uint32(5200))(d)
 	d = dhcpv4.WithDNS(net.ParseIP("10.10.0.1"), net.ParseIP("10.10.0.2"))(d)


### PR DESCRIPTION
All tests pass locally, as far as I can tell.

Less code.

API changes to make easier to use:
- No setters and getters on DHCPv4 packet anymore, just access fields
  directly.
- TransactionID changed from uint32 -> [4]byte to avoid parsing it at
  all (fixed-length array can be used as a map key).
- ServerHostName and BootFileName are translated to the correct type
  while parsing.
- Client HW Addr len does not have to be set manually anymore, is
  derived from the length of the byte slice (and automatically set when
  parsing).

Less error prone:
- IPs in packet can be nil or 0.0.0.0, get serialized all the same.
- MessageType returns 0 rather than nil, which was unchecked in netboot
  code.
- Setters and Getters eliminated in favor of exported member names,
  since there was no validation of values anyway.