### PR TITLE
[async] re-add modifiers to Send method

### DIFF
--- a/dhcpv4/async/client.go
+++ b/dhcpv4/async/client.go
@@ -194,7 +194,11 @@ func (c *Client) remoteAddr() (*net.UDPAddr, error) {
 
 // Send inserts a message to the queue to be sent asynchronously.
 // Returns a future which resolves to response and error.
-func (c *Client) Send(message *dhcpv4.DHCPv4) *promise.Future {
+func (c *Client) Send(message *dhcpv4.DHCPv4, modifiers ...dhcpv4.Modifier) *promise.Future {
+	for _, mod := range modifiers {
+		mod(message)
+	}
+
 	p := promise.NewPromise()
 	c.packetsLock.Lock()
 	c.packets[message.TransactionID] = p


### PR DESCRIPTION
It was removed in fe6f307df5d78a54ddd4a56a275043317148fe5a.

It is needed in https://github.com/pinterest/bender/blob/master/dhcpv4/dhcpv4.go#L59.