### PR TITLE
v4 packet API cleanup

### DIFF
--- a/dhcpv4/async/client.go
+++ b/dhcpv4/async/client.go
@@ -34,7 +34,7 @@ type Client struct {
 	receiveQueue chan *dhcpv4.DHCPv4
 	sendQueue    chan *dhcpv4.DHCPv4
 	packetsLock  sync.Mutex
-	packets      map[uint32]*promise.Promise
+	packets      map[dhcpv4.TransactionID]*promise.Promise
 	errors       chan error
 }
 
@@ -69,7 +69,7 @@ func (c *Client) Open(bufferSize int) error {
 	c.stopping = new(sync.WaitGroup)
 	c.sendQueue = make(chan *dhcpv4.DHCPv4, bufferSize)
 	c.receiveQueue = make(chan *dhcpv4.DHCPv4, bufferSize)
-	c.packets = make(map[uint32]*promise.Promise)
+	c.packets = make(map[dhcpv4.TransactionID]*promise.Promise)
 	c.packetsLock = sync.Mutex{}
 	c.errors = make(chan error)
 

--- a/dhcpv4/async/client.go
+++ b/dhcpv4/async/client.go
@@ -132,7 +132,7 @@ func (c *Client) senderLoop(ctx context.Context) {
 
 func (c *Client) send(packet *dhcpv4.DHCPv4) {
 	c.packetsLock.Lock()
-	p := c.packets[packet.TransactionID()]
+	p := c.packets[packet.TransactionID]
 	c.packetsLock.Unlock()
 
 	raddr, err := c.remoteAddr()
@@ -174,8 +174,8 @@ func (c *Client) receive(_ *dhcpv4.DHCPv4) {
 	}
 
 	c.packetsLock.Lock()
-	if p, ok := c.packets[received.TransactionID()]; ok {
-		delete(c.packets, received.TransactionID())
+	if p, ok := c.packets[received.TransactionID]; ok {
+		delete(c.packets, received.TransactionID)
 		p.Resolve(received)
 	}
 	c.packetsLock.Unlock()
@@ -201,7 +201,7 @@ func (c *Client) Send(message *dhcpv4.DHCPv4, modifiers ...dhcpv4.Modifier) *pro
 
 	p := promise.NewPromise()
 	c.packetsLock.Lock()
-	c.packets[message.TransactionID()] = p
+	c.packets[message.TransactionID] = p
 	c.packetsLock.Unlock()
 	c.sendQueue <- message
 	return p.Future

--- a/dhcpv4/async/client_test.go
+++ b/dhcpv4/async/client_test.go
@@ -121,5 +121,5 @@ func TestSend(t *testing.T) {
 	require.True(t, ok)
 	require.False(t, timeout)
 	require.NoError(t, err)
-	require.Equal(t, m.TransactionID(), r.TransactionID())
+	require.Equal(t, m.TransactionID, r.TransactionID)
 }

--- a/dhcpv4/bsdp/bsdp.go
+++ b/dhcpv4/bsdp/bsdp.go
@@ -143,12 +143,10 @@ func InformSelectForAck(ack dhcpv4.DHCPv4, replyPort uint16, selectedImage BootI
 	if needsReplyPort(replyPort) && replyPort >= 1024 {
 		return nil, errors.New("replyPort must be a privileged port")
 	}
-	d.SetOpcode(dhcpv4.OpcodeBootRequest)
-	d.SetHwType(ack.HwType())
-	d.SetHwAddrLen(ack.HwAddrLen())
-	clientHwAddr := ack.ClientHwAddr()
-	d.SetClientHwAddr(clientHwAddr[:])
-	d.SetTransactionID(ack.TransactionID())
+	d.OpCode = dhcpv4.OpcodeBootRequest
+	d.HWType = ack.HWType
+	d.ClientHWAddr = ack.ClientHWAddr
+	d.TransactionID = ack.TransactionID
 	if ack.IsBroadcast() {
 		d.SetBroadcast()
 	} else {
@@ -209,11 +207,10 @@ func NewReplyForInformList(inform *dhcpv4.DHCPv4, config ReplyConfig) (*dhcpv4.D
 	if err != nil {
 		return nil, err
 	}
-	reply.SetClientIPAddr(inform.ClientIPAddr())
-	reply.SetYourIPAddr(net.IPv4zero)
-	reply.SetGatewayIPAddr(inform.GatewayIPAddr())
-	reply.SetServerIPAddr(config.ServerIP)
-	reply.SetServerHostName([]byte(config.ServerHostname))
+	reply.ClientIPAddr = inform.ClientIPAddr
+	reply.GatewayIPAddr = inform.GatewayIPAddr
+	reply.ServerIPAddr = config.ServerIP
+	reply.ServerHostName = config.ServerHostname
 
 	reply.AddOption(&dhcpv4.OptMessageType{MessageType: dhcpv4.MessageTypeAck})
 	reply.AddOption(&dhcpv4.OptServerIdentifier{ServerID: config.ServerIP})
@@ -249,12 +246,11 @@ func NewReplyForInformSelect(inform *dhcpv4.DHCPv4, config ReplyConfig) (*dhcpv4
 		return nil, err
 	}
 
-	reply.SetClientIPAddr(inform.ClientIPAddr())
-	reply.SetYourIPAddr(net.IPv4zero)
-	reply.SetGatewayIPAddr(inform.GatewayIPAddr())
-	reply.SetServerIPAddr(config.ServerIP)
-	reply.SetServerHostName([]byte(config.ServerHostname))
-	reply.SetBootFileName([]byte(config.BootFileName))
+	reply.ClientIPAddr = inform.ClientIPAddr
+	reply.GatewayIPAddr = inform.GatewayIPAddr
+	reply.ServerIPAddr = config.ServerIP
+	reply.ServerHostName = config.ServerHostname
+	reply.BootFileName = config.BootFileName
 
 	reply.AddOption(&dhcpv4.OptMessageType{MessageType: dhcpv4.MessageTypeAck})
 	reply.AddOption(&dhcpv4.OptServerIdentifier{ServerID: config.ServerIP})

--- a/dhcpv4/bsdp/bsdp_test.go
+++ b/dhcpv4/bsdp/bsdp_test.go
@@ -274,7 +274,7 @@ func TestNewReplyForInformList(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, net.IP{1, 2, 3, 4}, ack.ClientIPAddr())
 	require.Equal(t, net.IPv4zero, ack.YourIPAddr())
-	require.Equal(t, "bsdp.foo.com", ack.ServerHostNameToString())
+	require.Equal(t, "bsdp.foo.com", ack.ServerHostName())
 
 	// Validate options.
 	RequireHasOption(t, ack, &dhcpv4.OptMessageType{MessageType: dhcpv4.MessageTypeAck})
@@ -355,7 +355,7 @@ func TestNewReplyForInformSelect(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, net.IP{1, 2, 3, 4}, ack.ClientIPAddr())
 	require.Equal(t, net.IPv4zero, ack.YourIPAddr())
-	require.Equal(t, "bsdp.foo.com", ack.ServerHostNameToString())
+	require.Equal(t, "bsdp.foo.com", ack.ServerHostName())
 
 	// Validate options.
 	RequireHasOption(t, ack, &dhcpv4.OptMessageType{MessageType: dhcpv4.MessageTypeAck})

--- a/dhcpv4/bsdp/bsdp_test.go
+++ b/dhcpv4/bsdp/bsdp_test.go
@@ -103,20 +103,19 @@ func TestNewInformList_ReplyPort(t *testing.T) {
 	require.Equal(t, replyPort, opt.(*OptReplyPort).Port)
 }
 
-func newAck(hwAddr []byte, transactionID uint32) *dhcpv4.DHCPv4 {
+func newAck(hwAddr net.HardwareAddr, transactionID [4]byte) *dhcpv4.DHCPv4 {
 	ack, _ := dhcpv4.New()
-	ack.SetTransactionID(transactionID)
-	ack.SetHwType(iana.HwTypeEthernet)
-	ack.SetClientHwAddr(hwAddr)
-	ack.SetHwAddrLen(uint8(len(hwAddr)))
+	ack.TransactionID = transactionID
+	ack.HWType = iana.HwTypeEthernet
+	ack.ClientHWAddr = hwAddr
 	ack.AddOption(&dhcpv4.OptMessageType{MessageType: dhcpv4.MessageTypeAck})
 	ack.AddOption(&dhcpv4.OptionGeneric{OptionCode: dhcpv4.OptionEnd})
 	return ack
 }
 
 func TestInformSelectForAck_Broadcast(t *testing.T) {
-	hwAddr := []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
-	tid := uint32(22)
+	hwAddr := net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+	tid := [4]byte{0x22, 0, 0, 0}
 	serverID := net.IPv4(1, 2, 3, 4)
 	bootImage := BootImage{
 		ID: BootImageID{
@@ -132,10 +131,10 @@ func TestInformSelectForAck_Broadcast(t *testing.T) {
 
 	m, err := InformSelectForAck(*ack, 0, bootImage)
 	require.NoError(t, err)
-	require.Equal(t, dhcpv4.OpcodeBootRequest, m.Opcode())
-	require.Equal(t, ack.HwType(), m.HwType())
-	require.Equal(t, ack.ClientHwAddr(), m.ClientHwAddr())
-	require.Equal(t, ack.TransactionID(), m.TransactionID())
+	require.Equal(t, dhcpv4.OpcodeBootRequest, m.OpCode)
+	require.Equal(t, ack.HWType, m.HWType)
+	require.Equal(t, ack.ClientHWAddr, m.ClientHWAddr)
+	require.Equal(t, ack.TransactionID, m.TransactionID)
 	require.True(t, m.IsBroadcast())
 
 	// Validate options.
@@ -157,8 +156,8 @@ func TestInformSelectForAck_Broadcast(t *testing.T) {
 }
 
 func TestInformSelectForAck_NoServerID(t *testing.T) {
-	hwAddr := []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
-	tid := uint32(22)
+	hwAddr := net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+	tid := [4]byte{0x22, 0, 0, 0}
 	bootImage := BootImage{
 		ID: BootImageID{
 			IsInstall: true,
@@ -174,8 +173,8 @@ func TestInformSelectForAck_NoServerID(t *testing.T) {
 }
 
 func TestInformSelectForAck_BadReplyPort(t *testing.T) {
-	hwAddr := []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
-	tid := uint32(22)
+	hwAddr := net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+	tid := [4]byte{0x22, 0, 0, 0}
 	serverID := net.IPv4(1, 2, 3, 4)
 	bootImage := BootImage{
 		ID: BootImageID{
@@ -194,8 +193,8 @@ func TestInformSelectForAck_BadReplyPort(t *testing.T) {
 }
 
 func TestInformSelectForAck_ReplyPort(t *testing.T) {
-	hwAddr := []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
-	tid := uint32(22)
+	hwAddr := net.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+	tid := [4]byte{0x22, 0, 0, 0}
 	serverID := net.IPv4(1, 2, 3, 4)
 	bootImage := BootImage{
 		ID: BootImageID{
@@ -272,9 +271,9 @@ func TestNewReplyForInformList(t *testing.T) {
 	}
 	ack, err := NewReplyForInformList(inform, config)
 	require.NoError(t, err)
-	require.Equal(t, net.IP{1, 2, 3, 4}, ack.ClientIPAddr())
-	require.Equal(t, net.IPv4zero, ack.YourIPAddr())
-	require.Equal(t, "bsdp.foo.com", ack.ServerHostName())
+	require.Equal(t, net.IP{1, 2, 3, 4}, ack.ClientIPAddr)
+	require.Equal(t, net.IPv4zero, ack.YourIPAddr)
+	require.Equal(t, "bsdp.foo.com", ack.ServerHostName)
 
 	// Validate options.
 	RequireHasOption(t, ack, &dhcpv4.OptMessageType{MessageType: dhcpv4.MessageTypeAck})
@@ -283,7 +282,7 @@ func TestNewReplyForInformList(t *testing.T) {
 	require.NotNil(t, ack.GetOneOption(dhcpv4.OptionVendorSpecificInformation))
 
 	// Ensure options terminated with End option.
-	require.Equal(t, &dhcpv4.OptionGeneric{OptionCode: dhcpv4.OptionEnd}, ack.Options()[len(ack.Options())-1])
+	require.Equal(t, &dhcpv4.OptionGeneric{OptionCode: dhcpv4.OptionEnd}, ack.Options[len(ack.Options)-1])
 
 	// Vendor-specific options.
 	vendorOpts := ack.GetOneOption(dhcpv4.OptionVendorSpecificInformation).(*OptVendorSpecificInformation)
@@ -353,9 +352,9 @@ func TestNewReplyForInformSelect(t *testing.T) {
 	}
 	ack, err := NewReplyForInformSelect(inform, config)
 	require.NoError(t, err)
-	require.Equal(t, net.IP{1, 2, 3, 4}, ack.ClientIPAddr())
-	require.Equal(t, net.IPv4zero, ack.YourIPAddr())
-	require.Equal(t, "bsdp.foo.com", ack.ServerHostName())
+	require.Equal(t, net.IP{1, 2, 3, 4}, ack.ClientIPAddr)
+	require.Equal(t, net.IPv4zero, ack.YourIPAddr)
+	require.Equal(t, "bsdp.foo.com", ack.ServerHostName)
 
 	// Validate options.
 	RequireHasOption(t, ack, &dhcpv4.OptMessageType{MessageType: dhcpv4.MessageTypeAck})
@@ -365,7 +364,7 @@ func TestNewReplyForInformSelect(t *testing.T) {
 	require.NotNil(t, ack.GetOneOption(dhcpv4.OptionVendorSpecificInformation))
 
 	// Ensure options are terminated with End option.
-	require.Equal(t, &dhcpv4.OptionGeneric{OptionCode: dhcpv4.OptionEnd}, ack.Options()[len(ack.Options())-1])
+	require.Equal(t, &dhcpv4.OptionGeneric{OptionCode: dhcpv4.OptionEnd}, ack.Options[len(ack.Options)-1])
 
 	vendorOpts := ack.GetOneOption(dhcpv4.OptionVendorSpecificInformation).(*OptVendorSpecificInformation)
 	RequireHasOption(t, vendorOpts, &OptMessageType{Type: MessageTypeSelect})

--- a/dhcpv4/bsdp/client.go
+++ b/dhcpv4/bsdp/client.go
@@ -19,7 +19,7 @@ func NewClient() *Client {
 }
 
 func castVendorOpt(ack *dhcpv4.DHCPv4) {
-	opts := ack.Options()
+	opts := ack.Options
 	for i := 0; i < len(opts); i++ {
 		if opts[i].Code() == dhcpv4.OptionVendorSpecificInformation {
 			vendorOpt, err := ParseOptVendorSpecificInformation(opts[i].ToBytes())

--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -331,11 +331,11 @@ func (c *Client) SendReceive(sendFd, recvFd int, packet *DHCPv4, messageType Mes
 				return
 			}
 			// check that this is a response to our message
-			if response.TransactionID() != packet.TransactionID() {
+			if response.TransactionID != packet.TransactionID {
 				continue
 			}
 			// wait for a response message
-			if response.Opcode() != OpcodeBootReply {
+			if response.OpCode != OpcodeBootReply {
 				continue
 			}
 			// if we are not requested to wait for a specific message type,
@@ -344,7 +344,7 @@ func (c *Client) SendReceive(sendFd, recvFd int, packet *DHCPv4, messageType Mes
 				break
 			}
 			// break if it's a reply of the desired type, continue otherwise
-			if response.MessageType() != nil && *response.MessageType() == messageType {
+			if response.MessageType() == messageType {
 				break
 			}
 		}

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -71,10 +71,8 @@ func TestFromBytes(t *testing.T) {
 	require.True(t, d.YourIPAddr().Equal(net.IPv4zero))
 	require.True(t, d.GatewayIPAddr().Equal(net.IPv4zero))
 	require.Equal(t, d.ClientHwAddr(), net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff})
-	hostname := d.ServerHostName()
-	require.Equal(t, hostname[:], expectedHostname)
-	bootfileName := d.BootFileName()
-	require.Equal(t, bootfileName[:], expectedBootfilename)
+	require.Equal(t, d.ServerHostName(), "")
+	require.Equal(t, d.BootFileName(), "")
 	// no need to check Magic Cookie as it is already validated in FromBytes
 	// above
 }
@@ -207,26 +205,14 @@ func TestSettersAndGetters(t *testing.T) {
 	d.SetFlags(0)
 
 	// getter/setter for ServerHostName
-	serverhostname := d.ServerHostName()
-	require.Equal(t, expectedHostname, serverhostname[:])
-	newHostname := []byte{'t', 'e', 's', 't'}
-	for i := 0; i < 60; i++ {
-		newHostname = append(newHostname, 0)
-	}
-	d.SetServerHostName(newHostname)
-	serverhostname = d.ServerHostName()
-	require.Equal(t, newHostname, serverhostname[:])
+	require.Equal(t, "", d.ServerHostName())
+	d.SetServerHostName("test")
+	require.Equal(t, "test", d.ServerHostName())
 
 	// getter/setter for BootFileName
-	bootfilename := d.BootFileName()
-	require.Equal(t, expectedBootfilename, bootfilename[:])
-	newBootfilename := []byte{'t', 'e', 's', 't'}
-	for i := 0; i < 124; i++ {
-		newBootfilename = append(newBootfilename, 0)
-	}
-	d.SetBootFileName(newBootfilename)
-	bootfilename = d.BootFileName()
-	require.Equal(t, newBootfilename, bootfilename[:])
+	require.Equal(t, "", d.BootFileName())
+	d.SetBootFileName("test")
+	require.Equal(t, "test", d.BootFileName())
 }
 
 func TestToStringMethods(t *testing.T) {
@@ -263,12 +249,12 @@ func TestToStringMethods(t *testing.T) {
 	require.Equal(t, "aa:bb:cc:dd:ee:ff", d.ClientHwAddrToString())
 
 	// ServerHostNameToString
-	d.SetServerHostName([]byte("my.host.local"))
-	require.Equal(t, "my.host.local", d.ServerHostNameToString())
+	d.SetServerHostName("my.host.local")
+	require.Equal(t, "my.host.local", d.ServerHostName())
 
 	// BootFileNameToString
-	d.SetBootFileName([]byte("/my/boot/file"))
-	require.Equal(t, "/my/boot/file", d.BootFileNameToString())
+	d.SetBootFileName("/my/boot/file")
+	require.Equal(t, "/my/boot/file", d.BootFileName())
 }
 
 func TestNewToBytes(t *testing.T) {

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -310,7 +310,7 @@ func TestNewToBytes(t *testing.T) {
 		expected = append(expected, 0)
 	}
 	// Magic Cookie
-	expected = append(expected, MagicCookie...)
+	expected = append(expected, magicCookie[:]...)
 	// End
 	expected = append(expected, 0xff)
 

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -61,18 +61,18 @@ func TestFromBytes(t *testing.T) {
 
 	d, err := FromBytes(data)
 	require.NoError(t, err)
-	require.Equal(t, d.Opcode(), OpcodeBootRequest)
-	require.Equal(t, d.HwType(), iana.HwTypeEthernet)
-	require.Equal(t, d.HopCount(), byte(3))
-	require.Equal(t, d.TransactionID(), TransactionID{0xaa, 0xbb, 0xcc, 0xdd})
-	require.Equal(t, d.NumSeconds(), uint16(3))
-	require.Equal(t, d.Flags(), uint16(1))
-	require.True(t, d.ClientIPAddr().Equal(net.IPv4zero))
-	require.True(t, d.YourIPAddr().Equal(net.IPv4zero))
-	require.True(t, d.GatewayIPAddr().Equal(net.IPv4zero))
-	require.Equal(t, d.ClientHwAddr(), net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff})
-	require.Equal(t, d.ServerHostName(), "")
-	require.Equal(t, d.BootFileName(), "")
+	require.Equal(t, d.OpCode, OpcodeBootRequest)
+	require.Equal(t, d.HWType, iana.HwTypeEthernet)
+	require.Equal(t, d.HopCount, byte(3))
+	require.Equal(t, d.TransactionID, TransactionID{0xaa, 0xbb, 0xcc, 0xdd})
+	require.Equal(t, d.NumSeconds, uint16(3))
+	require.Equal(t, d.Flags, uint16(1))
+	require.True(t, d.ClientIPAddr.Equal(net.IPv4zero))
+	require.True(t, d.YourIPAddr.Equal(net.IPv4zero))
+	require.True(t, d.GatewayIPAddr.Equal(net.IPv4zero))
+	require.Equal(t, d.ClientHWAddr, net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff})
+	require.Equal(t, d.ServerHostName, "")
+	require.Equal(t, d.BootFileName, "")
 	// no need to check Magic Cookie as it is already validated in FromBytes
 	// above
 }
@@ -118,143 +118,19 @@ func TestFromBytesInvalidOptions(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestSettersAndGetters(t *testing.T) {
-	data := []byte{
-		1,                      // dhcp request
-		1,                      // ethernet hw type
-		6,                      // hw addr length
-		3,                      // hop count
-		0xaa, 0xbb, 0xcc, 0xdd, // transaction ID, big endian (network)
-		0, 3, // number of seconds
-		0, 1, // broadcast
-		1, 2, 3, 4, // client IP address
-		5, 6, 7, 8, // your IP address
-		9, 10, 11, 12, // server IP address
-		13, 14, 15, 16, // gateway IP address
-		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // client MAC address + padding
-	}
-	// server host name
-	expectedHostname := []byte{}
-	for i := 0; i < 64; i++ {
-		expectedHostname = append(expectedHostname, 0)
-	}
-	data = append(data, expectedHostname...)
-	// boot file name
-	expectedBootfilename := []byte{}
-	for i := 0; i < 128; i++ {
-		expectedBootfilename = append(expectedBootfilename, 0)
-	}
-	data = append(data, expectedBootfilename...)
-	// magic cookie, then no options
-	data = append(data, []byte{99, 130, 83, 99}...)
-	d, err := FromBytes(data)
-	require.NoError(t, err)
-
-	// getter/setter for Opcode
-	require.Equal(t, OpcodeBootRequest, d.Opcode())
-	d.SetOpcode(OpcodeBootReply)
-	require.Equal(t, OpcodeBootReply, d.Opcode())
-
-	// getter/setter for HwType
-	require.Equal(t, iana.HwTypeEthernet, d.HwType())
-	d.SetHwType(iana.HwTypeARCNET)
-	require.Equal(t, iana.HwTypeARCNET, d.HwType())
-
-	// getter/setter for HopCount
-	require.Equal(t, uint8(3), d.HopCount())
-	d.SetHopCount(1)
-	require.Equal(t, uint8(1), d.HopCount())
-
-	// getter/setter for TransactionID
-	require.Equal(t, TransactionID{0xaa, 0xbb, 0xcc, 0xdd}, d.TransactionID())
-	d.SetTransactionID(TransactionID{0xee, 0xff, 0x00, 0x11})
-	require.Equal(t, TransactionID{0xee, 0xff, 0x00, 0x11}, d.TransactionID())
-
-	// getter/setter for TransactionID
-	require.Equal(t, uint16(3), d.NumSeconds())
-	d.SetNumSeconds(15)
-	require.Equal(t, uint16(15), d.NumSeconds())
-
-	// getter/setter for Flags
-	require.Equal(t, uint16(1), d.Flags())
-	d.SetFlags(0)
-	require.Equal(t, uint16(0), d.Flags())
-
-	// getter/setter for ClientIPAddr
-	require.True(t, d.ClientIPAddr().Equal(net.IPv4(1, 2, 3, 4)))
-	d.SetClientIPAddr(net.IPv4(4, 3, 2, 1))
-	require.True(t, d.ClientIPAddr().Equal(net.IPv4(4, 3, 2, 1)))
-
-	// getter/setter for YourIPAddr
-	require.True(t, d.YourIPAddr().Equal(net.IPv4(5, 6, 7, 8)))
-	d.SetYourIPAddr(net.IPv4(8, 7, 6, 5))
-	require.True(t, d.YourIPAddr().Equal(net.IPv4(8, 7, 6, 5)))
-
-	// getter/setter for ServerIPAddr
-	require.True(t, d.ServerIPAddr().Equal(net.IPv4(9, 10, 11, 12)))
-	d.SetServerIPAddr(net.IPv4(12, 11, 10, 9))
-	require.True(t, d.ServerIPAddr().Equal(net.IPv4(12, 11, 10, 9)))
-
-	// getter/setter for GatewayIPAddr
-	require.True(t, d.GatewayIPAddr().Equal(net.IPv4(13, 14, 15, 16)))
-	d.SetGatewayIPAddr(net.IPv4(16, 15, 14, 13))
-	require.True(t, d.GatewayIPAddr().Equal(net.IPv4(16, 15, 14, 13)))
-
-	// getter/setter for ClientHwAddr
-	require.Equal(t, net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, d.ClientHwAddr())
-	d.SetFlags(0)
-
-	// getter/setter for ServerHostName
-	require.Equal(t, "", d.ServerHostName())
-	d.SetServerHostName("test")
-	require.Equal(t, "test", d.ServerHostName())
-
-	// getter/setter for BootFileName
-	require.Equal(t, "", d.BootFileName())
-	d.SetBootFileName("test")
-	require.Equal(t, "test", d.BootFileName())
-}
-
 func TestToStringMethods(t *testing.T) {
 	d, err := New()
 	if err != nil {
 		t.Fatal(err)
 	}
-	// OpcodeToString
-	d.SetOpcode(OpcodeBootRequest)
-	require.Equal(t, "BootRequest", d.OpcodeToString())
-	d.SetOpcode(OpcodeBootReply)
-	require.Equal(t, "BootReply", d.OpcodeToString())
-	d.SetOpcode(OpcodeType(0))
-	require.Equal(t, "Unknown", d.OpcodeToString())
-
-	// HwTypeToString
-	d.SetHwType(iana.HwTypeEthernet)
-	require.Equal(t, "Ethernet", d.HwTypeToString())
-	d.SetHwType(iana.HwTypeARCNET)
-	require.Equal(t, "ARCNET", d.HwTypeToString())
-	d.SetHwType(iana.HwTypeType(0))
-	require.Equal(t, "Invalid", d.HwTypeToString())
 
 	// FlagsToString
 	d.SetUnicast()
 	require.Equal(t, "Unicast", d.FlagsToString())
 	d.SetBroadcast()
 	require.Equal(t, "Broadcast", d.FlagsToString())
-	d.SetFlags(0xffff)
+	d.Flags = 0xffff
 	require.Equal(t, "Broadcast (reserved bits not zeroed)", d.FlagsToString())
-
-	// ClientHwAddrToString
-	d.SetClientHwAddr(net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff})
-	require.Equal(t, "aa:bb:cc:dd:ee:ff", d.ClientHwAddrToString())
-
-	// ServerHostNameToString
-	d.SetServerHostName("my.host.local")
-	require.Equal(t, "my.host.local", d.ServerHostName())
-
-	// BootFileNameToString
-	d.SetBootFileName("/my/boot/file")
-	require.Equal(t, "/my/boot/file", d.BootFileName())
 }
 
 func TestNewToBytes(t *testing.T) {
@@ -291,7 +167,7 @@ func TestNewToBytes(t *testing.T) {
 	require.NoError(t, err)
 	// fix TransactionID to match the expected one, since it's randomly
 	// generated in New()
-	d.SetTransactionID(TransactionID{0x11, 0x22, 0x33, 0x44})
+	d.TransactionID = TransactionID{0x11, 0x22, 0x33, 0x44}
 	got := d.ToBytes()
 	require.Equal(t, expected, got)
 }
@@ -329,7 +205,7 @@ func TestAddOption(t *testing.T) {
 	d.AddOption(bootFileOpt1)
 	d.AddOption(bootFileOpt2)
 
-	options := d.Options()
+	options := d.Options
 	require.Equal(t, len(options), 4)
 	require.Equal(t, options[3].Code(), OptionEnd)
 }
@@ -337,18 +213,18 @@ func TestAddOption(t *testing.T) {
 func TestUpdateOption(t *testing.T) {
 	d, err := New()
 	require.NoError(t, err)
-	require.Equal(t, 1, len(d.options))
-	require.Equal(t, OptionEnd, d.options[0].Code())
+	require.Equal(t, 1, len(d.Options))
+	require.Equal(t, OptionEnd, d.Options[0].Code())
 	// test that it will add the option since it's missing
 	d.UpdateOption(&OptDomainName{DomainName: "slackware.it"})
-	require.Equal(t, 2, len(d.options))
-	require.Equal(t, OptionDomainName, d.options[0].Code())
-	require.Equal(t, OptionEnd, d.options[1].Code())
+	require.Equal(t, 2, len(d.Options))
+	require.Equal(t, OptionDomainName, d.Options[0].Code())
+	require.Equal(t, OptionEnd, d.Options[1].Code())
 	// test that it won't add another option of the same type
 	d.UpdateOption(&OptDomainName{DomainName: "slackware.it"})
-	require.Equal(t, 2, len(d.options))
-	require.Equal(t, OptionDomainName, d.options[0].Code())
-	require.Equal(t, OptionEnd, d.options[1].Code())
+	require.Equal(t, 2, len(d.Options))
+	require.Equal(t, OptionDomainName, d.Options[0].Code())
+	require.Equal(t, OptionEnd, d.Options[1].Code())
 }
 
 func TestStrippedOptions(t *testing.T) {
@@ -360,7 +236,7 @@ func TestStrippedOptions(t *testing.T) {
 		&OptClassIdentifier{"something"},
 		&OptionGeneric{OptionCode: OptionEnd},
 	}
-	d.SetOptions(opts)
+	d.Options = opts
 	stripped := d.StrippedOptions()
 	require.Equal(t, len(opts), len(stripped))
 	for i := range stripped {
@@ -369,7 +245,7 @@ func TestStrippedOptions(t *testing.T) {
 
 	// Set of options with additional options after OptionEnd
 	opts = append(opts, &OptMaximumDHCPMessageSize{uint16(1234)})
-	d.SetOptions(opts)
+	d.Options = opts
 	stripped = d.StrippedOptions()
 	require.Equal(t, len(opts)-1, len(stripped))
 	for i := range stripped {
@@ -391,8 +267,7 @@ func TestDHCPv4NewRequestFromOffer(t *testing.T) {
 	// Broadcast request
 	req, err = NewRequestFromOffer(offer)
 	require.NoError(t, err)
-	require.NotNil(t, req.MessageType())
-	require.Equal(t, MessageTypeRequest, *req.MessageType())
+	require.Equal(t, MessageTypeRequest, req.MessageType())
 	require.False(t, req.IsUnicast())
 	require.True(t, req.IsBroadcast())
 
@@ -412,50 +287,48 @@ func TestDHCPv4NewRequestFromOfferWithModifier(t *testing.T) {
 	userClass := WithUserClass([]byte("linuxboot"), false)
 	req, err := NewRequestFromOffer(offer, userClass)
 	require.NoError(t, err)
-	require.NotEqual(t, (*MessageType)(nil), *req.MessageType())
-	require.Equal(t, MessageTypeRequest, *req.MessageType())
-	require.Equal(t, "User Class Information -> linuxboot", req.options[3].String())
+	require.Equal(t, MessageTypeRequest, req.MessageType())
+	require.Equal(t, "User Class Information -> linuxboot", req.Options[3].String())
 }
 
 func TestNewReplyFromRequest(t *testing.T) {
 	discover, err := New()
 	require.NoError(t, err)
-	discover.SetGatewayIPAddr(net.IPv4(192, 168, 0, 1))
+	discover.GatewayIPAddr = net.IPv4(192, 168, 0, 1)
 	reply, err := NewReplyFromRequest(discover)
 	require.NoError(t, err)
-	require.Equal(t, discover.TransactionID(), reply.TransactionID())
-	require.Equal(t, discover.GatewayIPAddr(), reply.GatewayIPAddr())
+	require.Equal(t, discover.TransactionID, reply.TransactionID)
+	require.Equal(t, discover.GatewayIPAddr, reply.GatewayIPAddr)
 }
 
 func TestNewReplyFromRequestWithModifier(t *testing.T) {
 	discover, err := New()
 	require.NoError(t, err)
-	discover.SetGatewayIPAddr(net.IPv4(192, 168, 0, 1))
+	discover.GatewayIPAddr = net.IPv4(192, 168, 0, 1)
 	userClass := WithUserClass([]byte("linuxboot"), false)
 	reply, err := NewReplyFromRequest(discover, userClass)
 	require.NoError(t, err)
-	require.Equal(t, discover.TransactionID(), reply.TransactionID())
-	require.Equal(t, discover.GatewayIPAddr(), reply.GatewayIPAddr())
-	require.Equal(t, "User Class Information -> linuxboot", reply.options[0].String())
+	require.Equal(t, discover.TransactionID, reply.TransactionID)
+	require.Equal(t, discover.GatewayIPAddr, reply.GatewayIPAddr)
+	require.Equal(t, "User Class Information -> linuxboot", reply.Options[0].String())
 }
 
 func TestDHCPv4MessageTypeNil(t *testing.T) {
 	m, err := New()
 	require.NoError(t, err)
-	require.Nil(t, m.MessageType())
+	require.Equal(t, MessageTypeNone, m.MessageType())
 }
 
 func TestNewDiscovery(t *testing.T) {
 	hwAddr := net.HardwareAddr{1, 2, 3, 4, 5, 6}
 	m, err := NewDiscovery(hwAddr)
 	require.NoError(t, err)
-	require.NotNil(t, m.MessageType())
-	require.Equal(t, MessageTypeDiscover, *m.MessageType())
+	require.Equal(t, MessageTypeDiscover, m.MessageType())
 
 	// Validate fields of DISCOVER packet.
-	require.Equal(t, OpcodeBootRequest, m.Opcode())
-	require.Equal(t, iana.HwTypeEthernet, m.HwType())
-	require.Equal(t, hwAddr, m.ClientHwAddr())
+	require.Equal(t, OpcodeBootRequest, m.OpCode)
+	require.Equal(t, iana.HwTypeEthernet, m.HWType)
+	require.Equal(t, hwAddr, m.ClientHWAddr)
 	require.True(t, m.IsBroadcast())
 	require.True(t, HasOption(m, OptionParameterRequestList))
 	require.True(t, HasOption(m, OptionEnd))
@@ -467,12 +340,11 @@ func TestNewInform(t *testing.T) {
 	m, err := NewInform(hwAddr, localIP)
 
 	require.NoError(t, err)
-	require.Equal(t, OpcodeBootRequest, m.Opcode())
-	require.Equal(t, iana.HwTypeEthernet, m.HwType())
-	require.Equal(t, hwAddr, m.ClientHwAddr())
-	require.NotNil(t, m.MessageType())
-	require.Equal(t, MessageTypeInform, *m.MessageType())
-	require.True(t, m.ClientIPAddr().Equal(localIP))
+	require.Equal(t, OpcodeBootRequest, m.OpCode)
+	require.Equal(t, iana.HwTypeEthernet, m.HWType)
+	require.Equal(t, hwAddr, m.ClientHWAddr)
+	require.Equal(t, MessageTypeInform, m.MessageType())
+	require.True(t, m.ClientIPAddr.Equal(localIP))
 }
 
 func TestIsOptionRequested(t *testing.T) {

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -65,7 +65,7 @@ func TestFromBytes(t *testing.T) {
 	require.Equal(t, d.HwType(), iana.HwTypeEthernet)
 	require.Equal(t, d.HwAddrLen(), byte(6))
 	require.Equal(t, d.HopCount(), byte(3))
-	require.Equal(t, d.TransactionID(), uint32(0xaabbccdd))
+	require.Equal(t, d.TransactionID(), TransactionID{0xaa, 0xbb, 0xcc, 0xdd})
 	require.Equal(t, d.NumSeconds(), uint16(3))
 	require.Equal(t, d.Flags(), uint16(1))
 	require.True(t, d.ClientIPAddr().Equal(net.IPv4zero))
@@ -177,9 +177,9 @@ func TestSettersAndGetters(t *testing.T) {
 	require.Equal(t, uint8(1), d.HopCount())
 
 	// getter/setter for TransactionID
-	require.Equal(t, uint32(0xaabbccdd), d.TransactionID())
-	d.SetTransactionID(0xeeff0011)
-	require.Equal(t, uint32(0xeeff0011), d.TransactionID())
+	require.Equal(t, TransactionID{0xaa, 0xbb, 0xcc, 0xdd}, d.TransactionID())
+	d.SetTransactionID(TransactionID{0xee, 0xff, 0x00, 0x11})
+	require.Equal(t, TransactionID{0xee, 0xff, 0x00, 0x11}, d.TransactionID())
 
 	// getter/setter for TransactionID
 	require.Equal(t, uint16(3), d.NumSeconds())
@@ -318,7 +318,7 @@ func TestNewToBytes(t *testing.T) {
 	require.NoError(t, err)
 	// fix TransactionID to match the expected one, since it's randomly
 	// generated in New()
-	d.SetTransactionID(0x11223344)
+	d.SetTransactionID(TransactionID{0x11, 0x22, 0x33, 0x44})
 	got := d.ToBytes()
 	require.Equal(t, expected, got)
 }

--- a/dhcpv4/modifiers.go
+++ b/dhcpv4/modifiers.go
@@ -9,7 +9,7 @@ import (
 // WithTransactionID sets the Transaction ID for the DHCPv4 packet
 func WithTransactionID(xid TransactionID) Modifier {
 	return func(d *DHCPv4) *DHCPv4 {
-		d.SetTransactionID(xid)
+		d.TransactionID = xid
 		return d
 	}
 }
@@ -27,9 +27,9 @@ func WithBroadcast(broadcast bool) Modifier {
 }
 
 // WithHwAddr sets the hardware address for a packet
-func WithHwAddr(hwaddr []byte) Modifier {
+func WithHwAddr(hwaddr net.HardwareAddr) Modifier {
 	return func(d *DHCPv4) *DHCPv4 {
-		d.SetClientHwAddr(hwaddr)
+		d.ClientHWAddr = hwaddr
 		return d
 	}
 }
@@ -111,8 +111,8 @@ func WithRequestedOptions(optionCodes ...OptionCode) Modifier {
 func WithRelay(ip net.IP) Modifier {
 	return func(d *DHCPv4) *DHCPv4 {
 		d.SetUnicast()
-		d.SetGatewayIPAddr(ip)
-		d.SetHopCount(1)
+		d.GatewayIPAddr = ip
+		d.HopCount = 1
 		return d
 	}
 }

--- a/dhcpv4/modifiers.go
+++ b/dhcpv4/modifiers.go
@@ -7,7 +7,7 @@ import (
 )
 
 // WithTransactionID sets the Transaction ID for the DHCPv4 packet
-func WithTransactionID(xid uint32) Modifier {
+func WithTransactionID(xid TransactionID) Modifier {
 	return func(d *DHCPv4) *DHCPv4 {
 		d.SetTransactionID(xid)
 		return d

--- a/dhcpv4/modifiers_test.go
+++ b/dhcpv4/modifiers_test.go
@@ -11,7 +11,7 @@ func TestTransactionIDModifier(t *testing.T) {
 	d, err := New()
 	require.NoError(t, err)
 	d = WithTransactionID(TransactionID{0xdd, 0xcc, 0xbb, 0xaa})(d)
-	require.Equal(t, TransactionID{0xdd, 0xcc, 0xbb, 0xaa}, d.TransactionID())
+	require.Equal(t, TransactionID{0xdd, 0xcc, 0xbb, 0xaa}, d.TransactionID)
 }
 
 func TestBroadcastModifier(t *testing.T) {
@@ -30,7 +30,7 @@ func TestHwAddrModifier(t *testing.T) {
 	require.NoError(t, err)
 	hwaddr := net.HardwareAddr{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
 	d = WithHwAddr(hwaddr)(d)
-	require.Equal(t, hwaddr, d.ClientHwAddr())
+	require.Equal(t, hwaddr, d.ClientHWAddr)
 }
 
 func TestWithOptionModifier(t *testing.T) {
@@ -53,8 +53,8 @@ func TestUserClassModifier(t *testing.T) {
 		9,  // length
 		'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
-	require.Equal(t, "User Class Information -> linuxboot", d.options[0].String())
-	require.Equal(t, expected, d.options[0].ToBytes())
+	require.Equal(t, "User Class Information -> linuxboot", d.Options[0].String())
+	require.Equal(t, expected, d.Options[0].ToBytes())
 }
 
 func TestUserClassModifierRFC(t *testing.T) {
@@ -66,14 +66,14 @@ func TestUserClassModifierRFC(t *testing.T) {
 		10, // length
 		9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
-	require.Equal(t, "User Class Information -> linuxboot", d.options[0].String())
-	require.Equal(t, expected, d.options[0].ToBytes())
+	require.Equal(t, "User Class Information -> linuxboot", d.Options[0].String())
+	require.Equal(t, expected, d.Options[0].ToBytes())
 }
 
 func TestWithNetboot(t *testing.T) {
 	d, _ := New()
 	d = WithNetboot(d)
-	require.Equal(t, "Parameter Request List -> [TFTP Server Name, Bootfile Name]", d.options[0].String())
+	require.Equal(t, "Parameter Request List -> [TFTP Server Name, Bootfile Name]", d.Options[0].String())
 }
 
 func TestWithNetbootExistingTFTP(t *testing.T) {
@@ -83,7 +83,7 @@ func TestWithNetbootExistingTFTP(t *testing.T) {
 	}
 	d.AddOption(OptParams)
 	d = WithNetboot(d)
-	require.Equal(t, "Parameter Request List -> [TFTP Server Name, Bootfile Name]", d.options[0].String())
+	require.Equal(t, "Parameter Request List -> [TFTP Server Name, Bootfile Name]", d.Options[0].String())
 }
 
 func TestWithNetbootExistingBootfileName(t *testing.T) {
@@ -93,7 +93,7 @@ func TestWithNetbootExistingBootfileName(t *testing.T) {
 	}
 	d.AddOption(OptParams)
 	d = WithNetboot(d)
-	require.Equal(t, "Parameter Request List -> [Bootfile Name, TFTP Server Name]", d.options[0].String())
+	require.Equal(t, "Parameter Request List -> [Bootfile Name, TFTP Server Name]", d.Options[0].String())
 }
 
 func TestWithNetbootExistingBoth(t *testing.T) {
@@ -103,7 +103,7 @@ func TestWithNetbootExistingBoth(t *testing.T) {
 	}
 	d.AddOption(OptParams)
 	d = WithNetboot(d)
-	require.Equal(t, "Parameter Request List -> [Bootfile Name, TFTP Server Name]", d.options[0].String())
+	require.Equal(t, "Parameter Request List -> [Bootfile Name, TFTP Server Name]", d.Options[0].String())
 }
 
 func TestWithRequestedOptions(t *testing.T) {
@@ -133,34 +133,34 @@ func TestWithRelay(t *testing.T) {
 	d = WithRelay(ip)(d)
 	require.NotNil(t, d)
 	require.True(t, d.IsUnicast(), "expected unicast")
-	require.Equal(t, ip, d.GatewayIPAddr())
-	require.Equal(t, uint8(1), d.HopCount())
+	require.Equal(t, ip, d.GatewayIPAddr)
+	require.Equal(t, uint8(1), d.HopCount)
 }
 
 func TestWithNetmask(t *testing.T) {
 	d := &DHCPv4{}
 	d = WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
-	require.Equal(t, 1, len(d.options))
-	require.Equal(t, OptionSubnetMask, d.options[0].Code())
-	osm := d.options[0].(*OptSubnetMask)
+	require.Equal(t, 1, len(d.Options))
+	require.Equal(t, OptionSubnetMask, d.Options[0].Code())
+	osm := d.Options[0].(*OptSubnetMask)
 	require.Equal(t, net.IPv4Mask(255, 255, 255, 0), osm.SubnetMask)
 }
 
 func TestWithLeaseTime(t *testing.T) {
 	d := &DHCPv4{}
 	d = WithLeaseTime(uint32(3600))(d)
-	require.Equal(t, 1, len(d.options))
-	require.Equal(t, OptionIPAddressLeaseTime, d.options[0].Code())
-	olt := d.options[0].(*OptIPAddressLeaseTime)
+	require.Equal(t, 1, len(d.Options))
+	require.Equal(t, OptionIPAddressLeaseTime, d.Options[0].Code())
+	olt := d.Options[0].(*OptIPAddressLeaseTime)
 	require.Equal(t, uint32(3600), olt.LeaseTime)
 }
 
 func TestWithDNS(t *testing.T) {
 	d := &DHCPv4{}
 	d = WithDNS(net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.2"))(d)
-	require.Equal(t, 1, len(d.options))
-	require.Equal(t, OptionDomainNameServer, d.options[0].Code())
-	olt := d.options[0].(*OptDomainNameServer)
+	require.Equal(t, 1, len(d.Options))
+	require.Equal(t, OptionDomainNameServer, d.Options[0].Code())
+	olt := d.Options[0].(*OptDomainNameServer)
 	require.Equal(t, 2, len(olt.NameServers))
 	require.Equal(t, net.ParseIP("10.0.0.1"), olt.NameServers[0])
 	require.Equal(t, net.ParseIP("10.0.0.2"), olt.NameServers[1])
@@ -170,8 +170,8 @@ func TestWithDNS(t *testing.T) {
 func TestWithDomainSearchList(t *testing.T) {
 	d := &DHCPv4{}
 	d = WithDomainSearchList("slackware.it", "dhcp.slackware.it")(d)
-	require.Equal(t, 1, len(d.options))
-	osl := d.options[0].(*OptDomainSearch)
+	require.Equal(t, 1, len(d.Options))
+	osl := d.Options[0].(*OptDomainSearch)
 	require.Equal(t, OptionDNSDomainSearchList, osl.Code())
 	require.NotNil(t, osl.DomainSearch)
 	require.Equal(t, 2, len(osl.DomainSearch.Labels))
@@ -183,8 +183,8 @@ func TestWithRouter(t *testing.T) {
 	d := &DHCPv4{}
 	rtr := net.ParseIP("10.0.0.254")
 	d = WithRouter(rtr)(d)
-	require.Equal(t, 1, len(d.options))
-	ortr := d.options[0].(*OptRouter)
+	require.Equal(t, 1, len(d.Options))
+	ortr := d.Options[0].(*OptRouter)
 	require.Equal(t, OptionRouter, ortr.Code())
 	require.Equal(t, 1, len(ortr.Routers))
 	require.Equal(t, rtr, ortr.Routers[0])

--- a/dhcpv4/modifiers_test.go
+++ b/dhcpv4/modifiers_test.go
@@ -28,8 +28,8 @@ func TestBroadcastModifier(t *testing.T) {
 func TestHwAddrModifier(t *testing.T) {
 	d, err := New()
 	require.NoError(t, err)
-	hwaddr := [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
-	d = WithHwAddr(hwaddr[:])(d)
+	hwaddr := net.HardwareAddr{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
+	d = WithHwAddr(hwaddr)(d)
 	require.Equal(t, hwaddr, d.ClientHwAddr())
 }
 

--- a/dhcpv4/modifiers_test.go
+++ b/dhcpv4/modifiers_test.go
@@ -10,8 +10,8 @@ import (
 func TestTransactionIDModifier(t *testing.T) {
 	d, err := New()
 	require.NoError(t, err)
-	d = WithTransactionID(0xddccbbaa)(d)
-	require.Equal(t, uint32(0xddccbbaa), d.TransactionID())
+	d = WithTransactionID(TransactionID{0xdd, 0xcc, 0xbb, 0xaa})(d)
+	require.Equal(t, TransactionID{0xdd, 0xcc, 0xbb, 0xaa}, d.TransactionID())
 }
 
 func TestBroadcastModifier(t *testing.T) {

--- a/dhcpv4/options.go
+++ b/dhcpv4/options.go
@@ -1,9 +1,7 @@
 package dhcpv4
 
 import (
-	"bytes"
 	"errors"
-	"fmt"
 )
 
 // ErrShortByteStream is an error that is thrown any time a short byte stream is
@@ -13,10 +11,6 @@ var ErrShortByteStream = errors.New("short byte stream")
 // ErrZeroLengthByteStream is an error that is thrown any time a zero-length
 // byte stream is encountered.
 var ErrZeroLengthByteStream = errors.New("zero-length byte stream")
-
-// MagicCookie is the magic 4-byte value at the beginning of the list of options
-// in a DHCPv4 packet.
-var MagicCookie = []byte{99, 130, 83, 99}
 
 // OptionCode is a single byte representing the code for a given Option.
 type OptionCode byte
@@ -94,26 +88,12 @@ func ParseOption(data []byte) (Option, error) {
 }
 
 // OptionsFromBytes parses a sequence of bytes until the end and builds a list
-// of options from it. The sequence must contain the Magic Cookie. Returns an
-// error if any invalid option or length is found.
+// of options from it.
+//
+// The sequence should not contain the DHCP magic cookie.
+//
+// Returns an error if any invalid option or length is found.
 func OptionsFromBytes(data []byte) ([]Option, error) {
-	if len(data) < len(MagicCookie) {
-		return nil, errors.New("invalid options: shorter than 4 bytes")
-	}
-	if !bytes.Equal(data[:len(MagicCookie)], MagicCookie) {
-		return nil, fmt.Errorf("invalid magic cookie: %v", data[:len(MagicCookie)])
-	}
-	opts, err := OptionsFromBytesWithoutMagicCookie(data[len(MagicCookie):])
-	if err != nil {
-		return nil, err
-	}
-	return opts, nil
-}
-
-// OptionsFromBytesWithoutMagicCookie parses a sequence of bytes until the end
-// and builds a list of options from it. The sequence should not contain the
-// DHCP magic cookie. Returns an error if any invalid option or length is found.
-func OptionsFromBytesWithoutMagicCookie(data []byte) ([]Option, error) {
 	return OptionsFromBytesWithParser(data, ParseOption)
 }
 

--- a/dhcpv4/options_test.go
+++ b/dhcpv4/options_test.go
@@ -189,38 +189,3 @@ func TestParseOptionShortOption(t *testing.T) {
 	_, err := ParseOption(option)
 	require.Error(t, err, "should get error from short options")
 }
-
-func TestOptionsFromBytes(t *testing.T) {
-	options := []byte{
-		99, 130, 83, 99, // Magic Cookie
-		5, 4, 192, 168, 1, 1, // DNS
-		255,     // end
-		0, 0, 0, //padding
-	}
-	opts, err := OptionsFromBytes(options)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(opts))
-	require.Equal(t, opts[0].(*OptionGeneric), &OptionGeneric{OptionCode: OptionNameServer, Data: []byte{192, 168, 1, 1}})
-	require.Equal(t, opts[1].(*OptionGeneric), &OptionGeneric{OptionCode: OptionEnd})
-}
-
-func TestOptionsFromBytesZeroLength(t *testing.T) {
-	options := []byte{}
-	_, err := OptionsFromBytes(options)
-	require.Error(t, err)
-}
-
-func TestOptionsFromBytesBadMagicCookie(t *testing.T) {
-	options := []byte{1, 2, 3, 4}
-	_, err := OptionsFromBytes(options)
-	require.Error(t, err)
-}
-
-func TestOptionsFromBytesShortOption(t *testing.T) {
-	options := []byte{
-		99, 130, 83, 99, // Magic Cookie
-		5, 4, 192, 168, // DNS
-	}
-	_, err := OptionsFromBytes(options)
-	require.Error(t, err)
-}

--- a/dhcpv4/server_test.go
+++ b/dhcpv4/server_test.go
@@ -32,7 +32,7 @@ func DORAHandler(conn net.PacketConn, peer net.Addr, m *DHCPv4) {
 		log.Printf("Packet is nil!")
 		return
 	}
-	if m.Opcode() != OpcodeBootRequest {
+	if m.OpCode != OpcodeBootRequest {
 		log.Printf("Not a BootRequest!")
 		return
 	}
@@ -114,18 +114,18 @@ func TestServerActivateAndServe(t *testing.T) {
 	require.NotEqual(t, 0, len(ifaces))
 
 	xid := TransactionID{0xaa, 0xbb, 0xcc, 0xdd}
-	hwaddr := [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
+	hwaddr := net.HardwareAddr{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
 
 	modifiers := []Modifier{
 		WithTransactionID(xid),
-		WithHwAddr(hwaddr[:]),
+		WithHwAddr(hwaddr),
 	}
 
 	conv, err := c.Exchange(ifaces[0].Name, modifiers...)
 	require.NoError(t, err)
 	require.Equal(t, 4, len(conv))
 	for _, p := range conv {
-		require.Equal(t, xid, p.TransactionID())
-		require.Equal(t, [16]byte(hwaddr), p.ClientHwAddr())
+		require.Equal(t, xid, p.TransactionID)
+		require.Equal(t, hwaddr, p.ClientHWAddr)
 	}
 }

--- a/dhcpv4/server_test.go
+++ b/dhcpv4/server_test.go
@@ -113,7 +113,7 @@ func TestServerActivateAndServe(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, 0, len(ifaces))
 
-	xid := uint32(0xaabbccdd)
+	xid := TransactionID{0xaa, 0xbb, 0xcc, 0xdd}
 	hwaddr := [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
 
 	modifiers := []Modifier{

--- a/dhcpv4/types.go
+++ b/dhcpv4/types.go
@@ -3,6 +3,12 @@ package dhcpv4
 // values from http://www.networksorcery.com/enp/protocol/dhcp.htm and
 // http://www.networksorcery.com/enp/protocol/bootp/options.htm
 
+// TransactionID represents a 4-byte DHCP transaction ID as defined in RFC 951,
+// Section 3.
+//
+// The TransactionID is used to match DHCP replies to their original request.
+type TransactionID [4]byte
+
 // MessageType represents the possible DHCP message types - DISCOVER, OFFER, etc
 type MessageType byte
 

--- a/dhcpv4/types.go
+++ b/dhcpv4/types.go
@@ -28,14 +28,13 @@ const (
 )
 
 func (m MessageType) String() string {
-	if s, ok := MessageTypeToString[m]; ok {
+	if s, ok := messageTypeToString[m]; ok {
 		return s
 	}
 	return "Unknown"
 }
 
-// MessageTypeToString maps DHCP message types to human-readable strings.
-var MessageTypeToString = map[MessageType]string{
+var messageTypeToString = map[MessageType]string{
 	MessageTypeDiscover: "DISCOVER",
 	MessageTypeOffer:    "OFFER",
 	MessageTypeRequest:  "REQUEST",
@@ -56,14 +55,13 @@ const (
 )
 
 func (o OpcodeType) String() string {
-	if s, ok := OpcodeToString[o]; ok {
+	if s, ok := opcodeToString[o]; ok {
 		return s
 	}
 	return "Unknown"
 }
 
-// OpcodeToString maps an OpcodeType to its mnemonic name
-var OpcodeToString = map[OpcodeType]string{
+var opcodeToString = map[OpcodeType]string{
 	OpcodeBootRequest: "BootRequest",
 	OpcodeBootReply:   "BootReply",
 }
@@ -233,14 +231,13 @@ const (
 )
 
 func (o OptionCode) String() string {
-	if s, ok := OptionCodeToString[o]; ok {
+	if s, ok := optionCodeToString[o]; ok {
 		return s
 	}
 	return "Unknown"
 }
 
-// OptionCodeToString maps an OptionCode to its mnemonic name
-var OptionCodeToString = map[OptionCode]string{
+var optionCodeToString = map[OptionCode]string{
 	OptionPad:                                        "Pad",
 	OptionSubnetMask:                                 "Subnet Mask",
 	OptionTimeOffset:                                 "Time Offset",

--- a/netboot/netboot.go
+++ b/netboot/netboot.go
@@ -19,7 +19,7 @@ var sleeper = func(d time.Duration) {
 func RequestNetbootv6(ifname string, timeout time.Duration, retries int, modifiers ...dhcpv6.Modifier) ([]dhcpv6.DHCPv6, error) {
 	var (
 		conversation []dhcpv6.DHCPv6
-		err error
+		err          error
 	)
 	modifiers = append(modifiers, dhcpv6.WithNetboot)
 	delay := 2 * time.Second
@@ -136,8 +136,8 @@ func ConversationToNetconfv4(conversation []*dhcpv4.DHCPv4) (*NetConf, string, e
 		// look for a BootReply packet of type Offer containing the bootfile URL.
 		// Normally both packets with Message Type OFFER or ACK do contain
 		// the bootfile URL.
-		if m.Opcode() == dhcpv4.OpcodeBootReply && *m.MessageType() == dhcpv4.MessageTypeOffer {
-			bootFileUrl = m.BootFileNameToString()
+		if m.OpCode == dhcpv4.OpcodeBootReply && m.MessageType() == dhcpv4.MessageTypeOffer {
+			bootFileUrl = m.BootFileName
 			reply = m
 			break
 		}

--- a/netboot/netconf.go
+++ b/netboot/netconf.go
@@ -79,8 +79,8 @@ func GetNetConfFromPacketv6(d *dhcpv6.DHCPv6Message) (*NetConf, error) {
 // Reply packet and returns a populated NetConf structure
 func GetNetConfFromPacketv4(d *dhcpv4.DHCPv4) (*NetConf, error) {
 	// extract the address from the DHCPv4 address
-	ipAddr := d.YourIPAddr()
-	if ipAddr.Equal(net.IPv4zero) {
+	ipAddr := d.YourIPAddr
+	if ipAddr == nil || ipAddr.Equal(net.IPv4zero) {
 		return nil, errors.New("ip address is null (0.0.0.0)")
 	}
 	netconf := NetConf{}

--- a/netboot/netconf_test.go
+++ b/netboot/netconf_test.go
@@ -108,21 +108,21 @@ func TestGetNetConfFromPacketv6(t *testing.T) {
 
 func TestGetNetConfFromPacketv4AddrZero(t *testing.T) {
 	d := dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.IPv4zero)
+	d.YourIPAddr = net.IPv4zero
 	_, err := GetNetConfFromPacketv4(&d)
 	require.Error(t, err)
 }
 
 func TestGetNetConfFromPacketv4NoMask(t *testing.T) {
 	d := dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	_, err := GetNetConfFromPacketv4(&d)
 	require.Error(t, err)
 }
 
 func TestGetNetConfFromPacketv4NullMask(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(0, 0, 0, 0))(d)
 	_, err := GetNetConfFromPacketv4(d)
 	require.Error(t, err)
@@ -130,7 +130,7 @@ func TestGetNetConfFromPacketv4NullMask(t *testing.T) {
 
 func TestGetNetConfFromPacketv4NoLeaseTime(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	_, err := GetNetConfFromPacketv4(d)
 	require.Error(t, err)
@@ -138,7 +138,7 @@ func TestGetNetConfFromPacketv4NoLeaseTime(t *testing.T) {
 
 func TestGetNetConfFromPacketv4NoDNS(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	d = dhcpv4.WithLeaseTime(uint32(0))(d)
 	_, err := GetNetConfFromPacketv4(d)
@@ -147,7 +147,7 @@ func TestGetNetConfFromPacketv4NoDNS(t *testing.T) {
 
 func TestGetNetConfFromPacketv4EmptyDNSList(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	d = dhcpv4.WithLeaseTime(uint32(0))(d)
 	d = dhcpv4.WithDNS()(d)
@@ -157,7 +157,7 @@ func TestGetNetConfFromPacketv4EmptyDNSList(t *testing.T) {
 
 func TestGetNetConfFromPacketv4NoSearchList(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	d = dhcpv4.WithLeaseTime(uint32(0))(d)
 	d = dhcpv4.WithDNS(net.ParseIP("10.10.0.1"), net.ParseIP("10.10.0.2"))(d)
@@ -167,7 +167,7 @@ func TestGetNetConfFromPacketv4NoSearchList(t *testing.T) {
 
 func TestGetNetConfFromPacketv4EmptySearchList(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	d = dhcpv4.WithLeaseTime(uint32(0))(d)
 	d = dhcpv4.WithDNS(net.ParseIP("10.10.0.1"), net.ParseIP("10.10.0.2"))(d)
@@ -178,7 +178,7 @@ func TestGetNetConfFromPacketv4EmptySearchList(t *testing.T) {
 
 func TestGetNetConfFromPacketv4NoRouter(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	d = dhcpv4.WithLeaseTime(uint32(0))(d)
 	d = dhcpv4.WithDNS(net.ParseIP("10.10.0.1"), net.ParseIP("10.10.0.2"))(d)
@@ -189,7 +189,7 @@ func TestGetNetConfFromPacketv4NoRouter(t *testing.T) {
 
 func TestGetNetConfFromPacketv4EmptyRouter(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	d = dhcpv4.WithLeaseTime(uint32(0))(d)
 	d = dhcpv4.WithDNS(net.ParseIP("10.10.0.1"), net.ParseIP("10.10.0.2"))(d)
@@ -201,7 +201,7 @@ func TestGetNetConfFromPacketv4EmptyRouter(t *testing.T) {
 
 func TestGetNetConfFromPacketv4(t *testing.T) {
 	d := &dhcpv4.DHCPv4{}
-	d.SetYourIPAddr(net.ParseIP("10.0.0.1"))
+	d.YourIPAddr = net.ParseIP("10.0.0.1")
 	d = dhcpv4.WithNetmask(net.IPv4Mask(255, 255, 255, 0))(d)
 	d = dhcpv4.WithLeaseTime(uint32(5200))(d)
 	d = dhcpv4.WithDNS(net.ParseIP("10.10.0.1"), net.ParseIP("10.10.0.2"))(d)


### PR DESCRIPTION
Starting with the easy stuff from the other PR. Just cleans up the DHCPv4 type itself, and the marshaling/unmarshaling of data for just the message. Options to come.