### PR TITLE
Conform to RFC 3396 & RFC 2131 wrt Options

### DIFF
--- a/dhcpv4/bsdp/option_vendor_specific_information.go
+++ b/dhcpv4/bsdp/option_vendor_specific_information.go
@@ -87,11 +87,6 @@ func (o *OptVendorSpecificInformation) String() string {
 	return s
 }
 
-// GetOption returns all suboptions that match the given OptionCode code.
-func (o *OptVendorSpecificInformation) GetOption(code dhcpv4.OptionCode) []dhcpv4.Option {
-	return o.Options.Get(code)
-}
-
 // GetOneOption returns the first suboption that matches the OptionCode code.
 func (o *OptVendorSpecificInformation) GetOneOption(code dhcpv4.OptionCode) dhcpv4.Option {
 	return o.Options.GetOne(code)

--- a/dhcpv4/bsdp/option_vendor_specific_information_test.go
+++ b/dhcpv4/bsdp/option_vendor_specific_information_test.go
@@ -166,52 +166,6 @@ func TestOptVendorSpecificInformationString(t *testing.T) {
 	require.Equal(t, expectedString, o.String())
 }
 
-func TestOptVendorSpecificInformationGetOptions(t *testing.T) {
-	// No option
-	o := &OptVendorSpecificInformation{
-		[]dhcpv4.Option{
-			&OptMessageType{MessageTypeList},
-			Version1_1,
-		},
-	}
-	foundOpts := o.GetOption(OptionBootImageList)
-	require.Empty(t, foundOpts, "should not get any options")
-
-	// One option
-	o = &OptVendorSpecificInformation{
-		[]dhcpv4.Option{
-			&OptMessageType{MessageTypeList},
-			Version1_1,
-		},
-	}
-	foundOpts = o.GetOption(OptionMessageType)
-	require.Equal(t, 1, len(foundOpts), "should only get one option")
-	require.Equal(t, MessageTypeList, foundOpts[0].(*OptMessageType).Type)
-
-	// Multiple options
-	//
-	// TODO: Remove this test when RFC 3396 is properly implemented. This
-	// isn't a valid packet. RFC 2131, Section 4.1: "Options may appear
-	// only once." RFC 3396 clarifies this to say that options will be
-	// concatenated. I.e., in this case, the bytes would be:
-	//
-	// <versioncode> 4 1 1 0 1
-	//
-	// Which would obviously not be parsed by the Version parser, as it
-	// only accepts two bytes.
-	o = &OptVendorSpecificInformation{
-		[]dhcpv4.Option{
-			&OptMessageType{MessageTypeList},
-			Version1_1,
-			Version1_0,
-		},
-	}
-	foundOpts = o.GetOption(OptionVersion)
-	require.Equal(t, 2, len(foundOpts), "should get two options")
-	require.Equal(t, Version1_1, foundOpts[0].(Version))
-	require.Equal(t, Version1_0, foundOpts[1].(Version))
-}
-
 func TestOptVendorSpecificInformationGetOneOption(t *testing.T) {
 	// No option
 	o := &OptVendorSpecificInformation{
@@ -232,15 +186,4 @@ func TestOptVendorSpecificInformationGetOneOption(t *testing.T) {
 	}
 	foundOpt = o.GetOneOption(OptionMessageType)
 	require.Equal(t, MessageTypeList, foundOpt.(*OptMessageType).Type)
-
-	// Multiple options
-	o = &OptVendorSpecificInformation{
-		[]dhcpv4.Option{
-			&OptMessageType{MessageTypeList},
-			Version1_1,
-			Version1_0,
-		},
-	}
-	foundOpt = o.GetOneOption(OptionVersion)
-	require.Equal(t, Version1_1, foundOpt.(Version))
 }

--- a/dhcpv4/modifiers.go
+++ b/dhcpv4/modifiers.go
@@ -37,7 +37,7 @@ func WithHwAddr(hwaddr net.HardwareAddr) Modifier {
 // WithOption appends a DHCPv4 option provided by the user
 func WithOption(opt Option) Modifier {
 	return func(d *DHCPv4) *DHCPv4 {
-		d.AddOption(opt)
+		d.UpdateOption(opt)
 		return d
 	}
 }
@@ -52,7 +52,7 @@ func WithUserClass(uc []byte, rfc bool) Modifier {
 			UserClasses: [][]byte{uc},
 			Rfc3004:     rfc,
 		}
-		d.AddOption(&ouc)
+		d.UpdateOption(&ouc)
 		return d
 	}
 }
@@ -85,7 +85,7 @@ func WithNetboot(d *DHCPv4) *DHCPv4 {
 		OptParams = &OptParameterRequestList{
 			RequestedOpts: []OptionCode{OptionTFTPServerName, OptionBootfileName},
 		}
-		d.AddOption(OptParams)
+		d.UpdateOption(OptParams)
 	}
 	return d
 }
@@ -96,7 +96,7 @@ func WithRequestedOptions(optionCodes ...OptionCode) Modifier {
 		params := d.GetOneOption(OptionParameterRequestList)
 		if params == nil {
 			params = &OptParameterRequestList{}
-			d.AddOption(params)
+			d.UpdateOption(params)
 		}
 		opts := params.(*OptParameterRequestList)
 		for _, optionCode := range optionCodes {

--- a/dhcpv4/modifiers_test.go
+++ b/dhcpv4/modifiers_test.go
@@ -69,7 +69,7 @@ func TestUserClassModifierRFC(t *testing.T) {
 func TestWithNetboot(t *testing.T) {
 	d, _ := New()
 	d = WithNetboot(d)
-	require.Equal(t, "Parameter Request List -> [TFTP Server Name, Bootfile Name]", d.Options[0].String())
+	require.Equal(t, "Parameter Request List -> TFTP Server Name, Bootfile Name", d.Options[0].String())
 }
 
 func TestWithNetbootExistingTFTP(t *testing.T) {
@@ -79,7 +79,7 @@ func TestWithNetbootExistingTFTP(t *testing.T) {
 	}
 	d.UpdateOption(OptParams)
 	d = WithNetboot(d)
-	require.Equal(t, "Parameter Request List -> [TFTP Server Name, Bootfile Name]", d.Options[0].String())
+	require.Equal(t, "Parameter Request List -> TFTP Server Name, Bootfile Name", d.Options[0].String())
 }
 
 func TestWithNetbootExistingBootfileName(t *testing.T) {
@@ -89,7 +89,7 @@ func TestWithNetbootExistingBootfileName(t *testing.T) {
 	}
 	d.UpdateOption(OptParams)
 	d = WithNetboot(d)
-	require.Equal(t, "Parameter Request List -> [Bootfile Name, TFTP Server Name]", d.Options[0].String())
+	require.Equal(t, "Parameter Request List -> Bootfile Name, TFTP Server Name", d.Options[0].String())
 }
 
 func TestWithNetbootExistingBoth(t *testing.T) {
@@ -99,7 +99,7 @@ func TestWithNetbootExistingBoth(t *testing.T) {
 	}
 	d.UpdateOption(OptParams)
 	d = WithNetboot(d)
-	require.Equal(t, "Parameter Request List -> [Bootfile Name, TFTP Server Name]", d.Options[0].String())
+	require.Equal(t, "Parameter Request List -> Bootfile Name, TFTP Server Name", d.Options[0].String())
 }
 
 func TestWithRequestedOptions(t *testing.T) {

--- a/dhcpv4/modifiers_test.go
+++ b/dhcpv4/modifiers_test.go
@@ -77,7 +77,7 @@ func TestWithNetbootExistingTFTP(t *testing.T) {
 	OptParams := &OptParameterRequestList{
 		RequestedOpts: []OptionCode{OptionTFTPServerName},
 	}
-	d.AddOption(OptParams)
+	d.UpdateOption(OptParams)
 	d = WithNetboot(d)
 	require.Equal(t, "Parameter Request List -> [TFTP Server Name, Bootfile Name]", d.Options[0].String())
 }
@@ -87,7 +87,7 @@ func TestWithNetbootExistingBootfileName(t *testing.T) {
 	OptParams := &OptParameterRequestList{
 		RequestedOpts: []OptionCode{OptionBootfileName},
 	}
-	d.AddOption(OptParams)
+	d.UpdateOption(OptParams)
 	d = WithNetboot(d)
 	require.Equal(t, "Parameter Request List -> [Bootfile Name, TFTP Server Name]", d.Options[0].String())
 }
@@ -97,7 +97,7 @@ func TestWithNetbootExistingBoth(t *testing.T) {
 	OptParams := &OptParameterRequestList{
 		RequestedOpts: []OptionCode{OptionBootfileName, OptionTFTPServerName},
 	}
-	d.AddOption(OptParams)
+	d.UpdateOption(OptParams)
 	d = WithNetboot(d)
 	require.Equal(t, "Parameter Request List -> [Bootfile Name, TFTP Server Name]", d.Options[0].String())
 }

--- a/dhcpv4/option_generic_test.go
+++ b/dhcpv4/option_generic_test.go
@@ -43,5 +43,5 @@ func TestOptionGenericStringUnknown(t *testing.T) {
 		OptionCode: optionCode(102), // Returned option code.
 		Data:       []byte{byte(MessageTypeDiscover)},
 	}
-	require.Equal(t, "unknown -> [1]", o.String())
+	require.Equal(t, "unknown (102) -> [1]", o.String())
 }

--- a/dhcpv4/option_message_type_test.go
+++ b/dhcpv4/option_message_type_test.go
@@ -37,5 +37,5 @@ func TestOptMessageTypeString(t *testing.T) {
 
 	// unknown
 	o = OptMessageType{MessageType: 99}
-	require.Equal(t, "DHCP Message Type -> Unknown", o.String())
+	require.Equal(t, "DHCP Message Type -> unknown (99)", o.String())
 }

--- a/dhcpv4/option_parameter_request_list_test.go
+++ b/dhcpv4/option_parameter_request_list_test.go
@@ -14,7 +14,7 @@ func TestOptParameterRequestListInterfaceMethods(t *testing.T) {
 	expectedBytes := []byte{67, 5}
 	require.Equal(t, expectedBytes, o.ToBytes(), "ToBytes")
 
-	expectedString := "Parameter Request List -> [Bootfile Name, Name Server]"
+	expectedString := "Parameter Request List -> Bootfile Name, Name Server"
 	require.Equal(t, expectedString, o.String(), "String")
 }
 
@@ -25,6 +25,6 @@ func TestParseOptParameterRequestList(t *testing.T) {
 	)
 	o, err = ParseOptParameterRequestList([]byte{67, 5})
 	require.NoError(t, err)
-	expectedOpts := []OptionCode{OptionBootfileName, OptionNameServer}
+	expectedOpts := OptionCodeList{OptionBootfileName, OptionNameServer}
 	require.Equal(t, expectedOpts, o.RequestedOpts)
 }

--- a/dhcpv4/server_test.go
+++ b/dhcpv4/server_test.go
@@ -41,7 +41,7 @@ func DORAHandler(conn net.PacketConn, peer net.Addr, m *DHCPv4) {
 		log.Printf("NewReplyFromRequest failed: %v", err)
 		return
 	}
-	reply.AddOption(&OptServerIdentifier{ServerID: net.IP{1, 2, 3, 4}})
+	reply.UpdateOption(&OptServerIdentifier{ServerID: net.IP{1, 2, 3, 4}})
 	opt := m.GetOneOption(OptionDHCPMessageType)
 	if opt == nil {
 		log.Printf("No message type found!")
@@ -49,9 +49,9 @@ func DORAHandler(conn net.PacketConn, peer net.Addr, m *DHCPv4) {
 	}
 	switch opt.(*OptMessageType).MessageType {
 	case MessageTypeDiscover:
-		reply.AddOption(&OptMessageType{MessageType: MessageTypeOffer})
+		reply.UpdateOption(&OptMessageType{MessageType: MessageTypeOffer})
 	case MessageTypeRequest:
-		reply.AddOption(&OptMessageType{MessageType: MessageTypeAck})
+		reply.UpdateOption(&OptMessageType{MessageType: MessageTypeAck})
 	default:
 		log.Printf("Unhandled message type: %v", opt.(*OptMessageType).MessageType)
 		return

--- a/dhcpv4/types.go
+++ b/dhcpv4/types.go
@@ -1,5 +1,9 @@
 package dhcpv4
 
+import (
+	"fmt"
+)
+
 // values from http://www.networksorcery.com/enp/protocol/dhcp.htm and
 // http://www.networksorcery.com/enp/protocol/bootp/options.htm
 
@@ -31,7 +35,7 @@ func (m MessageType) String() string {
 	if s, ok := messageTypeToString[m]; ok {
 		return s
 	}
-	return "Unknown"
+	return fmt.Sprintf("unknown (%d)", byte(m))
 }
 
 var messageTypeToString = map[MessageType]string{
@@ -58,7 +62,7 @@ func (o OpcodeType) String() string {
 	if s, ok := opcodeToString[o]; ok {
 		return s
 	}
-	return "Unknown"
+	return fmt.Sprintf("unknown (%d)", uint8(o))
 }
 
 var opcodeToString = map[OpcodeType]string{
@@ -87,7 +91,7 @@ func (o optionCode) String() string {
 	if s, ok := optionCodeToString[o]; ok {
 		return s
 	}
-	return "unknown"
+	return fmt.Sprintf("unknown (%d)", o)
 }
 
 // DHCPv4 Options

--- a/dhcpv4/ztpv4/ztp_test.go
+++ b/dhcpv4/ztpv4/ztp_test.go
@@ -54,13 +54,13 @@ func TestParseV4VendorClass(t *testing.T) {
 			}
 
 			if tc.vc != "" {
-				packet.AddOption(&dhcpv4.OptClassIdentifier{
+				packet.UpdateOption(&dhcpv4.OptClassIdentifier{
 					Identifier: tc.vc,
 				})
 			}
 
 			if tc.hostname != "" {
-				packet.AddOption(&dhcpv4.OptHostName{
+				packet.UpdateOption(&dhcpv4.OptHostName{
 					HostName: tc.hostname,
 				})
 			}


### PR DESCRIPTION
Removes AddOption and GetOption.

RFC 2131 specifies that options may only appear once (Section 4.1). If
an option does appear more than once, its byte values must be
concatenated.

RFC 3396 further specifies that to send options longer than 255 bytes,
one option may be split into multiple option codes, which must be
concatenated back together by the receiver.

Both of these are concerned with the byte representation of options.
Fact is, based on both RFCs one can say that an option may only appear
once, but may be composed of multiple values. (Like the multiple IP options.)

Because an option may appear only once logically in any case, we remove
the AddOption and GetOption functions and leave only UpdateOption and
GetOneOption.

Also remove all additions & checks of the End option - the marshaling
and unmarshaling code is exclusively responsible for that now.

(will rebase after #226 is merged.)

The full RFC 3396 is not supported at the moment, as the Overload option is not respected. (Who TF even uses that.)