### PR TITLE
dhcpv4: simplify option marshaling

### DIFF
--- a/dhcpv4/bsdp/boot_image.go
+++ b/dhcpv4/bsdp/boot_image.go
@@ -1,7 +1,6 @@
 package bsdp
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	"github.com/u-root/u-root/pkg/uio"
@@ -36,15 +35,16 @@ type BootImageID struct {
 	Index     uint16
 }
 
-// ToBytes serializes a BootImageID to network-order bytes.
-func (b BootImageID) ToBytes() []byte {
-	bytes := make([]byte, 4)
+// Marshal writes the binary representation to buf.
+func (b BootImageID) Marshal(buf *uio.Lexer) {
+	var byte0 byte
 	if b.IsInstall {
-		bytes[0] |= 0x80
+		byte0 |= 0x80
 	}
-	bytes[0] |= byte(b.ImageType)
-	binary.BigEndian.PutUint16(bytes[2:], b.Index)
-	return bytes
+	byte0 |= byte(b.ImageType)
+	buf.Write8(byte0)
+	buf.Write8(byte(0))
+	buf.Write16(b.Index)
 }
 
 // String converts a BootImageID to a human-readable representation.
@@ -78,12 +78,11 @@ type BootImage struct {
 	Name string
 }
 
-// ToBytes converts a BootImage to a slice of bytes.
-func (b *BootImage) ToBytes() []byte {
-	bytes := b.ID.ToBytes()
-	bytes = append(bytes, byte(len(b.Name)))
-	bytes = append(bytes, []byte(b.Name)...)
-	return bytes
+// Marshal write a BootImage to buf.
+func (b BootImage) Marshal(buf *uio.Lexer) {
+	b.ID.Marshal(buf)
+	buf.Write8(uint8(len(b.Name)))
+	buf.WriteBytes([]byte(b.Name))
 }
 
 // String converts a BootImage to a human-readable representation.

--- a/dhcpv4/bsdp/boot_image_test.go
+++ b/dhcpv4/bsdp/boot_image_test.go
@@ -13,12 +13,12 @@ func TestBootImageIDToBytes(t *testing.T) {
 		ImageType: BootImageTypeMacOSX,
 		Index:     0x1000,
 	}
-	actual := b.ToBytes()
+	actual := uio.ToBigEndian(b)
 	expected := []byte{0x81, 0, 0x10, 0}
 	require.Equal(t, expected, actual)
 
 	b.IsInstall = false
-	actual = b.ToBytes()
+	actual = uio.ToBigEndian(b)
 	expected = []byte{0x01, 0, 0x10, 0}
 	require.Equal(t, expected, actual)
 }
@@ -30,7 +30,7 @@ func TestBootImageIDFromBytes(t *testing.T) {
 		Index:     0x1000,
 	}
 	var newBootImage BootImageID
-	require.NoError(t, uio.FromBigEndian(&newBootImage, b.ToBytes()))
+	require.NoError(t, uio.FromBigEndian(&newBootImage, uio.ToBigEndian(b)))
 	require.Equal(t, b, newBootImage)
 
 	b = BootImageID{
@@ -38,7 +38,7 @@ func TestBootImageIDFromBytes(t *testing.T) {
 		ImageType: BootImageTypeMacOSX,
 		Index:     0x1011,
 	}
-	require.NoError(t, uio.FromBigEndian(&newBootImage, b.ToBytes()))
+	require.NoError(t, uio.FromBigEndian(&newBootImage, uio.ToBigEndian(b)))
 	require.Equal(t, b, newBootImage)
 }
 
@@ -70,7 +70,7 @@ func TestBootImageToBytes(t *testing.T) {
 		6,                         // len(Name)
 		98, 115, 100, 112, 45, 49, // byte-encoding of Name
 	}
-	actual := b.ToBytes()
+	actual := uio.ToBigEndian(b)
 	require.Equal(t, expected, actual)
 
 	b = BootImage{
@@ -86,7 +86,7 @@ func TestBootImageToBytes(t *testing.T) {
 		7,                             // len(Name)
 		98, 115, 100, 112, 45, 50, 49, // byte-encoding of Name
 	}
-	actual = b.ToBytes()
+	actual = uio.ToBigEndian(b)
 	require.Equal(t, expected, actual)
 }
 

--- a/dhcpv4/bsdp/bsdp.go
+++ b/dhcpv4/bsdp/bsdp.go
@@ -36,7 +36,7 @@ func ParseBootImageListFromAck(ack dhcpv4.DHCPv4) ([]BootImage, error) {
 	if opt == nil {
 		return nil, errors.New("ParseBootImageListFromAck: could not find vendor-specific option")
 	}
-	vendorOpt, err := ParseOptVendorSpecificInformation(opt.ToBytes()[2:])
+	vendorOpt, err := ParseOptVendorSpecificInformation(opt.ToBytes())
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func MessageTypeFromPacket(packet *dhcpv4.DHCPv4) *MessageType {
 		err        error
 	)
 	for _, opt := range packet.GetOption(dhcpv4.OptionVendorSpecificInformation) {
-		if vendorOpts, err = ParseOptVendorSpecificInformation(opt.ToBytes()[2:]); err == nil {
+		if vendorOpts, err = ParseOptVendorSpecificInformation(opt.ToBytes()); err == nil {
 			if o := vendorOpts.GetOneOption(OptionMessageType); o != nil {
 				if optMessageType, ok := o.(*OptMessageType); ok {
 					return &optMessageType.Type

--- a/dhcpv4/bsdp/bsdp_option_boot_image_list.go
+++ b/dhcpv4/bsdp/bsdp_option_boot_image_list.go
@@ -52,12 +52,3 @@ func (o *OptBootImageList) String() string {
 	}
 	return s
 }
-
-// Length returns the length of the data portion of this option.
-func (o *OptBootImageList) Length() int {
-	length := 0
-	for _, image := range o.Images {
-		length += 4 + 1 + len(image.Name)
-	}
-	return length
-}

--- a/dhcpv4/bsdp/bsdp_option_boot_image_list.go
+++ b/dhcpv4/bsdp/bsdp_option_boot_image_list.go
@@ -37,12 +37,11 @@ func (o *OptBootImageList) Code() dhcpv4.OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptBootImageList) ToBytes() []byte {
-	bs := make([]byte, 0, 2+o.Length())
-	bs = append(bs, []byte{byte(o.Code()), byte(o.Length())}...)
+	buf := uio.NewBigEndianBuffer(nil)
 	for _, image := range o.Images {
-		bs = append(bs, image.ToBytes()...)
+		image.Marshal(buf)
 	}
-	return bs
+	return buf.Data()
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/bsdp/bsdp_option_boot_image_list_test.go
+++ b/dhcpv4/bsdp/bsdp_option_boot_image_list_test.go
@@ -29,8 +29,6 @@ func TestOptBootImageListInterfaceMethods(t *testing.T) {
 	require.Equal(t, OptionBootImageList, o.Code(), "Code")
 	require.Equal(t, 22, o.Length(), "Length")
 	expectedBytes := []byte{
-		9,  // code
-		22, // length
 		// boot image 1
 		0x1, 0x0, 0x03, 0xe9, // ID
 		6, // name length

--- a/dhcpv4/bsdp/bsdp_option_boot_image_list_test.go
+++ b/dhcpv4/bsdp/bsdp_option_boot_image_list_test.go
@@ -27,7 +27,6 @@ func TestOptBootImageListInterfaceMethods(t *testing.T) {
 	}
 	o := OptBootImageList{bs}
 	require.Equal(t, OptionBootImageList, o.Code(), "Code")
-	require.Equal(t, 22, o.Length(), "Length")
 	expectedBytes := []byte{
 		// boot image 1
 		0x1, 0x0, 0x03, 0xe9, // ID

--- a/dhcpv4/bsdp/bsdp_option_default_boot_image_id.go
+++ b/dhcpv4/bsdp/bsdp_option_default_boot_image_id.go
@@ -33,8 +33,7 @@ func (o *OptDefaultBootImageID) Code() dhcpv4.OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptDefaultBootImageID) ToBytes() []byte {
-	serializedID := o.ID.ToBytes()
-	return append([]byte{byte(o.Code()), byte(len(serializedID))}, serializedID...)
+	return uio.ToBigEndian(o.ID)
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/bsdp/bsdp_option_default_boot_image_id.go
+++ b/dhcpv4/bsdp/bsdp_option_default_boot_image_id.go
@@ -40,8 +40,3 @@ func (o *OptDefaultBootImageID) ToBytes() []byte {
 func (o *OptDefaultBootImageID) String() string {
 	return fmt.Sprintf("BSDP Default Boot Image ID -> %s", o.ID.String())
 }
-
-// Length returns the length of the data portion of this option.
-func (o *OptDefaultBootImageID) Length() int {
-	return 4
-}

--- a/dhcpv4/bsdp/bsdp_option_default_boot_image_id_test.go
+++ b/dhcpv4/bsdp/bsdp_option_default_boot_image_id_test.go
@@ -11,7 +11,6 @@ func TestOptDefaultBootImageIDInterfaceMethods(t *testing.T) {
 	b := BootImageID{IsInstall: true, ImageType: BootImageTypeMacOSX, Index: 1001}
 	o := OptDefaultBootImageID{b}
 	require.Equal(t, OptionDefaultBootImageID, o.Code(), "Code")
-	require.Equal(t, 4, o.Length(), "Length")
 	require.Equal(t, uio.ToBigEndian(b), o.ToBytes(), "ToBytes")
 }
 

--- a/dhcpv4/bsdp/bsdp_option_default_boot_image_id_test.go
+++ b/dhcpv4/bsdp/bsdp_option_default_boot_image_id_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 func TestOptDefaultBootImageIDInterfaceMethods(t *testing.T) {
@@ -11,13 +12,12 @@ func TestOptDefaultBootImageIDInterfaceMethods(t *testing.T) {
 	o := OptDefaultBootImageID{b}
 	require.Equal(t, OptionDefaultBootImageID, o.Code(), "Code")
 	require.Equal(t, 4, o.Length(), "Length")
-	expectedBytes := []byte{byte(OptionDefaultBootImageID), 4}
-	require.Equal(t, append(expectedBytes, b.ToBytes()...), o.ToBytes(), "ToBytes")
+	require.Equal(t, uio.ToBigEndian(b), o.ToBytes(), "ToBytes")
 }
 
 func TestParseOptDefaultBootImageID(t *testing.T) {
 	b := BootImageID{IsInstall: true, ImageType: BootImageTypeMacOSX, Index: 1001}
-	o, err := ParseOptDefaultBootImageID(b.ToBytes())
+	o, err := ParseOptDefaultBootImageID(uio.ToBigEndian(b))
 	require.NoError(t, err)
 	require.Equal(t, &OptDefaultBootImageID{b}, o)
 

--- a/dhcpv4/bsdp/bsdp_option_generic.go
+++ b/dhcpv4/bsdp/bsdp_option_generic.go
@@ -27,7 +27,7 @@ func (o OptGeneric) Code() dhcpv4.OptionCode {
 
 // ToBytes returns a serialized generic option as a slice of bytes.
 func (o OptGeneric) ToBytes() []byte {
-	return append([]byte{byte(o.Code()), byte(o.Length())}, o.Data...)
+	return o.Data
 }
 
 // String returns a human-readable representation of a generic option.

--- a/dhcpv4/bsdp/bsdp_option_generic.go
+++ b/dhcpv4/bsdp/bsdp_option_generic.go
@@ -38,8 +38,3 @@ func (o OptGeneric) String() string {
 	}
 	return fmt.Sprintf("%v -> %v", code, o.Data)
 }
-
-// Length returns the number of bytes comprising the data section of the option.
-func (o OptGeneric) Length() int {
-	return len(o.Data)
-}

--- a/dhcpv4/bsdp/bsdp_option_generic_test.go
+++ b/dhcpv4/bsdp/bsdp_option_generic_test.go
@@ -55,12 +55,3 @@ func TestOptGenericStringUnknown(t *testing.T) {
 	}
 	require.Equal(t, "Unknown -> [5]", o.String())
 }
-
-func TestOptGenericLength(t *testing.T) {
-	filename := "some_machine_name"
-	o := OptGeneric{
-		OptionCode: OptionMachineName,
-		Data:       []byte(filename),
-	}
-	require.Equal(t, len(filename), o.Length())
-}

--- a/dhcpv4/bsdp/bsdp_option_generic_test.go
+++ b/dhcpv4/bsdp/bsdp_option_generic_test.go
@@ -36,7 +36,7 @@ func TestOptGenericToBytes(t *testing.T) {
 		Data:       []byte{192, 168, 0, 1},
 	}
 	serialized := o.ToBytes()
-	expected := []byte{3, 4, 192, 168, 0, 1}
+	expected := []byte{192, 168, 0, 1}
 	require.Equal(t, expected, serialized)
 }
 

--- a/dhcpv4/bsdp/bsdp_option_machine_name.go
+++ b/dhcpv4/bsdp/bsdp_option_machine_name.go
@@ -32,8 +32,3 @@ func (o *OptMachineName) ToBytes() []byte {
 func (o *OptMachineName) String() string {
 	return "BSDP Machine Name -> " + o.Name
 }
-
-// Length returns the length of the data portion of this option.
-func (o *OptMachineName) Length() int {
-	return len(o.Name)
-}

--- a/dhcpv4/bsdp/bsdp_option_machine_name.go
+++ b/dhcpv4/bsdp/bsdp_option_machine_name.go
@@ -25,7 +25,7 @@ func (o *OptMachineName) Code() dhcpv4.OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptMachineName) ToBytes() []byte {
-	return append([]byte{byte(o.Code()), byte(o.Length())}, []byte(o.Name)...)
+	return []byte(o.Name)
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/bsdp/bsdp_option_machine_name_test.go
+++ b/dhcpv4/bsdp/bsdp_option_machine_name_test.go
@@ -9,7 +9,6 @@ import (
 func TestOptMachineNameInterfaceMethods(t *testing.T) {
 	o := OptMachineName{"somebox"}
 	require.Equal(t, OptionMachineName, o.Code(), "Code")
-	require.Equal(t, 7, o.Length(), "Length")
 	expectedBytes := []byte{'s', 'o', 'm', 'e', 'b', 'o', 'x'}
 	require.Equal(t, expectedBytes, o.ToBytes(), "ToBytes")
 }

--- a/dhcpv4/bsdp/bsdp_option_machine_name_test.go
+++ b/dhcpv4/bsdp/bsdp_option_machine_name_test.go
@@ -10,7 +10,7 @@ func TestOptMachineNameInterfaceMethods(t *testing.T) {
 	o := OptMachineName{"somebox"}
 	require.Equal(t, OptionMachineName, o.Code(), "Code")
 	require.Equal(t, 7, o.Length(), "Length")
-	expectedBytes := []byte{130, 7, 's', 'o', 'm', 'e', 'b', 'o', 'x'}
+	expectedBytes := []byte{'s', 'o', 'm', 'e', 'b', 'o', 'x'}
 	require.Equal(t, expectedBytes, o.ToBytes(), "ToBytes")
 }
 

--- a/dhcpv4/bsdp/bsdp_option_message_type.go
+++ b/dhcpv4/bsdp/bsdp_option_message_type.go
@@ -53,7 +53,7 @@ func (o *OptMessageType) Code() dhcpv4.OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptMessageType) ToBytes() []byte {
-	return []byte{byte(o.Code()), 1, byte(o.Type)}
+	return []byte{byte(o.Type)}
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/bsdp/bsdp_option_message_type.go
+++ b/dhcpv4/bsdp/bsdp_option_message_type.go
@@ -60,8 +60,3 @@ func (o *OptMessageType) ToBytes() []byte {
 func (o *OptMessageType) String() string {
 	return fmt.Sprintf("BSDP Message Type -> %s", o.Type.String())
 }
-
-// Length returns the length of the data portion of this option.
-func (o *OptMessageType) Length() int {
-	return 1
-}

--- a/dhcpv4/bsdp/bsdp_option_message_type_test.go
+++ b/dhcpv4/bsdp/bsdp_option_message_type_test.go
@@ -10,7 +10,7 @@ func TestOptMessageTypeInterfaceMethods(t *testing.T) {
 	o := OptMessageType{MessageTypeList}
 	require.Equal(t, OptionMessageType, o.Code(), "Code")
 	require.Equal(t, 1, o.Length(), "Length")
-	require.Equal(t, []byte{1, 1, 1}, o.ToBytes(), "ToBytes")
+	require.Equal(t, []byte{1}, o.ToBytes(), "ToBytes")
 }
 
 func TestParseOptMessageType(t *testing.T) {

--- a/dhcpv4/bsdp/bsdp_option_message_type_test.go
+++ b/dhcpv4/bsdp/bsdp_option_message_type_test.go
@@ -9,7 +9,6 @@ import (
 func TestOptMessageTypeInterfaceMethods(t *testing.T) {
 	o := OptMessageType{MessageTypeList}
 	require.Equal(t, OptionMessageType, o.Code(), "Code")
-	require.Equal(t, 1, o.Length(), "Length")
 	require.Equal(t, []byte{1}, o.ToBytes(), "ToBytes")
 }
 

--- a/dhcpv4/bsdp/bsdp_option_reply_port.go
+++ b/dhcpv4/bsdp/bsdp_option_reply_port.go
@@ -1,7 +1,6 @@
 package bsdp
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
@@ -32,9 +31,9 @@ func (o *OptReplyPort) Code() dhcpv4.OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptReplyPort) ToBytes() []byte {
-	serialized := make([]byte, 2)
-	binary.BigEndian.PutUint16(serialized, o.Port)
-	return append([]byte{byte(o.Code()), 2}, serialized...)
+	buf := uio.NewBigEndianBuffer(nil)
+	buf.Write16(o.Port)
+	return buf.Data()
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/bsdp/bsdp_option_reply_port.go
+++ b/dhcpv4/bsdp/bsdp_option_reply_port.go
@@ -40,8 +40,3 @@ func (o *OptReplyPort) ToBytes() []byte {
 func (o *OptReplyPort) String() string {
 	return fmt.Sprintf("BSDP Reply Port -> %v", o.Port)
 }
-
-// Length returns the length of the data portion of this option.
-func (o *OptReplyPort) Length() int {
-	return 2
-}

--- a/dhcpv4/bsdp/bsdp_option_reply_port_test.go
+++ b/dhcpv4/bsdp/bsdp_option_reply_port_test.go
@@ -9,7 +9,6 @@ import (
 func TestOptReplyPortInterfaceMethods(t *testing.T) {
 	o := OptReplyPort{1234}
 	require.Equal(t, OptionReplyPort, o.Code(), "Code")
-	require.Equal(t, 2, o.Length(), "Length")
 	require.Equal(t, []byte{4, 210}, o.ToBytes(), "ToBytes")
 }
 

--- a/dhcpv4/bsdp/bsdp_option_reply_port_test.go
+++ b/dhcpv4/bsdp/bsdp_option_reply_port_test.go
@@ -10,7 +10,7 @@ func TestOptReplyPortInterfaceMethods(t *testing.T) {
 	o := OptReplyPort{1234}
 	require.Equal(t, OptionReplyPort, o.Code(), "Code")
 	require.Equal(t, 2, o.Length(), "Length")
-	require.Equal(t, []byte{byte(OptionReplyPort), 2, 4, 210}, o.ToBytes(), "ToBytes")
+	require.Equal(t, []byte{4, 210}, o.ToBytes(), "ToBytes")
 }
 
 func TestParseOptReplyPort(t *testing.T) {

--- a/dhcpv4/bsdp/bsdp_option_selected_boot_image_id.go
+++ b/dhcpv4/bsdp/bsdp_option_selected_boot_image_id.go
@@ -33,8 +33,7 @@ func (o *OptSelectedBootImageID) Code() dhcpv4.OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptSelectedBootImageID) ToBytes() []byte {
-	serializedID := o.ID.ToBytes()
-	return append([]byte{byte(o.Code()), byte(len(serializedID))}, serializedID...)
+	return uio.ToBigEndian(o.ID)
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/bsdp/bsdp_option_selected_boot_image_id.go
+++ b/dhcpv4/bsdp/bsdp_option_selected_boot_image_id.go
@@ -40,8 +40,3 @@ func (o *OptSelectedBootImageID) ToBytes() []byte {
 func (o *OptSelectedBootImageID) String() string {
 	return fmt.Sprintf("BSDP Selected Boot Image ID -> %s", o.ID.String())
 }
-
-// Length returns the length of the data portion of this option.
-func (o *OptSelectedBootImageID) Length() int {
-	return 4
-}

--- a/dhcpv4/bsdp/bsdp_option_selected_boot_image_id_test.go
+++ b/dhcpv4/bsdp/bsdp_option_selected_boot_image_id_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 func TestOptSelectedBootImageIDInterfaceMethods(t *testing.T) {
@@ -11,19 +12,17 @@ func TestOptSelectedBootImageIDInterfaceMethods(t *testing.T) {
 	o := OptSelectedBootImageID{b}
 	require.Equal(t, OptionSelectedBootImageID, o.Code(), "Code")
 	require.Equal(t, 4, o.Length(), "Length")
-	expectedBytes := []byte{byte(OptionSelectedBootImageID), 4}
-	require.Equal(t, append(expectedBytes, b.ToBytes()...), o.ToBytes(), "ToBytes")
+	require.Equal(t, uio.ToBigEndian(b), o.ToBytes(), "ToBytes")
 }
 
 func TestParseOptSelectedBootImageID(t *testing.T) {
 	b := BootImageID{IsInstall: true, ImageType: BootImageTypeMacOSX, Index: 1001}
-	data := b.ToBytes()
-	o, err := ParseOptSelectedBootImageID(data)
+	o, err := ParseOptSelectedBootImageID(uio.ToBigEndian(b))
 	require.NoError(t, err)
 	require.Equal(t, &OptSelectedBootImageID{b}, o)
 
 	// Short byte stream
-	data = []byte{}
+	data := []byte{}
 	_, err = ParseOptSelectedBootImageID(data)
 	require.Error(t, err, "should get error from short byte stream")
 

--- a/dhcpv4/bsdp/bsdp_option_selected_boot_image_id_test.go
+++ b/dhcpv4/bsdp/bsdp_option_selected_boot_image_id_test.go
@@ -11,7 +11,6 @@ func TestOptSelectedBootImageIDInterfaceMethods(t *testing.T) {
 	b := BootImageID{IsInstall: true, ImageType: BootImageTypeMacOSX, Index: 1001}
 	o := OptSelectedBootImageID{b}
 	require.Equal(t, OptionSelectedBootImageID, o.Code(), "Code")
-	require.Equal(t, 4, o.Length(), "Length")
 	require.Equal(t, uio.ToBigEndian(b), o.ToBytes(), "ToBytes")
 }
 

--- a/dhcpv4/bsdp/bsdp_option_server_identifier.go
+++ b/dhcpv4/bsdp/bsdp_option_server_identifier.go
@@ -27,8 +27,7 @@ func (o *OptServerIdentifier) Code() dhcpv4.OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptServerIdentifier) ToBytes() []byte {
-	ret := []byte{byte(o.Code()), byte(o.Length())}
-	return append(ret, o.ServerID.To4()...)
+	return o.ServerID.To4()
 }
 
 // String returns a human-readable string.

--- a/dhcpv4/bsdp/bsdp_option_server_identifier.go
+++ b/dhcpv4/bsdp/bsdp_option_server_identifier.go
@@ -34,9 +34,3 @@ func (o *OptServerIdentifier) ToBytes() []byte {
 func (o *OptServerIdentifier) String() string {
 	return fmt.Sprintf("BSDP Server Identifier -> %v", o.ServerID.String())
 }
-
-// Length returns the length of the data portion (excluding option code an byte
-// length).
-func (o *OptServerIdentifier) Length() int {
-	return len(o.ServerID.To4())
-}

--- a/dhcpv4/bsdp/bsdp_option_server_identifier_test.go
+++ b/dhcpv4/bsdp/bsdp_option_server_identifier_test.go
@@ -11,7 +11,7 @@ func TestOptServerIdentifierInterfaceMethods(t *testing.T) {
 	ip := net.IP{192, 168, 0, 1}
 	o := OptServerIdentifier{ServerID: ip}
 	require.Equal(t, OptionServerIdentifier, o.Code(), "Code")
-	expectedBytes := []byte{3, 4, 192, 168, 0, 1}
+	expectedBytes := []byte{192, 168, 0, 1}
 	require.Equal(t, expectedBytes, o.ToBytes(), "ToBytes")
 	require.Equal(t, 4, o.Length(), "Length")
 	require.Equal(t, "BSDP Server Identifier -> 192.168.0.1", o.String(), "String")

--- a/dhcpv4/bsdp/bsdp_option_server_identifier_test.go
+++ b/dhcpv4/bsdp/bsdp_option_server_identifier_test.go
@@ -13,7 +13,6 @@ func TestOptServerIdentifierInterfaceMethods(t *testing.T) {
 	require.Equal(t, OptionServerIdentifier, o.Code(), "Code")
 	expectedBytes := []byte{192, 168, 0, 1}
 	require.Equal(t, expectedBytes, o.ToBytes(), "ToBytes")
-	require.Equal(t, 4, o.Length(), "Length")
 	require.Equal(t, "BSDP Server Identifier -> 192.168.0.1", o.String(), "String")
 }
 

--- a/dhcpv4/bsdp/bsdp_option_server_priority.go
+++ b/dhcpv4/bsdp/bsdp_option_server_priority.go
@@ -35,9 +35,3 @@ func (o *OptServerPriority) ToBytes() []byte {
 func (o *OptServerPriority) String() string {
 	return fmt.Sprintf("BSDP Server Priority -> %v", o.Priority)
 }
-
-// Length returns the length of the data portion (excluding option code an byte
-// length).
-func (o *OptServerPriority) Length() int {
-	return 2
-}

--- a/dhcpv4/bsdp/bsdp_option_server_priority.go
+++ b/dhcpv4/bsdp/bsdp_option_server_priority.go
@@ -1,7 +1,6 @@
 package bsdp
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
@@ -27,9 +26,9 @@ func (o *OptServerPriority) Code() dhcpv4.OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptServerPriority) ToBytes() []byte {
-	serialized := make([]byte, 2)
-	binary.BigEndian.PutUint16(serialized, uint16(o.Priority))
-	return append([]byte{byte(o.Code()), byte(o.Length())}, serialized...)
+	buf := uio.NewBigEndianBuffer(nil)
+	buf.Write16(o.Priority)
+	return buf.Data()
 }
 
 // String returns a human-readable string.

--- a/dhcpv4/bsdp/bsdp_option_server_priority_test.go
+++ b/dhcpv4/bsdp/bsdp_option_server_priority_test.go
@@ -10,7 +10,6 @@ func TestOptServerPriorityInterfaceMethods(t *testing.T) {
 	o := OptServerPriority{Priority: 100}
 	require.Equal(t, OptionServerPriority, o.Code(), "Code")
 	require.Equal(t, []byte{0, 100}, o.ToBytes(), "ToBytes")
-	require.Equal(t, 2, o.Length(), "Length")
 	require.Equal(t, "BSDP Server Priority -> 100", o.String(), "String")
 }
 

--- a/dhcpv4/bsdp/bsdp_option_server_priority_test.go
+++ b/dhcpv4/bsdp/bsdp_option_server_priority_test.go
@@ -9,7 +9,7 @@ import (
 func TestOptServerPriorityInterfaceMethods(t *testing.T) {
 	o := OptServerPriority{Priority: 100}
 	require.Equal(t, OptionServerPriority, o.Code(), "Code")
-	require.Equal(t, []byte{4, 2, 0, 100}, o.ToBytes(), "ToBytes")
+	require.Equal(t, []byte{0, 100}, o.ToBytes(), "ToBytes")
 	require.Equal(t, 2, o.Length(), "Length")
 	require.Equal(t, "BSDP Server Priority -> 100", o.String(), "String")
 }

--- a/dhcpv4/bsdp/bsdp_option_version.go
+++ b/dhcpv4/bsdp/bsdp_option_version.go
@@ -34,7 +34,7 @@ func (o *OptVersion) Code() dhcpv4.OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptVersion) ToBytes() []byte {
-	return append([]byte{byte(o.Code()), 2}, o.Version...)
+	return o.Version
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/bsdp/bsdp_option_version.go
+++ b/dhcpv4/bsdp/bsdp_option_version.go
@@ -41,8 +41,3 @@ func (o *OptVersion) ToBytes() []byte {
 func (o *OptVersion) String() string {
 	return fmt.Sprintf("BSDP Version -> %v.%v", o.Version[0], o.Version[1])
 }
-
-// Length returns the length of the data portion of this option.
-func (o *OptVersion) Length() int {
-	return 2
-}

--- a/dhcpv4/bsdp/bsdp_option_version_test.go
+++ b/dhcpv4/bsdp/bsdp_option_version_test.go
@@ -10,7 +10,7 @@ func TestOptVersionInterfaceMethods(t *testing.T) {
 	o := OptVersion{Version1_1}
 	require.Equal(t, OptionVersion, o.Code(), "Code")
 	require.Equal(t, 2, o.Length(), "Length")
-	require.Equal(t, []byte{2, 2, 1, 1}, o.ToBytes(), "ToBytes")
+	require.Equal(t, []byte{1, 1}, o.ToBytes(), "ToBytes")
 }
 
 func TestParseOptVersion(t *testing.T) {

--- a/dhcpv4/bsdp/bsdp_option_version_test.go
+++ b/dhcpv4/bsdp/bsdp_option_version_test.go
@@ -9,7 +9,6 @@ import (
 func TestOptVersionInterfaceMethods(t *testing.T) {
 	o := OptVersion{Version1_1}
 	require.Equal(t, OptionVersion, o.Code(), "Code")
-	require.Equal(t, 2, o.Length(), "Length")
 	require.Equal(t, []byte{1, 1}, o.ToBytes(), "ToBytes")
 }
 

--- a/dhcpv4/bsdp/option_vendor_specific_information.go
+++ b/dhcpv4/bsdp/option_vendor_specific_information.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 // OptVendorSpecificInformation encapsulates the BSDP-specific options used for
@@ -64,13 +65,7 @@ func (o *OptVendorSpecificInformation) Code() dhcpv4.OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptVendorSpecificInformation) ToBytes() []byte {
-	bs := []byte{byte(o.Code()), byte(o.Length())}
-
-	// Append data section
-	for _, opt := range o.Options {
-		bs = append(bs, opt.ToBytes()...)
-	}
-	return bs
+	return uio.ToBigEndian(o.Options)
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/bsdp/option_vendor_specific_information.go
+++ b/dhcpv4/bsdp/option_vendor_specific_information.go
@@ -82,16 +82,6 @@ func (o *OptVendorSpecificInformation) String() string {
 	return s
 }
 
-// Length returns the length of the data portion of this option. Take into
-// account code + data length bytes for each sub option.
-func (o *OptVendorSpecificInformation) Length() int {
-	var length int
-	for _, opt := range o.Options {
-		length += 2 + opt.Length()
-	}
-	return length
-}
-
 // GetOption returns all suboptions that match the given OptionCode code.
 func (o *OptVendorSpecificInformation) GetOption(code dhcpv4.OptionCode) []dhcpv4.Option {
 	return o.Options.Get(code)

--- a/dhcpv4/bsdp/option_vendor_specific_information_test.go
+++ b/dhcpv4/bsdp/option_vendor_specific_information_test.go
@@ -12,7 +12,6 @@ func TestOptVendorSpecificInformationInterfaceMethods(t *testing.T) {
 	versionOpt := &OptVersion{Version1_1}
 	o := &OptVendorSpecificInformation{[]dhcpv4.Option{messageTypeOpt, versionOpt}}
 	require.Equal(t, dhcpv4.OptionVendorSpecificInformation, o.Code(), "Code")
-	require.Equal(t, 2+messageTypeOpt.Length()+2+versionOpt.Length(), o.Length(), "Length")
 
 	expectedBytes := []byte{
 		1, 1, 1, // List option

--- a/dhcpv4/bsdp/option_vendor_specific_information_test.go
+++ b/dhcpv4/bsdp/option_vendor_specific_information_test.go
@@ -15,8 +15,6 @@ func TestOptVendorSpecificInformationInterfaceMethods(t *testing.T) {
 	require.Equal(t, 2+messageTypeOpt.Length()+2+versionOpt.Length(), o.Length(), "Length")
 
 	expectedBytes := []byte{
-		43,      // code
-		7,       // length
 		1, 1, 1, // List option
 		2, 2, 1, 1, // Version option
 	}

--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"strings"
 
@@ -472,29 +471,6 @@ func (d *DHCPv4) Summary() string {
 	return ret
 }
 
-// ValidateOptions runs sanity checks on the DHCPv4 packet and prints a number
-// of warnings if something is incorrect.
-func (d *DHCPv4) ValidateOptions() {
-	// TODO find duplicate options
-	foundOptionEnd := false
-	for _, opt := range d.Options {
-		if foundOptionEnd {
-			if opt.Code() == OptionEnd {
-				log.Print("Warning: found duplicate End option")
-			}
-			if opt.Code() != OptionEnd && opt.Code() != OptionPad {
-				log.Printf("Warning: found option %v (%v) after End option", opt.Code(), opt.Code().String())
-			}
-		}
-		if opt.Code() == OptionEnd {
-			foundOptionEnd = true
-		}
-	}
-	if !foundOptionEnd {
-		log.Print("Warning: no End option found")
-	}
-}
-
 // IsOptionRequested returns true if that option is within the requested
 // options of the DHCPv4 message.
 func (d *DHCPv4) IsOptionRequested(requested OptionCode) bool {
@@ -553,9 +529,7 @@ func (d *DHCPv4) ToBytes() []byte {
 
 	// The magic cookie.
 	buf.WriteBytes(magicCookie[:])
-
-	for _, opt := range d.Options {
-		buf.WriteBytes(opt.ToBytes())
-	}
+	d.Options.Marshal(buf)
+	buf.Write8(uint8(OptionEnd))
 	return buf.Data()
 }

--- a/dhcpv4/modifiers_test.go
+++ b/dhcpv4/modifiers_test.go
@@ -49,8 +49,6 @@ func TestUserClassModifier(t *testing.T) {
 	userClass := WithUserClass([]byte("linuxboot"), false)
 	d = userClass(d)
 	expected := []byte{
-		77, // OptionUserClass
-		9,  // length
 		'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
 	require.Equal(t, "User Class Information -> linuxboot", d.Options[0].String())
@@ -62,8 +60,6 @@ func TestUserClassModifierRFC(t *testing.T) {
 	userClass := WithUserClass([]byte("linuxboot"), true)
 	d = userClass(d)
 	expected := []byte{
-		77, // OptionUserClass
-		10, // length
 		9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
 	require.Equal(t, "User Class Information -> linuxboot", d.Options[0].String())

--- a/dhcpv4/option_archtype.go
+++ b/dhcpv4/option_archtype.go
@@ -30,12 +30,6 @@ func (o *OptClientArchType) ToBytes() []byte {
 	return buf.Data()
 }
 
-// Length returns the length of the data portion (excluding option code an byte
-// length).
-func (o *OptClientArchType) Length() int {
-	return 2 * len(o.ArchTypes)
-}
-
 // String returns a human-readable string.
 func (o *OptClientArchType) String() string {
 	var archTypes string

--- a/dhcpv4/option_archtype.go
+++ b/dhcpv4/option_archtype.go
@@ -4,7 +4,6 @@ package dhcpv4
 // https://tools.ietf.org/html/rfc4578
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	"github.com/insomniacslk/dhcp/iana"
@@ -24,13 +23,11 @@ func (o *OptClientArchType) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptClientArchType) ToBytes() []byte {
-	ret := []byte{byte(o.Code()), byte(o.Length())}
+	buf := uio.NewBigEndianBuffer(nil)
 	for _, at := range o.ArchTypes {
-		buf := make([]byte, 2)
-		binary.BigEndian.PutUint16(buf[0:2], uint16(at))
-		ret = append(ret, buf...)
+		buf.Write16(uint16(at))
 	}
-	return ret
+	return buf.Data()
 }
 
 // Length returns the length of the data portion (excluding option code an byte

--- a/dhcpv4/option_archtype_test.go
+++ b/dhcpv4/option_archtype_test.go
@@ -9,23 +9,19 @@ import (
 
 func TestParseOptClientArchType(t *testing.T) {
 	data := []byte{
-		93,   // OptionClientSystemArchitectureType
-		2,    // Length
 		0, 6, // EFI_IA32
 	}
-	opt, err := ParseOptClientArchType(data[2:])
+	opt, err := ParseOptClientArchType(data)
 	require.NoError(t, err)
 	require.Equal(t, opt.ArchTypes[0], iana.EFI_IA32)
 }
 
 func TestParseOptClientArchTypeMultiple(t *testing.T) {
 	data := []byte{
-		93,   // OptionClientSystemArchitectureType
-		4,    // Length
 		0, 6, // EFI_IA32
 		0, 2, // EFI_ITANIUM
 	}
-	opt, err := ParseOptClientArchType(data[2:])
+	opt, err := ParseOptClientArchType(data)
 	require.NoError(t, err)
 	require.Equal(t, opt.ArchTypes[0], iana.EFI_IA32)
 	require.Equal(t, opt.ArchTypes[1], iana.EFI_ITANIUM)
@@ -39,23 +35,19 @@ func TestParseOptClientArchTypeInvalid(t *testing.T) {
 
 func TestOptClientArchTypeParseAndToBytes(t *testing.T) {
 	data := []byte{
-		93,   // OptionClientSystemArchitectureType
-		2,    // Length
 		0, 8, // EFI_XSCALE
 	}
-	opt, err := ParseOptClientArchType(data[2:])
+	opt, err := ParseOptClientArchType(data)
 	require.NoError(t, err)
 	require.Equal(t, opt.ToBytes(), data)
 }
 
 func TestOptClientArchTypeParseAndToBytesMultiple(t *testing.T) {
 	data := []byte{
-		93,   // OptionClientSystemArchitectureType
-		4,    // Length
 		0, 8, // EFI_XSCALE
 		0, 6, // EFI_IA32
 	}
-	opt, err := ParseOptClientArchType(data[2:])
+	opt, err := ParseOptClientArchType(data)
 	require.NoError(t, err)
 	require.Equal(t, opt.ToBytes(), data)
 }

--- a/dhcpv4/option_archtype_test.go
+++ b/dhcpv4/option_archtype_test.go
@@ -56,6 +56,5 @@ func TestOptClientArchType(t *testing.T) {
 	opt := OptClientArchType{
 		ArchTypes: []iana.ArchType{iana.EFI_ITANIUM},
 	}
-	require.Equal(t, opt.Length(), 2)
 	require.Equal(t, opt.Code(), OptionClientSystemArchitectureType)
 }

--- a/dhcpv4/option_bootfile_name.go
+++ b/dhcpv4/option_bootfile_name.go
@@ -19,7 +19,7 @@ func (op *OptBootfileName) Code() OptionCode {
 
 // ToBytes serializes the option and returns it as a sequence of bytes
 func (op *OptBootfileName) ToBytes() []byte {
-	return append([]byte{byte(op.Code()), byte(op.Length())}, []byte(op.BootfileName)...)
+	return []byte(op.BootfileName)
 }
 
 // Length returns the option length in bytes

--- a/dhcpv4/option_bootfile_name.go
+++ b/dhcpv4/option_bootfile_name.go
@@ -22,14 +22,8 @@ func (op *OptBootfileName) ToBytes() []byte {
 	return []byte(op.BootfileName)
 }
 
-// Length returns the option length in bytes
-func (op *OptBootfileName) Length() int {
-	return len(op.BootfileName)
-}
-
 func (op *OptBootfileName) String() string {
 	return fmt.Sprintf("Bootfile Name -> %s", op.BootfileName)
-
 }
 
 // ParseOptBootfileName returns a new OptBootfile from a byte stream or error if any

--- a/dhcpv4/option_bootfile_name_test.go
+++ b/dhcpv4/option_bootfile_name_test.go
@@ -28,7 +28,6 @@ func TestParseOptBootfileName(t *testing.T) {
 	}
 	opt, err := ParseOptBootfileName(expected)
 	require.NoError(t, err)
-	require.Equal(t, 9, opt.Length())
 	require.Equal(t, "linuxboot", opt.BootfileName)
 }
 

--- a/dhcpv4/option_bootfile_name_test.go
+++ b/dhcpv4/option_bootfile_name_test.go
@@ -17,8 +17,6 @@ func TestOptBootfileNameToBytes(t *testing.T) {
 	}
 	data := opt.ToBytes()
 	expected := []byte{
-		67, // OptionBootfileName
-		9,  // length
 		'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
 	require.Equal(t, expected, data)

--- a/dhcpv4/option_broadcast_address.go
+++ b/dhcpv4/option_broadcast_address.go
@@ -36,9 +36,3 @@ func (o *OptBroadcastAddress) ToBytes() []byte {
 func (o *OptBroadcastAddress) String() string {
 	return fmt.Sprintf("Broadcast Address -> %v", o.BroadcastAddress.String())
 }
-
-// Length returns the length of the data portion (excluding option code an byte
-// length).
-func (o *OptBroadcastAddress) Length() int {
-	return len(o.BroadcastAddress.To4())
-}

--- a/dhcpv4/option_broadcast_address.go
+++ b/dhcpv4/option_broadcast_address.go
@@ -29,8 +29,7 @@ func (o *OptBroadcastAddress) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptBroadcastAddress) ToBytes() []byte {
-	ret := []byte{byte(o.Code()), byte(o.Length())}
-	return append(ret, o.BroadcastAddress.To4()...)
+	return []byte(o.BroadcastAddress.To4())
 }
 
 // String returns a human-readable string.

--- a/dhcpv4/option_broadcast_address_test.go
+++ b/dhcpv4/option_broadcast_address_test.go
@@ -13,7 +13,7 @@ func TestOptBroadcastAddressInterfaceMethods(t *testing.T) {
 
 	require.Equal(t, OptionBroadcastAddress, o.Code(), "Code")
 
-	expectedBytes := []byte{byte(OptionBroadcastAddress), 4, 192, 168, 0, 1}
+	expectedBytes := []byte{192, 168, 0, 1}
 	require.Equal(t, expectedBytes, o.ToBytes(), "ToBytes")
 
 	require.Equal(t, 4, o.Length(), "Length")

--- a/dhcpv4/option_broadcast_address_test.go
+++ b/dhcpv4/option_broadcast_address_test.go
@@ -16,8 +16,6 @@ func TestOptBroadcastAddressInterfaceMethods(t *testing.T) {
 	expectedBytes := []byte{192, 168, 0, 1}
 	require.Equal(t, expectedBytes, o.ToBytes(), "ToBytes")
 
-	require.Equal(t, 4, o.Length(), "Length")
-
 	require.Equal(t, "Broadcast Address -> 192.168.0.1", o.String(), "String")
 }
 

--- a/dhcpv4/option_class_identifier.go
+++ b/dhcpv4/option_class_identifier.go
@@ -25,7 +25,7 @@ func (o *OptClassIdentifier) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptClassIdentifier) ToBytes() []byte {
-	return append([]byte{byte(o.Code()), byte(o.Length())}, []byte(o.Identifier)...)
+	return []byte(o.Identifier)
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/option_class_identifier.go
+++ b/dhcpv4/option_class_identifier.go
@@ -32,9 +32,3 @@ func (o *OptClassIdentifier) ToBytes() []byte {
 func (o *OptClassIdentifier) String() string {
 	return fmt.Sprintf("Class Identifier -> %v", o.Identifier)
 }
-
-// Length returns the length of the data portion (excluding option code and byte
-// for length, if any).
-func (o *OptClassIdentifier) Length() int {
-	return len(o.Identifier)
-}

--- a/dhcpv4/option_class_identifier_test.go
+++ b/dhcpv4/option_class_identifier_test.go
@@ -10,7 +10,7 @@ func TestOptClassIdentifierInterfaceMethods(t *testing.T) {
 	o := OptClassIdentifier{Identifier: "foo"}
 	require.Equal(t, OptionClassIdentifier, o.Code(), "Code")
 	require.Equal(t, 3, o.Length(), "Length")
-	require.Equal(t, []byte{byte(OptionClassIdentifier), 3, 'f', 'o', 'o'}, o.ToBytes(), "ToBytes")
+	require.Equal(t, []byte{'f', 'o', 'o'}, o.ToBytes(), "ToBytes")
 }
 
 func TestParseOptClassIdentifier(t *testing.T) {

--- a/dhcpv4/option_class_identifier_test.go
+++ b/dhcpv4/option_class_identifier_test.go
@@ -9,7 +9,6 @@ import (
 func TestOptClassIdentifierInterfaceMethods(t *testing.T) {
 	o := OptClassIdentifier{Identifier: "foo"}
 	require.Equal(t, OptionClassIdentifier, o.Code(), "Code")
-	require.Equal(t, 3, o.Length(), "Length")
 	require.Equal(t, []byte{'f', 'o', 'o'}, o.ToBytes(), "ToBytes")
 }
 

--- a/dhcpv4/option_domain_name.go
+++ b/dhcpv4/option_domain_name.go
@@ -23,7 +23,7 @@ func (o *OptDomainName) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptDomainName) ToBytes() []byte {
-	return append([]byte{byte(o.Code()), byte(o.Length())}, []byte(o.DomainName)...)
+	return []byte(o.DomainName)
 }
 
 // String returns a human-readable string.

--- a/dhcpv4/option_domain_name.go
+++ b/dhcpv4/option_domain_name.go
@@ -30,9 +30,3 @@ func (o *OptDomainName) ToBytes() []byte {
 func (o *OptDomainName) String() string {
 	return fmt.Sprintf("Domain Name -> %v", o.DomainName)
 }
-
-// Length returns the length of the data portion (excluding option code an byte
-// length).
-func (o *OptDomainName) Length() int {
-	return len(o.DomainName)
-}

--- a/dhcpv4/option_domain_name_server.go
+++ b/dhcpv4/option_domain_name_server.go
@@ -38,9 +38,3 @@ func (o *OptDomainNameServer) ToBytes() []byte {
 func (o *OptDomainNameServer) String() string {
 	return fmt.Sprintf("Domain Name Servers -> %s", IPsToString(o.NameServers))
 }
-
-// Length returns the length of the data portion (excluding option code an byte
-// length).
-func (o *OptDomainNameServer) Length() int {
-	return len(o.NameServers) * 4
-}

--- a/dhcpv4/option_domain_name_server.go
+++ b/dhcpv4/option_domain_name_server.go
@@ -31,23 +31,12 @@ func (o *OptDomainNameServer) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptDomainNameServer) ToBytes() []byte {
-	ret := []byte{byte(o.Code()), byte(o.Length())}
-	for _, ns := range o.NameServers {
-		ret = append(ret, ns.To4()...)
-	}
-	return ret
+	return IPsToBytes(o.NameServers)
 }
 
 // String returns a human-readable string.
 func (o *OptDomainNameServer) String() string {
-	var servers string
-	for idx, ns := range o.NameServers {
-		servers += ns.String()
-		if idx < len(o.NameServers)-1 {
-			servers += ", "
-		}
-	}
-	return fmt.Sprintf("Domain Name Servers -> %v", servers)
+	return fmt.Sprintf("Domain Name Servers -> %s", IPsToString(o.NameServers))
 }
 
 // Length returns the length of the data portion (excluding option code an byte

--- a/dhcpv4/option_domain_name_server_test.go
+++ b/dhcpv4/option_domain_name_server_test.go
@@ -14,7 +14,6 @@ func TestOptDomainNameServerInterfaceMethods(t *testing.T) {
 	}
 	o := OptDomainNameServer{NameServers: servers}
 	require.Equal(t, OptionDomainNameServer, o.Code(), "Code")
-	require.Equal(t, net.IPv4len*len(servers), o.Length(), "Length")
 	require.Equal(t, servers, o.NameServers, "NameServers")
 }
 

--- a/dhcpv4/option_domain_name_test.go
+++ b/dhcpv4/option_domain_name_test.go
@@ -9,7 +9,6 @@ import (
 func TestOptDomainNameInterfaceMethods(t *testing.T) {
 	o := OptDomainName{DomainName: "foo"}
 	require.Equal(t, OptionDomainName, o.Code(), "Code")
-	require.Equal(t, 3, o.Length(), "Length")
 	require.Equal(t, []byte{'f', 'o', 'o'}, o.ToBytes(), "ToBytes")
 }
 

--- a/dhcpv4/option_domain_name_test.go
+++ b/dhcpv4/option_domain_name_test.go
@@ -10,7 +10,7 @@ func TestOptDomainNameInterfaceMethods(t *testing.T) {
 	o := OptDomainName{DomainName: "foo"}
 	require.Equal(t, OptionDomainName, o.Code(), "Code")
 	require.Equal(t, 3, o.Length(), "Length")
-	require.Equal(t, []byte{byte(OptionDomainName), 3, 'f', 'o', 'o'}, o.ToBytes(), "ToBytes")
+	require.Equal(t, []byte{'f', 'o', 'o'}, o.ToBytes(), "ToBytes")
 }
 
 func TestParseOptDomainName(t *testing.T) {

--- a/dhcpv4/option_domain_search.go
+++ b/dhcpv4/option_domain_search.go
@@ -24,9 +24,7 @@ func (op *OptDomainSearch) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (op *OptDomainSearch) ToBytes() []byte {
-	buf := []byte{byte(op.Code()), byte(op.Length())}
-	buf = append(buf, op.DomainSearch.ToBytes()...)
-	return buf
+	return op.DomainSearch.ToBytes()
 }
 
 // Length returns the length of the data portion (excluding option code an byte

--- a/dhcpv4/option_domain_search.go
+++ b/dhcpv4/option_domain_search.go
@@ -27,12 +27,6 @@ func (op *OptDomainSearch) ToBytes() []byte {
 	return op.DomainSearch.ToBytes()
 }
 
-// Length returns the length of the data portion (excluding option code an byte
-// length).
-func (op *OptDomainSearch) Length() int {
-	return op.DomainSearch.Length()
-}
-
 // String returns a human-readable string.
 func (op *OptDomainSearch) String() string {
 	return fmt.Sprintf("DNS Domain Search List -> %v", op.DomainSearch.Labels)

--- a/dhcpv4/option_domain_search_test.go
+++ b/dhcpv4/option_domain_search_test.go
@@ -16,7 +16,6 @@ func TestParseOptDomainSearch(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, len(opt.DomainSearch.Labels))
 	require.Equal(t, data, opt.DomainSearch.ToBytes())
-	require.Equal(t, len(data), opt.DomainSearch.Length())
 	require.Equal(t, opt.DomainSearch.Labels[0], "example.com")
 	require.Equal(t, opt.DomainSearch.Labels[1], "subnet.example.org")
 }

--- a/dhcpv4/option_domain_search_test.go
+++ b/dhcpv4/option_domain_search_test.go
@@ -9,24 +9,20 @@ import (
 
 func TestParseOptDomainSearch(t *testing.T) {
 	data := []byte{
-		119, // OptionDNSDomainSearchList
-		33,  // length
 		7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
 		6, 's', 'u', 'b', 'n', 'e', 't', 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'o', 'r', 'g', 0,
 	}
-	opt, err := ParseOptDomainSearch(data[2:])
+	opt, err := ParseOptDomainSearch(data)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(opt.DomainSearch.Labels))
-	require.Equal(t, data[2:], opt.DomainSearch.ToBytes())
-	require.Equal(t, len(data[2:]), opt.DomainSearch.Length())
+	require.Equal(t, data, opt.DomainSearch.ToBytes())
+	require.Equal(t, len(data), opt.DomainSearch.Length())
 	require.Equal(t, opt.DomainSearch.Labels[0], "example.com")
 	require.Equal(t, opt.DomainSearch.Labels[1], "subnet.example.org")
 }
 
 func TestOptDomainSearchToBytes(t *testing.T) {
 	expected := []byte{
-		119, // OptionDNSDomainSearchList
-		33,  // length
 		7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
 		6, 's', 'u', 'b', 'n', 'e', 't', 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'o', 'r', 'g', 0,
 	}

--- a/dhcpv4/option_generic.go
+++ b/dhcpv4/option_generic.go
@@ -36,8 +36,3 @@ func (o OptionGeneric) ToBytes() []byte {
 func (o OptionGeneric) String() string {
 	return fmt.Sprintf("%v -> %v", o.OptionCode.String(), o.Data)
 }
-
-// Length returns the number of bytes comprising the data section of the option.
-func (o OptionGeneric) Length() int {
-	return len(o.Data)
-}

--- a/dhcpv4/option_generic.go
+++ b/dhcpv4/option_generic.go
@@ -29,13 +29,7 @@ func (o OptionGeneric) Code() OptionCode {
 
 // ToBytes returns a serialized generic option as a slice of bytes.
 func (o OptionGeneric) ToBytes() []byte {
-	ret := []byte{byte(o.OptionCode)}
-	if o.OptionCode == OptionEnd || o.OptionCode == OptionPad {
-		return ret
-	}
-	ret = append(ret, byte(o.Length()))
-	ret = append(ret, o.Data...)
-	return ret
+	return o.Data
 }
 
 // String returns a human-readable representation of a generic option.

--- a/dhcpv4/option_generic_test.go
+++ b/dhcpv4/option_generic_test.go
@@ -45,12 +45,3 @@ func TestOptionGenericStringUnknown(t *testing.T) {
 	}
 	require.Equal(t, "Unknown -> [1]", o.String())
 }
-
-func TestOptionGenericLength(t *testing.T) {
-	filename := "/path/to/file"
-	o := OptionGeneric{
-		OptionCode: OptionBootfileName,
-		Data:       []byte(filename),
-	}
-	require.Equal(t, len(filename), o.Length())
-}

--- a/dhcpv4/option_generic_test.go
+++ b/dhcpv4/option_generic_test.go
@@ -26,19 +26,7 @@ func TestOptionGenericToBytes(t *testing.T) {
 		Data:       []byte{byte(MessageTypeDiscover)},
 	}
 	serialized := o.ToBytes()
-	expected := []byte{53, 1, 1}
-	require.Equal(t, expected, serialized)
-}
-
-func TestOptionGenericToBytesZeroOptions(t *testing.T) {
-	o := OptionGeneric{OptionCode: OptionEnd}
-	serialized := o.ToBytes()
-	expected := []byte{255}
-	require.Equal(t, expected, serialized)
-
-	o = OptionGeneric{OptionCode: OptionPad}
-	serialized = o.ToBytes()
-	expected = []byte{0}
+	expected := []byte{1}
 	require.Equal(t, expected, serialized)
 }
 

--- a/dhcpv4/option_host_name.go
+++ b/dhcpv4/option_host_name.go
@@ -30,9 +30,3 @@ func (o *OptHostName) ToBytes() []byte {
 func (o *OptHostName) String() string {
 	return fmt.Sprintf("Host Name -> %v", o.HostName)
 }
-
-// Length returns the length of the data portion (excluding option code an byte
-// length).
-func (o *OptHostName) Length() int {
-	return len(o.HostName)
-}

--- a/dhcpv4/option_host_name.go
+++ b/dhcpv4/option_host_name.go
@@ -23,7 +23,7 @@ func (o *OptHostName) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptHostName) ToBytes() []byte {
-	return append([]byte{byte(o.Code()), byte(o.Length())}, []byte(o.HostName)...)
+	return []byte(o.HostName)
 }
 
 // String returns a human-readable string.

--- a/dhcpv4/option_host_name_test.go
+++ b/dhcpv4/option_host_name_test.go
@@ -10,7 +10,7 @@ func TestOptHostNameInterfaceMethods(t *testing.T) {
 	o := OptHostName{HostName: "foo"}
 	require.Equal(t, OptionHostName, o.Code(), "Code")
 	require.Equal(t, 3, o.Length(), "Length")
-	require.Equal(t, []byte{byte(OptionHostName), 3, 'f', 'o', 'o'}, o.ToBytes(), "ToBytes")
+	require.Equal(t, []byte{'f', 'o', 'o'}, o.ToBytes(), "ToBytes")
 }
 
 func TestParseOptHostName(t *testing.T) {

--- a/dhcpv4/option_host_name_test.go
+++ b/dhcpv4/option_host_name_test.go
@@ -9,7 +9,6 @@ import (
 func TestOptHostNameInterfaceMethods(t *testing.T) {
 	o := OptHostName{HostName: "foo"}
 	require.Equal(t, OptionHostName, o.Code(), "Code")
-	require.Equal(t, 3, o.Length(), "Length")
 	require.Equal(t, []byte{'f', 'o', 'o'}, o.ToBytes(), "ToBytes")
 }
 

--- a/dhcpv4/option_ip_address_lease_time.go
+++ b/dhcpv4/option_ip_address_lease_time.go
@@ -1,7 +1,6 @@
 package dhcpv4
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	"github.com/u-root/u-root/pkg/uio"
@@ -30,10 +29,9 @@ func (o *OptIPAddressLeaseTime) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptIPAddressLeaseTime) ToBytes() []byte {
-	serializedTime := make([]byte, 4)
-	binary.BigEndian.PutUint32(serializedTime, o.LeaseTime)
-	serializedOpt := []byte{byte(o.Code()), byte(o.Length())}
-	return append(serializedOpt, serializedTime...)
+	buf := uio.NewBigEndianBuffer(nil)
+	buf.Write32(o.LeaseTime)
+	return buf.Data()
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/option_ip_address_lease_time.go
+++ b/dhcpv4/option_ip_address_lease_time.go
@@ -38,9 +38,3 @@ func (o *OptIPAddressLeaseTime) ToBytes() []byte {
 func (o *OptIPAddressLeaseTime) String() string {
 	return fmt.Sprintf("IP Addresses Lease Time -> %v", o.LeaseTime)
 }
-
-// Length returns the length of the data portion (excluding option code and byte
-// for length, if any).
-func (o *OptIPAddressLeaseTime) Length() int {
-	return 4
-}

--- a/dhcpv4/option_ip_address_lease_time_test.go
+++ b/dhcpv4/option_ip_address_lease_time_test.go
@@ -9,7 +9,6 @@ import (
 func TestOptIPAddressLeaseTimeInterfaceMethods(t *testing.T) {
 	o := OptIPAddressLeaseTime{LeaseTime: 43200}
 	require.Equal(t, OptionIPAddressLeaseTime, o.Code(), "Code")
-	require.Equal(t, 4, o.Length(), "Length")
 	require.Equal(t, []byte{0, 0, 168, 192}, o.ToBytes(), "ToBytes")
 }
 

--- a/dhcpv4/option_ip_address_lease_time_test.go
+++ b/dhcpv4/option_ip_address_lease_time_test.go
@@ -10,7 +10,7 @@ func TestOptIPAddressLeaseTimeInterfaceMethods(t *testing.T) {
 	o := OptIPAddressLeaseTime{LeaseTime: 43200}
 	require.Equal(t, OptionIPAddressLeaseTime, o.Code(), "Code")
 	require.Equal(t, 4, o.Length(), "Length")
-	require.Equal(t, []byte{51, 4, 0, 0, 168, 192}, o.ToBytes(), "ToBytes")
+	require.Equal(t, []byte{0, 0, 168, 192}, o.ToBytes(), "ToBytes")
 }
 
 func TestParseOptIPAddressLeaseTime(t *testing.T) {

--- a/dhcpv4/option_maximum_dhcp_message_size.go
+++ b/dhcpv4/option_maximum_dhcp_message_size.go
@@ -37,9 +37,3 @@ func (o *OptMaximumDHCPMessageSize) ToBytes() []byte {
 func (o *OptMaximumDHCPMessageSize) String() string {
 	return fmt.Sprintf("Maximum DHCP Message Size -> %v", o.Size)
 }
-
-// Length returns the length of the data portion (excluding option code and byte
-// for length, if any).
-func (o *OptMaximumDHCPMessageSize) Length() int {
-	return 2
-}

--- a/dhcpv4/option_maximum_dhcp_message_size.go
+++ b/dhcpv4/option_maximum_dhcp_message_size.go
@@ -1,7 +1,6 @@
 package dhcpv4
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	"github.com/u-root/u-root/pkg/uio"
@@ -29,10 +28,9 @@ func (o *OptMaximumDHCPMessageSize) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptMaximumDHCPMessageSize) ToBytes() []byte {
-	serializedSize := make([]byte, 2)
-	binary.BigEndian.PutUint16(serializedSize, o.Size)
-	serializedOpt := []byte{byte(o.Code()), byte(o.Length())}
-	return append(serializedOpt, serializedSize...)
+	buf := uio.NewBigEndianBuffer(nil)
+	buf.Write16(o.Size)
+	return buf.Data()
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/option_maximum_dhcp_message_size_test.go
+++ b/dhcpv4/option_maximum_dhcp_message_size_test.go
@@ -10,7 +10,7 @@ func TestOptMaximumDHCPMessageSizeInterfaceMethods(t *testing.T) {
 	o := OptMaximumDHCPMessageSize{Size: 1500}
 	require.Equal(t, OptionMaximumDHCPMessageSize, o.Code(), "Code")
 	require.Equal(t, 2, o.Length(), "Length")
-	require.Equal(t, []byte{57, 2, 5, 220}, o.ToBytes(), "ToBytes")
+	require.Equal(t, []byte{5, 220}, o.ToBytes(), "ToBytes")
 }
 
 func TestParseOptMaximumDHCPMessageSize(t *testing.T) {

--- a/dhcpv4/option_maximum_dhcp_message_size_test.go
+++ b/dhcpv4/option_maximum_dhcp_message_size_test.go
@@ -9,7 +9,6 @@ import (
 func TestOptMaximumDHCPMessageSizeInterfaceMethods(t *testing.T) {
 	o := OptMaximumDHCPMessageSize{Size: 1500}
 	require.Equal(t, OptionMaximumDHCPMessageSize, o.Code(), "Code")
-	require.Equal(t, 2, o.Length(), "Length")
 	require.Equal(t, []byte{5, 220}, o.ToBytes(), "ToBytes")
 }
 

--- a/dhcpv4/option_message_type.go
+++ b/dhcpv4/option_message_type.go
@@ -28,7 +28,7 @@ func (o *OptMessageType) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptMessageType) ToBytes() []byte {
-	return []byte{byte(o.Code()), byte(o.Length()), byte(o.MessageType)}
+	return []byte{byte(o.MessageType)}
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/option_message_type.go
+++ b/dhcpv4/option_message_type.go
@@ -35,9 +35,3 @@ func (o *OptMessageType) ToBytes() []byte {
 func (o *OptMessageType) String() string {
 	return fmt.Sprintf("DHCP Message Type -> %s", o.MessageType.String())
 }
-
-// Length returns the length of the data portion (excluding option code and byte
-// for length, if any).
-func (o *OptMessageType) Length() int {
-	return 1
-}

--- a/dhcpv4/option_message_type_test.go
+++ b/dhcpv4/option_message_type_test.go
@@ -10,7 +10,7 @@ func TestOptMessageTypeInterfaceMethods(t *testing.T) {
 	o := OptMessageType{MessageType: MessageTypeDiscover}
 	require.Equal(t, OptionDHCPMessageType, o.Code(), "Code")
 	require.Equal(t, 1, o.Length(), "Length")
-	require.Equal(t, []byte{53, 1, 1}, o.ToBytes(), "ToBytes")
+	require.Equal(t, []byte{1}, o.ToBytes(), "ToBytes")
 }
 
 func TestOptMessageTypeNew(t *testing.T) {

--- a/dhcpv4/option_message_type_test.go
+++ b/dhcpv4/option_message_type_test.go
@@ -9,7 +9,6 @@ import (
 func TestOptMessageTypeInterfaceMethods(t *testing.T) {
 	o := OptMessageType{MessageType: MessageTypeDiscover}
 	require.Equal(t, OptionDHCPMessageType, o.Code(), "Code")
-	require.Equal(t, 1, o.Length(), "Length")
 	require.Equal(t, []byte{1}, o.ToBytes(), "ToBytes")
 }
 

--- a/dhcpv4/option_ntp_servers.go
+++ b/dhcpv4/option_ntp_servers.go
@@ -29,23 +29,12 @@ func (o *OptNTPServers) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptNTPServers) ToBytes() []byte {
-	ret := []byte{byte(o.Code()), byte(o.Length())}
-	for _, ntp := range o.NTPServers {
-		ret = append(ret, ntp.To4()...)
-	}
-	return ret
+	return IPsToBytes(o.NTPServers)
 }
 
 // String returns a human-readable string.
 func (o *OptNTPServers) String() string {
-	var ntpServers string
-	for idx, ntp := range o.NTPServers {
-		ntpServers += ntp.String()
-		if idx < len(o.NTPServers)-1 {
-			ntpServers += ", "
-		}
-	}
-	return fmt.Sprintf("NTP Servers -> %v", ntpServers)
+	return fmt.Sprintf("NTP Servers -> %v", IPsToString(o.NTPServers))
 }
 
 // Length returns the length of the data portion (excluding option code an byte

--- a/dhcpv4/option_ntp_servers.go
+++ b/dhcpv4/option_ntp_servers.go
@@ -36,9 +36,3 @@ func (o *OptNTPServers) ToBytes() []byte {
 func (o *OptNTPServers) String() string {
 	return fmt.Sprintf("NTP Servers -> %v", IPsToString(o.NTPServers))
 }
-
-// Length returns the length of the data portion (excluding option code an byte
-// length).
-func (o *OptNTPServers) Length() int {
-	return len(o.NTPServers) * 4
-}

--- a/dhcpv4/option_ntp_servers_test.go
+++ b/dhcpv4/option_ntp_servers_test.go
@@ -14,7 +14,6 @@ func TestOptNTPServersInterfaceMethods(t *testing.T) {
 	}
 	o := OptNTPServers{NTPServers: ntpServers}
 	require.Equal(t, OptionNTPServers, o.Code(), "Code")
-	require.Equal(t, net.IPv4len*len(ntpServers), o.Length(), "Length")
 	require.Equal(t, ntpServers, o.NTPServers, "NTPServers")
 }
 

--- a/dhcpv4/option_parameter_request_list.go
+++ b/dhcpv4/option_parameter_request_list.go
@@ -33,11 +33,11 @@ func (o *OptParameterRequestList) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptParameterRequestList) ToBytes() []byte {
-	ret := []byte{byte(o.Code()), byte(o.Length())}
+	buf := uio.NewBigEndianBuffer(nil)
 	for _, req := range o.RequestedOpts {
-		ret = append(ret, byte(req))
+		buf.Write8(uint8(req))
 	}
-	return ret
+	return buf.Data()
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/option_parameter_request_list.go
+++ b/dhcpv4/option_parameter_request_list.go
@@ -52,9 +52,3 @@ func (o *OptParameterRequestList) String() string {
 	}
 	return fmt.Sprintf("Parameter Request List -> [%v]", strings.Join(optNames, ", "))
 }
-
-// Length returns the length of the data portion (excluding option code and byte
-// for length, if any).
-func (o *OptParameterRequestList) Length() int {
-	return len(o.RequestedOpts)
-}

--- a/dhcpv4/option_parameter_request_list_test.go
+++ b/dhcpv4/option_parameter_request_list_test.go
@@ -11,7 +11,7 @@ func TestOptParameterRequestListInterfaceMethods(t *testing.T) {
 	o := &OptParameterRequestList{RequestedOpts: requestedOpts}
 	require.Equal(t, OptionParameterRequestList, o.Code(), "Code")
 
-	expectedBytes := []byte{55, 2, 67, 5}
+	expectedBytes := []byte{67, 5}
 	require.Equal(t, expectedBytes, o.ToBytes(), "ToBytes")
 
 	expectedString := "Parameter Request List -> [Bootfile Name, Name Server]"

--- a/dhcpv4/option_relay_agent_information.go
+++ b/dhcpv4/option_relay_agent_information.go
@@ -1,6 +1,10 @@
 package dhcpv4
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/u-root/u-root/pkg/uio"
+)
 
 // This option implements the relay agent information option
 // https://tools.ietf.org/html/rfc3046
@@ -28,11 +32,7 @@ func (o *OptRelayAgentInformation) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptRelayAgentInformation) ToBytes() []byte {
-	ret := []byte{byte(o.Code()), byte(o.Length())}
-	for _, opt := range o.Options {
-		ret = append(ret, opt.ToBytes()...)
-	}
-	return ret
+	return uio.ToBigEndian(o.Options)
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/option_relay_agent_information.go
+++ b/dhcpv4/option_relay_agent_information.go
@@ -39,13 +39,3 @@ func (o *OptRelayAgentInformation) ToBytes() []byte {
 func (o *OptRelayAgentInformation) String() string {
 	return fmt.Sprintf("Relay Agent Information -> %v", o.Options)
 }
-
-// Length returns the length of the data portion (excluding option code and byte
-// for length, if any).
-func (o *OptRelayAgentInformation) Length() int {
-	l := 0
-	for _, opt := range o.Options {
-		l += 2 + opt.Length()
-	}
-	return l
-}

--- a/dhcpv4/option_relay_agent_information_test.go
+++ b/dhcpv4/option_relay_agent_information_test.go
@@ -8,8 +8,6 @@ import (
 
 func TestParseOptRelayAgentInformation(t *testing.T) {
 	data := []byte{
-		byte(OptionRelayAgentInformation),
-		13,
 		1, 5, 'l', 'i', 'n', 'u', 'x',
 		2, 4, 'b', 'o', 'o', 't',
 	}
@@ -22,7 +20,7 @@ func TestParseOptRelayAgentInformation(t *testing.T) {
 	opt, err = ParseOptRelayAgentInformation([]byte{1, 1})
 	require.Error(t, err)
 
-	opt, err = ParseOptRelayAgentInformation(data[2:])
+	opt, err = ParseOptRelayAgentInformation(data)
 	require.NoError(t, err)
 	require.Equal(t, len(opt.Options), 2)
 	circuit := opt.Options.GetOne(1).(*OptionGeneric)
@@ -34,15 +32,14 @@ func TestParseOptRelayAgentInformation(t *testing.T) {
 }
 
 func TestParseOptRelayAgentInformationToBytes(t *testing.T) {
-	opt := OptRelayAgentInformation{}
-	opt1 := &OptionGeneric{OptionCode: 1, Data: []byte("linux")}
-	opt.Options = append(opt.Options, opt1)
-	opt2 := &OptionGeneric{OptionCode: 2, Data: []byte("boot")}
-	opt.Options = append(opt.Options, opt2)
+	opt := OptRelayAgentInformation{
+		Options: Options{
+			&OptionGeneric{OptionCode: 1, Data: []byte("linux")},
+			&OptionGeneric{OptionCode: 2, Data: []byte("boot")},
+		},
+	}
 	data := opt.ToBytes()
 	expected := []byte{
-		byte(OptionRelayAgentInformation),
-		13,
 		1, 5, 'l', 'i', 'n', 'u', 'x',
 		2, 4, 'b', 'o', 'o', 't',
 	}

--- a/dhcpv4/option_requested_ip_address.go
+++ b/dhcpv4/option_requested_ip_address.go
@@ -30,8 +30,7 @@ func (o *OptRequestedIPAddress) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptRequestedIPAddress) ToBytes() []byte {
-	ret := []byte{byte(o.Code()), byte(o.Length())}
-	return append(ret, o.RequestedAddr.To4()...)
+	return o.RequestedAddr.To4()
 }
 
 // String returns a human-readable string.

--- a/dhcpv4/option_requested_ip_address.go
+++ b/dhcpv4/option_requested_ip_address.go
@@ -37,9 +37,3 @@ func (o *OptRequestedIPAddress) ToBytes() []byte {
 func (o *OptRequestedIPAddress) String() string {
 	return fmt.Sprintf("Requested IP Address -> %v", o.RequestedAddr.String())
 }
-
-// Length returns the length of the data portion (excluding option code an byte
-// length).
-func (o *OptRequestedIPAddress) Length() int {
-	return len(o.RequestedAddr.To4())
-}

--- a/dhcpv4/option_requested_ip_address_test.go
+++ b/dhcpv4/option_requested_ip_address_test.go
@@ -16,8 +16,6 @@ func TestOptRequestedIPAddressInterfaceMethods(t *testing.T) {
 	expectedBytes := []byte{192, 168, 0, 1}
 	require.Equal(t, expectedBytes, o.ToBytes(), "ToBytes")
 
-	require.Equal(t, 4, o.Length(), "Length")
-
 	require.Equal(t, "Requested IP Address -> 192.168.0.1", o.String(), "String")
 }
 

--- a/dhcpv4/option_requested_ip_address_test.go
+++ b/dhcpv4/option_requested_ip_address_test.go
@@ -13,7 +13,7 @@ func TestOptRequestedIPAddressInterfaceMethods(t *testing.T) {
 
 	require.Equal(t, OptionRequestedIPAddress, o.Code(), "Code")
 
-	expectedBytes := []byte{byte(OptionRequestedIPAddress), 4, 192, 168, 0, 1}
+	expectedBytes := []byte{192, 168, 0, 1}
 	require.Equal(t, expectedBytes, o.ToBytes(), "ToBytes")
 
 	require.Equal(t, 4, o.Length(), "Length")

--- a/dhcpv4/option_root_path.go
+++ b/dhcpv4/option_root_path.go
@@ -25,7 +25,7 @@ func (o *OptRootPath) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptRootPath) ToBytes() []byte {
-	return append([]byte{byte(o.Code()), byte(o.Length())}, []byte(o.Path)...)
+	return []byte(o.Path)
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/option_root_path.go
+++ b/dhcpv4/option_root_path.go
@@ -32,9 +32,3 @@ func (o *OptRootPath) ToBytes() []byte {
 func (o *OptRootPath) String() string {
 	return fmt.Sprintf("Root Path -> %v", o.Path)
 }
-
-// Length returns the length of the data portion (excluding option code and byte
-// for length, if any).
-func (o *OptRootPath) Length() int {
-	return len(o.Path)
-}

--- a/dhcpv4/option_root_path_test.go
+++ b/dhcpv4/option_root_path_test.go
@@ -11,8 +11,6 @@ func TestOptRootPathInterfaceMethods(t *testing.T) {
 	require.Equal(t, OptionRootPath, o.Code(), "Code")
 	require.Equal(t, 12, o.Length(), "Length")
 	wantBytes := []byte{
-		byte(OptionRootPath),
-		12,
 		'/', 'f', 'o', 'o', '/', 'b', 'a', 'r', '/', 'b', 'a', 'z',
 	}
 	require.Equal(t, wantBytes, o.ToBytes(), "ToBytes")

--- a/dhcpv4/option_root_path_test.go
+++ b/dhcpv4/option_root_path_test.go
@@ -9,7 +9,6 @@ import (
 func TestOptRootPathInterfaceMethods(t *testing.T) {
 	o := OptRootPath{Path: "/foo/bar/baz"}
 	require.Equal(t, OptionRootPath, o.Code(), "Code")
-	require.Equal(t, 12, o.Length(), "Length")
 	wantBytes := []byte{
 		'/', 'f', 'o', 'o', '/', 'b', 'a', 'r', '/', 'b', 'a', 'z',
 	}

--- a/dhcpv4/option_router.go
+++ b/dhcpv4/option_router.go
@@ -76,9 +76,3 @@ func (o *OptRouter) ToBytes() []byte {
 func (o *OptRouter) String() string {
 	return fmt.Sprintf("Routers -> %s", IPsToString(o.Routers))
 }
-
-// Length returns the length of the data portion (excluding option code an byte
-// length).
-func (o *OptRouter) Length() int {
-	return len(o.Routers) * 4
-}

--- a/dhcpv4/option_router_test.go
+++ b/dhcpv4/option_router_test.go
@@ -14,7 +14,6 @@ func TestOptRoutersInterfaceMethods(t *testing.T) {
 	}
 	o := OptRouter{Routers: routers}
 	require.Equal(t, OptionRouter, o.Code(), "Code")
-	require.Equal(t, net.IPv4len*len(routers), o.Length(), "Length")
 	require.Equal(t, routers, o.Routers, "Routers")
 }
 

--- a/dhcpv4/option_server_identifier.go
+++ b/dhcpv4/option_server_identifier.go
@@ -36,9 +36,3 @@ func (o *OptServerIdentifier) ToBytes() []byte {
 func (o *OptServerIdentifier) String() string {
 	return fmt.Sprintf("Server Identifier -> %v", o.ServerID.String())
 }
-
-// Length returns the length of the data portion (excluding option code an byte
-// length).
-func (o *OptServerIdentifier) Length() int {
-	return len(o.ServerID.To4())
-}

--- a/dhcpv4/option_server_identifier.go
+++ b/dhcpv4/option_server_identifier.go
@@ -29,8 +29,7 @@ func (o *OptServerIdentifier) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptServerIdentifier) ToBytes() []byte {
-	ret := []byte{byte(o.Code()), byte(o.Length())}
-	return append(ret, o.ServerID.To4()...)
+	return o.ServerID.To4()
 }
 
 // String returns a human-readable string.

--- a/dhcpv4/option_server_identifier_test.go
+++ b/dhcpv4/option_server_identifier_test.go
@@ -16,8 +16,6 @@ func TestOptServerIdentifierInterfaceMethods(t *testing.T) {
 	expectedBytes := []byte{192, 168, 0, 1}
 	require.Equal(t, expectedBytes, o.ToBytes(), "ToBytes")
 
-	require.Equal(t, 4, o.Length(), "Length")
-
 	require.Equal(t, "Server Identifier -> 192.168.0.1", o.String(), "String")
 }
 

--- a/dhcpv4/option_server_identifier_test.go
+++ b/dhcpv4/option_server_identifier_test.go
@@ -13,7 +13,7 @@ func TestOptServerIdentifierInterfaceMethods(t *testing.T) {
 
 	require.Equal(t, OptionServerIdentifier, o.Code(), "Code")
 
-	expectedBytes := []byte{54, 4, 192, 168, 0, 1}
+	expectedBytes := []byte{192, 168, 0, 1}
 	require.Equal(t, expectedBytes, o.ToBytes(), "ToBytes")
 
 	require.Equal(t, 4, o.Length(), "Length")

--- a/dhcpv4/option_subnet_mask.go
+++ b/dhcpv4/option_subnet_mask.go
@@ -29,8 +29,7 @@ func (o *OptSubnetMask) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptSubnetMask) ToBytes() []byte {
-	ret := []byte{byte(o.Code()), byte(o.Length())}
-	return append(ret, o.SubnetMask[:4]...)
+	return o.SubnetMask[:net.IPv4len]
 }
 
 // String returns a human-readable string.

--- a/dhcpv4/option_subnet_mask.go
+++ b/dhcpv4/option_subnet_mask.go
@@ -36,9 +36,3 @@ func (o *OptSubnetMask) ToBytes() []byte {
 func (o *OptSubnetMask) String() string {
 	return fmt.Sprintf("Subnet Mask -> %v", o.SubnetMask.String())
 }
-
-// Length returns the length of the data portion (excluding option code an byte
-// length).
-func (o *OptSubnetMask) Length() int {
-	return 4
-}

--- a/dhcpv4/option_subnet_mask_test.go
+++ b/dhcpv4/option_subnet_mask_test.go
@@ -16,8 +16,6 @@ func TestOptSubnetMaskInterfaceMethods(t *testing.T) {
 	expectedBytes := []byte{255, 255, 255, 0}
 	require.Equal(t, expectedBytes, o.ToBytes(), "ToBytes")
 
-	require.Equal(t, 4, o.Length(), "Length")
-
 	require.Equal(t, "Subnet Mask -> ffffff00", o.String(), "String")
 }
 

--- a/dhcpv4/option_subnet_mask_test.go
+++ b/dhcpv4/option_subnet_mask_test.go
@@ -13,7 +13,7 @@ func TestOptSubnetMaskInterfaceMethods(t *testing.T) {
 
 	require.Equal(t, OptionSubnetMask, o.Code(), "Code")
 
-	expectedBytes := []byte{1, 4, 255, 255, 255, 0}
+	expectedBytes := []byte{255, 255, 255, 0}
 	require.Equal(t, expectedBytes, o.ToBytes(), "ToBytes")
 
 	require.Equal(t, 4, o.Length(), "Length")

--- a/dhcpv4/option_tftp_server_name.go
+++ b/dhcpv4/option_tftp_server_name.go
@@ -22,11 +22,6 @@ func (op *OptTFTPServerName) ToBytes() []byte {
 	return []byte(op.TFTPServerName)
 }
 
-// Length returns the option length in bytes
-func (op *OptTFTPServerName) Length() int {
-	return len(op.TFTPServerName)
-}
-
 func (op *OptTFTPServerName) String() string {
 	return fmt.Sprintf("TFTP Server Name -> %s", op.TFTPServerName)
 }

--- a/dhcpv4/option_tftp_server_name.go
+++ b/dhcpv4/option_tftp_server_name.go
@@ -19,7 +19,7 @@ func (op *OptTFTPServerName) Code() OptionCode {
 
 // ToBytes serializes the option and returns it as a sequence of bytes
 func (op *OptTFTPServerName) ToBytes() []byte {
-	return append([]byte{byte(op.Code()), byte(op.Length())}, []byte(op.TFTPServerName)...)
+	return []byte(op.TFTPServerName)
 }
 
 // Length returns the option length in bytes

--- a/dhcpv4/option_tftp_server_name_test.go
+++ b/dhcpv4/option_tftp_server_name_test.go
@@ -17,8 +17,6 @@ func TestOptTFTPServerNameToBytes(t *testing.T) {
 	}
 	data := opt.ToBytes()
 	expected := []byte{
-		66, // OptionTFTPServerName
-		9,  // length
 		'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
 	require.Equal(t, expected, data)

--- a/dhcpv4/option_tftp_server_name_test.go
+++ b/dhcpv4/option_tftp_server_name_test.go
@@ -28,7 +28,6 @@ func TestParseOptTFTPServerName(t *testing.T) {
 	}
 	opt, err := ParseOptTFTPServerName(expected)
 	require.NoError(t, err)
-	require.Equal(t, 9, opt.Length())
 	require.Equal(t, "linuxboot", string(opt.TFTPServerName))
 }
 

--- a/dhcpv4/option_userclass.go
+++ b/dhcpv4/option_userclass.go
@@ -36,18 +36,6 @@ func (op *OptUserClass) ToBytes() []byte {
 	return buf.Data()
 }
 
-// Length returns the option length
-func (op *OptUserClass) Length() int {
-	ret := 0
-	if !op.Rfc3004 {
-		return len(op.UserClasses[0])
-	}
-	for _, uc := range op.UserClasses {
-		ret += 1 + len(uc)
-	}
-	return ret
-}
-
 func (op *OptUserClass) String() string {
 	ucStrings := make([]string, 0, len(op.UserClasses))
 	if !op.Rfc3004 {

--- a/dhcpv4/option_userclass.go
+++ b/dhcpv4/option_userclass.go
@@ -24,15 +24,16 @@ func (op *OptUserClass) Code() OptionCode {
 
 // ToBytes serializes the option and returns it as a sequence of bytes
 func (op *OptUserClass) ToBytes() []byte {
-	buf := []byte{byte(op.Code()), byte(op.Length())}
+	buf := uio.NewBigEndianBuffer(nil)
 	if !op.Rfc3004 {
-		return append(buf, op.UserClasses[0]...)
+		buf.WriteBytes(op.UserClasses[0])
+	} else {
+		for _, uc := range op.UserClasses {
+			buf.Write8(uint8(len(uc)))
+			buf.WriteBytes(uc)
+		}
 	}
-	for _, uc := range op.UserClasses {
-		buf = append(buf, byte(len(uc)))
-		buf = append(buf, uc...)
-	}
-	return buf
+	return buf.Data()
 }
 
 // Length returns the option length

--- a/dhcpv4/option_userclass_test.go
+++ b/dhcpv4/option_userclass_test.go
@@ -13,8 +13,6 @@ func TestOptUserClassToBytes(t *testing.T) {
 	}
 	data := opt.ToBytes()
 	expected := []byte{
-		77, // OptionUserClass
-		10, // length
 		9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
 	require.Equal(t, expected, data)
@@ -26,8 +24,6 @@ func TestOptUserClassMicrosoftToBytes(t *testing.T) {
 	}
 	data := opt.ToBytes()
 	expected := []byte{
-		77, // OptionUserClass
-		9,  // length
 		'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 	}
 	require.Equal(t, expected, data)
@@ -91,8 +87,6 @@ func TestOptUserClassToBytesMultiple(t *testing.T) {
 	}
 	data := opt.ToBytes()
 	expected := []byte{
-		77, // OptionUserClass
-		15, // length
 		9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
 		4, 't', 'e', 's', 't',
 	}

--- a/dhcpv4/option_userclass_test.go
+++ b/dhcpv4/option_userclass_test.go
@@ -93,15 +93,6 @@ func TestOptUserClassToBytesMultiple(t *testing.T) {
 	require.Equal(t, expected, data)
 }
 
-func TestOptUserClassLength(t *testing.T) {
-	expected := []byte{
-		9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't', 'X',
-	}
-	opt, err := ParseOptUserClass(expected)
-	require.NoError(t, err)
-	require.Equal(t, 11, opt.Length())
-}
-
 func TestParseOptUserClassZeroLength(t *testing.T) {
 	expected := []byte{
 		0, 0,

--- a/dhcpv4/option_vivc.go
+++ b/dhcpv4/option_vivc.go
@@ -63,14 +63,3 @@ func (o *OptVIVC) String() string {
 
 	return buf.String()[:buf.Len()-1]
 }
-
-// Length returns the length of the data portion (excluding option code and byte
-// for length, if any).
-func (o *OptVIVC) Length() int {
-	n := 0
-	for _, id := range o.Identifiers {
-		// each class has a header of endID (4 bytes) and length (1 byte)
-		n += 5 + len(id.Data)
-	}
-	return n
-}

--- a/dhcpv4/option_vivc.go
+++ b/dhcpv4/option_vivc.go
@@ -2,7 +2,6 @@ package dhcpv4
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 
 	"github.com/u-root/u-root/pkg/uio"
@@ -44,17 +43,13 @@ func (o *OptVIVC) Code() OptionCode {
 
 // ToBytes returns a serialized stream of bytes for this option.
 func (o *OptVIVC) ToBytes() []byte {
-	buf := make([]byte, o.Length()+2)
-	copy(buf[0:], []byte{byte(o.Code()), byte(o.Length())})
-
-	b := buf[2:]
+	buf := uio.NewBigEndianBuffer(nil)
 	for _, id := range o.Identifiers {
-		binary.BigEndian.PutUint32(b[0:4], id.EntID)
-		b[4] = byte(len(id.Data))
-		copy(b[5:], id.Data)
-		b = b[len(id.Data)+5:]
+		buf.Write32(id.EntID)
+		buf.Write8(uint8(len(id.Data)))
+		buf.WriteBytes(id.Data)
 	}
-	return buf
+	return buf.Data()
 }
 
 // String returns a human-readable string for this option.

--- a/dhcpv4/option_vivc_test.go
+++ b/dhcpv4/option_vivc_test.go
@@ -14,7 +14,6 @@ var (
 		},
 	}
 	sampleVIVCOptRaw = []byte{
-		byte(OptionVendorIdentifyingVendorClass), 44, // option header
 		0x0, 0x0, 0x0, 0x9, // enterprise id 9
 		0xf, // length
 		'C', 'i', 's', 'c', 'o', 'I', 'd', 'e', 'n', 't', 'i', 'f', 'i', 'e', 'r',
@@ -31,13 +30,13 @@ func TestOptVIVCInterfaceMethods(t *testing.T) {
 }
 
 func TestParseOptVICO(t *testing.T) {
-	o, err := ParseOptVIVC(sampleVIVCOptRaw[2:])
+	o, err := ParseOptVIVC(sampleVIVCOptRaw)
 	require.NoError(t, err)
 	require.Equal(t, &sampleVIVCOpt, o)
 
 	// Identifier len too long
-	data := make([]byte, len(sampleVIVCOptRaw[2:]))
-	copy(data, sampleVIVCOptRaw[2:])
+	data := make([]byte, len(sampleVIVCOptRaw))
+	copy(data, sampleVIVCOptRaw)
 	data[4] = 40
 	_, err = ParseOptVIVC(data)
 	require.Error(t, err, "should get error from bad length")

--- a/dhcpv4/option_vivc_test.go
+++ b/dhcpv4/option_vivc_test.go
@@ -25,7 +25,6 @@ var (
 
 func TestOptVIVCInterfaceMethods(t *testing.T) {
 	require.Equal(t, OptionVendorIdentifyingVendorClass, sampleVIVCOpt.Code(), "Code")
-	require.Equal(t, 44, sampleVIVCOpt.Length(), "Length")
 	require.Equal(t, sampleVIVCOptRaw, sampleVIVCOpt.ToBytes(), "ToBytes")
 }
 

--- a/dhcpv4/options.go
+++ b/dhcpv4/options.go
@@ -31,7 +31,6 @@ type OptionCode byte
 type Option interface {
 	Code() OptionCode
 	ToBytes() []byte
-	Length() int
 	String() string
 }
 

--- a/dhcpv4/options_test.go
+++ b/dhcpv4/options_test.go
@@ -18,7 +18,6 @@ func TestParseOption(t *testing.T) {
 	generic := opt.(*OptionGeneric)
 	require.Equal(t, OptionNameServer, generic.Code())
 	require.Equal(t, []byte{192, 168, 1, 254}, generic.Data)
-	require.Equal(t, 4, generic.Length())
 	require.Equal(t, "Name Server -> [192 168 1 254]", generic.String())
 
 	// Option subnet mask
@@ -26,7 +25,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionSubnetMask, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionSubnetMask, opt.Code(), "Code")
-	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option router
@@ -34,7 +32,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionRouter, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionRouter, opt.Code(), "Code")
-	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option domain name server
@@ -42,7 +39,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionDomainNameServer, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionDomainNameServer, opt.Code(), "Code")
-	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option host name
@@ -50,7 +46,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionHostName, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionHostName, opt.Code(), "Code")
-	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option domain name
@@ -58,7 +53,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionDomainName, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionDomainName, opt.Code(), "Code")
-	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option root path
@@ -66,7 +60,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionRootPath, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionRootPath, opt.Code(), "Code")
-	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option broadcast address
@@ -74,7 +67,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionBroadcastAddress, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionBroadcastAddress, opt.Code(), "Code")
-	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option NTP servers
@@ -82,7 +74,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionNTPServers, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionNTPServers, opt.Code(), "Code")
-	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Requested IP address
@@ -90,7 +81,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionRequestedIPAddress, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionRequestedIPAddress, opt.Code(), "Code")
-	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Requested IP address lease time
@@ -98,7 +88,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionIPAddressLeaseTime, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionIPAddressLeaseTime, opt.Code(), "Code")
-	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Message type
@@ -106,7 +95,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionDHCPMessageType, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionDHCPMessageType, opt.Code(), "Code")
-	require.Equal(t, 1, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option server ID
@@ -114,7 +102,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionServerIdentifier, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionServerIdentifier, opt.Code(), "Code")
-	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Parameter request list
@@ -122,7 +109,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionParameterRequestList, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionParameterRequestList, opt.Code(), "Code")
-	require.Equal(t, 3, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option max message size
@@ -130,7 +116,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionMaximumDHCPMessageSize, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionMaximumDHCPMessageSize, opt.Code(), "Code")
-	require.Equal(t, 2, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option class identifier
@@ -138,7 +123,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionClassIdentifier, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionClassIdentifier, opt.Code(), "Code")
-	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option TFTP server name
@@ -146,7 +130,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionTFTPServerName, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionTFTPServerName, opt.Code(), "Code")
-	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option Bootfile name
@@ -154,7 +137,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionBootfileName, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionBootfileName, opt.Code(), "Code")
-	require.Equal(t, 9, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option user class information
@@ -162,7 +144,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionUserClassInformation, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionUserClassInformation, opt.Code(), "Code")
-	require.Equal(t, 5, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option relay agent information
@@ -170,7 +151,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionRelayAgentInformation, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionRelayAgentInformation, opt.Code(), "Code")
-	require.Equal(t, 6, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option client system architecture type option
@@ -178,7 +158,6 @@ func TestParseOption(t *testing.T) {
 	opt, err = ParseOption(OptionClientSystemArchitectureType, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionClientSystemArchitectureType, opt.Code(), "Code")
-	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 }
 

--- a/dhcpv4/options_test.go
+++ b/dhcpv4/options_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 func TestParseOption(t *testing.T) {
 	// Generic
-	option := []byte{5, 4, 192, 168, 1, 254} // DNS option
-	opt, err := ParseOption(OptionCode(option[0]), option[2:])
+	option := []byte{192, 168, 1, 254} // Name server option
+	opt, err := ParseOption(OptionNameServer, option)
 	require.NoError(t, err)
 	generic := opt.(*OptionGeneric)
 	require.Equal(t, OptionNameServer, generic.Code())
@@ -21,164 +22,221 @@ func TestParseOption(t *testing.T) {
 	require.Equal(t, "Name Server -> [192 168 1 254]", generic.String())
 
 	// Option subnet mask
-	option = []byte{1, 4, 255, 255, 255, 0}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{255, 255, 255, 0}
+	opt, err = ParseOption(OptionSubnetMask, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionSubnetMask, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option router
-	option = []byte{3, 4, 192, 168, 1, 1}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{192, 168, 1, 1}
+	opt, err = ParseOption(OptionRouter, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionRouter, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option domain name server
-	option = []byte{6, 4, 192, 168, 1, 1}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{192, 168, 1, 1}
+	opt, err = ParseOption(OptionDomainNameServer, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionDomainNameServer, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option host name
-	option = []byte{12, 4, 't', 'e', 's', 't'}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{'t', 'e', 's', 't'}
+	opt, err = ParseOption(OptionHostName, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionHostName, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option domain name
-	option = []byte{15, 4, 't', 'e', 's', 't'}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{'t', 'e', 's', 't'}
+	opt, err = ParseOption(OptionDomainName, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionDomainName, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option root path
-	option = []byte{17, 4, '/', 'f', 'o', 'o'}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{'/', 'f', 'o', 'o'}
+	opt, err = ParseOption(OptionRootPath, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionRootPath, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option broadcast address
-	option = []byte{28, 4, 255, 255, 255, 255}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{255, 255, 255, 255}
+	opt, err = ParseOption(OptionBroadcastAddress, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionBroadcastAddress, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option NTP servers
-	option = []byte{42, 4, 10, 10, 10, 10}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{10, 10, 10, 10}
+	opt, err = ParseOption(OptionNTPServers, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionNTPServers, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Requested IP address
-	option = []byte{50, 4, 1, 2, 3, 4}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{1, 2, 3, 4}
+	opt, err = ParseOption(OptionRequestedIPAddress, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionRequestedIPAddress, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Requested IP address lease time
-	option = []byte{51, 4, 0, 0, 0, 0}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{0, 0, 0, 0}
+	opt, err = ParseOption(OptionIPAddressLeaseTime, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionIPAddressLeaseTime, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Message type
-	option = []byte{53, 1, 1}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{1}
+	opt, err = ParseOption(OptionDHCPMessageType, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionDHCPMessageType, opt.Code(), "Code")
 	require.Equal(t, 1, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option server ID
-	option = []byte{54, 4, 1, 2, 3, 4}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{1, 2, 3, 4}
+	opt, err = ParseOption(OptionServerIdentifier, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionServerIdentifier, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Parameter request list
-	option = []byte{55, 3, 5, 53, 61}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{5, 53, 61}
+	opt, err = ParseOption(OptionParameterRequestList, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionParameterRequestList, opt.Code(), "Code")
 	require.Equal(t, 3, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option max message size
-	option = []byte{57, 2, 1, 2}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{1, 2}
+	opt, err = ParseOption(OptionMaximumDHCPMessageSize, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionMaximumDHCPMessageSize, opt.Code(), "Code")
 	require.Equal(t, 2, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option class identifier
-	option = []byte{60, 4, 't', 'e', 's', 't'}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{'t', 'e', 's', 't'}
+	opt, err = ParseOption(OptionClassIdentifier, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionClassIdentifier, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option TFTP server name
-	option = []byte{66, 4, 't', 'e', 's', 't'}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{'t', 'e', 's', 't'}
+	opt, err = ParseOption(OptionTFTPServerName, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionTFTPServerName, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option Bootfile name
-	option = []byte{67, 9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't'}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't'}
+	opt, err = ParseOption(OptionBootfileName, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionBootfileName, opt.Code(), "Code")
 	require.Equal(t, 9, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option user class information
-	option = []byte{77, 5, 4, 't', 'e', 's', 't'}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{4, 't', 'e', 's', 't'}
+	opt, err = ParseOption(OptionUserClassInformation, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionUserClassInformation, opt.Code(), "Code")
 	require.Equal(t, 5, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option relay agent information
-	option = []byte{82, 6, 1, 4, 129, 168, 0, 1}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{1, 4, 129, 168, 0, 1}
+	opt, err = ParseOption(OptionRelayAgentInformation, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionRelayAgentInformation, opt.Code(), "Code")
 	require.Equal(t, 6, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
 
 	// Option client system architecture type option
-	option = []byte{93, 4, 't', 'e', 's', 't'}
-	opt, err = ParseOption(OptionCode(option[0]), option[2:])
+	option = []byte{'t', 'e', 's', 't'}
+	opt, err = ParseOption(OptionClientSystemArchitectureType, option)
 	require.NoError(t, err)
 	require.Equal(t, OptionClientSystemArchitectureType, opt.Code(), "Code")
 	require.Equal(t, 4, opt.Length(), "Length")
 	require.Equal(t, option, opt.ToBytes(), "ToBytes")
+}
+
+func TestOptionsMarshal(t *testing.T) {
+	for i, tt := range []struct {
+		opts Options
+		want []byte
+	}{
+		{
+			opts: nil,
+			want: nil,
+		},
+		{
+			opts: Options{
+				&OptionGeneric{
+					OptionCode: 5,
+					Data:       []byte{1, 2, 3, 4},
+				},
+			},
+			want: []byte{
+				5 /* key */, 4 /* length */, 1, 2, 3, 4,
+			},
+		},
+		{
+			// Test sorted key order.
+			opts: Options{
+				&OptionGeneric{
+					OptionCode: 5,
+					Data:       []byte{1, 2, 3},
+				},
+				&OptionGeneric{
+					OptionCode: 100,
+					Data:       []byte{101, 102, 103},
+				},
+			},
+			want: []byte{
+				5, 3, 1, 2, 3,
+				100, 3, 101, 102, 103,
+			},
+		},
+		{
+			// Test RFC 3396.
+			opts: Options{
+				&OptionGeneric{
+					OptionCode: 5,
+					Data:       bytes.Repeat([]byte{10}, math.MaxUint8+1),
+				},
+			},
+			want: append(append(
+				[]byte{5, math.MaxUint8}, bytes.Repeat([]byte{10}, math.MaxUint8)...),
+				5, 1, 10,
+			),
+		},
+	} {
+		t.Run(fmt.Sprintf("Test %02d", i), func(t *testing.T) {
+			require.Equal(t, uio.ToBigEndian(tt.opts), tt.want)
+		})
+	}
 }
 
 func TestOptionsUnmarshal(t *testing.T) {


### PR DESCRIPTION
- Consolidate writing the option code and length to Options.Marshal
  rather than doing it in each individual option.
- Support RFC 3396.
- Use uio in marshaling code to simplify.
- Remove Option.Length() - unused and wrong to use anyway due to RFC 3396.