### PR TITLE
Added osx to continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ env:
   - TEST_SUITE=unit
   - TEST_SUITE=linters
 
+os:
+  - linux
+  - osx
+
 before_install:
   - go get -t -v ./...
 


### PR DESCRIPTION
As discussed in https://github.com/insomniacslk/dhcp/issues/229 we need to test on all the OSes we support