### PR TITLE
[dhcpv4] move default to main directory

### DIFF
--- a/dhcpv4/bsdp/bsdp.go
+++ b/dhcpv4/bsdp/bsdp.go
@@ -40,7 +40,7 @@ func ParseBootImageListFromAck(ack *dhcpv4.DHCPv4) ([]BootImage, error) {
 }
 
 func needsReplyPort(replyPort uint16) bool {
-	return replyPort != 0 && replyPort != client4.ClientPort
+	return replyPort != 0 && replyPort != dhcpv4.ClientPort
 }
 
 // MessageTypeFromPacket extracts the BSDP message type (LIST, SELECT) from the

--- a/dhcpv4/bsdp/bsdp.go
+++ b/dhcpv4/bsdp/bsdp.go
@@ -6,7 +6,6 @@ import (
 	"net"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/insomniacslk/dhcp/dhcpv4/client4"
 )
 
 // MaxDHCPMessageSize is the size set in DHCP option 57 (DHCP Maximum Message Size).

--- a/dhcpv4/bsdp/bsdp_test.go
+++ b/dhcpv4/bsdp/bsdp_test.go
@@ -58,7 +58,7 @@ func TestParseBootImageListFromAckNoVendorOption(t *testing.T) {
 func TestNeedsReplyPort(t *testing.T) {
 	require.True(t, needsReplyPort(123))
 	require.False(t, needsReplyPort(0))
-	require.False(t, needsReplyPort(client4.ClientPort))
+	require.False(t, needsReplyPort(dhcpv4.ClientPort))
 }
 
 func TestNewInformList_NoReplyPort(t *testing.T) {
@@ -215,13 +215,13 @@ func TestInformSelectForAck_ReplyPort(t *testing.T) {
 }
 
 func TestNewReplyForInformList_NoDefaultImage(t *testing.T) {
-	inform, _ := NewInformList(net.HardwareAddr{1, 2, 3, 4, 5, 6}, net.IP{1, 2, 3, 4}, client4.ClientPort)
+	inform, _ := NewInformList(net.HardwareAddr{1, 2, 3, 4, 5, 6}, net.IP{1, 2, 3, 4}, dhcpv4.ClientPort)
 	_, err := NewReplyForInformList(inform, ReplyConfig{})
 	require.Error(t, err)
 }
 
 func TestNewReplyForInformList_NoImages(t *testing.T) {
-	inform, _ := NewInformList(net.HardwareAddr{1, 2, 3, 4, 5, 6}, net.IP{1, 2, 3, 4}, client4.ClientPort)
+	inform, _ := NewInformList(net.HardwareAddr{1, 2, 3, 4, 5, 6}, net.IP{1, 2, 3, 4}, dhcpv4.ClientPort)
 	fakeImage := BootImage{
 		ID: BootImageID{ImageType: BootImageTypeMacOSX},
 	}
@@ -239,7 +239,7 @@ func TestNewReplyForInformList_NoImages(t *testing.T) {
 }
 
 func TestNewReplyForInformList(t *testing.T) {
-	inform, _ := NewInformList(net.HardwareAddr{1, 2, 3, 4, 5, 6}, net.IP{1, 2, 3, 4}, client4.ClientPort)
+	inform, _ := NewInformList(net.HardwareAddr{1, 2, 3, 4, 5, 6}, net.IP{1, 2, 3, 4}, dhcpv4.ClientPort)
 	images := []BootImage{
 		BootImage{
 			ID: BootImageID{
@@ -293,13 +293,13 @@ func TestNewReplyForInformList(t *testing.T) {
 }
 
 func TestNewReplyForInformSelect_NoSelectedImage(t *testing.T) {
-	inform, _ := NewInformList(net.HardwareAddr{1, 2, 3, 4, 5, 6}, net.IP{1, 2, 3, 4}, client4.ClientPort)
+	inform, _ := NewInformList(net.HardwareAddr{1, 2, 3, 4, 5, 6}, net.IP{1, 2, 3, 4}, dhcpv4.ClientPort)
 	_, err := NewReplyForInformSelect(inform, ReplyConfig{})
 	require.Error(t, err)
 }
 
 func TestNewReplyForInformSelect_NoImages(t *testing.T) {
-	inform, _ := NewInformList(net.HardwareAddr{1, 2, 3, 4, 5, 6}, net.IP{1, 2, 3, 4}, client4.ClientPort)
+	inform, _ := NewInformList(net.HardwareAddr{1, 2, 3, 4, 5, 6}, net.IP{1, 2, 3, 4}, dhcpv4.ClientPort)
 	fakeImage := BootImage{
 		ID: BootImageID{ImageType: BootImageTypeMacOSX},
 	}
@@ -317,7 +317,7 @@ func TestNewReplyForInformSelect_NoImages(t *testing.T) {
 }
 
 func TestNewReplyForInformSelect(t *testing.T) {
-	inform, _ := NewInformList(net.HardwareAddr{1, 2, 3, 4, 5, 6}, net.IP{1, 2, 3, 4}, client4.ClientPort)
+	inform, _ := NewInformList(net.HardwareAddr{1, 2, 3, 4, 5, 6}, net.IP{1, 2, 3, 4}, dhcpv4.ClientPort)
 	images := []BootImage{
 		BootImage{
 			ID: BootImageID{

--- a/dhcpv4/bsdp/bsdp_test.go
+++ b/dhcpv4/bsdp/bsdp_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/insomniacslk/dhcp/dhcpv4/client4"
 	"github.com/insomniacslk/dhcp/iana"
 	"github.com/stretchr/testify/require"
 )

--- a/dhcpv4/bsdp/client.go
+++ b/dhcpv4/bsdp/client.go
@@ -35,7 +35,7 @@ func (c *Client) Exchange(ifname string) ([]*Packet, error) {
 	}
 
 	// INFORM[LIST]
-	informList, err := NewInformListForInterface(ifname, client4.ClientPort)
+	informList, err := NewInformListForInterface(ifname, dhcpv4.ClientPort)
 	if err != nil {
 		return conversation, err
 	}
@@ -60,7 +60,7 @@ func (c *Client) Exchange(ifname string) ([]*Packet, error) {
 	}
 
 	// INFORM[SELECT]
-	informSelect, err := InformSelectForAck(PacketFor(ackForList), client4.ClientPort, bootImages[0])
+	informSelect, err := InformSelectForAck(PacketFor(ackForList), dhcpv4.ClientPort, bootImages[0])
 	if err != nil {
 		return conversation, err
 	}

--- a/dhcpv4/client4/client.go
+++ b/dhcpv4/client4/client.go
@@ -113,7 +113,7 @@ func MakeBroadcastSocket(ifname string) (int, error) {
 // MakeListeningSocket creates a listening socket on 0.0.0.0 for the DHCP client
 // port and returns it.
 func MakeListeningSocket(ifname string) (int, error) {
-	return makeListeningSocketWithCustomPort(ifname, ClientPort)
+	return makeListeningSocketWithCustomPort(ifname, dhcpv4.ClientPort)
 }
 
 func htons(v uint16) uint16 {
@@ -157,7 +157,7 @@ func toUDPAddr(addr net.Addr, defaultAddr *net.UDPAddr) (*net.UDPAddr, error) {
 }
 
 func (c *Client) getLocalUDPAddr() (*net.UDPAddr, error) {
-	defaultLocalAddr := &net.UDPAddr{IP: net.IPv4zero, Port: ClientPort}
+	defaultLocalAddr := &net.UDPAddr{IP: net.IPv4zero, Port: dhcpv4.ClientPort}
 	laddr, err := toUDPAddr(c.LocalAddr, defaultLocalAddr)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid local address: %s", err)
@@ -166,7 +166,7 @@ func (c *Client) getLocalUDPAddr() (*net.UDPAddr, error) {
 }
 
 func (c *Client) getRemoteUDPAddr() (*net.UDPAddr, error) {
-	defaultRemoteAddr := &net.UDPAddr{IP: net.IPv4bcast, Port: ServerPort}
+	defaultRemoteAddr := &net.UDPAddr{IP: net.IPv4bcast, Port: dhcpv4.ServerPort}
 	raddr, err := toUDPAddr(c.RemoteAddr, defaultRemoteAddr)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid remote address: %s", err)
@@ -304,7 +304,7 @@ func (c *Client) SendReceive(sendFd, recvFd int, packet *dhcpv4.DHCPv4, messageT
 			udph := buf[iph.Len:n]
 			// check source and destination ports
 			srcPort := int(binary.BigEndian.Uint16(udph[0:2]))
-			expectedSrcPort := ServerPort
+			expectedSrcPort := dhcpv4.ServerPort
 			if c.RemoteAddr != nil {
 				expectedSrcPort = c.RemoteAddr.(*net.UDPAddr).Port
 			}
@@ -312,7 +312,7 @@ func (c *Client) SendReceive(sendFd, recvFd int, packet *dhcpv4.DHCPv4, messageT
 				continue
 			}
 			dstPort := int(binary.BigEndian.Uint16(udph[2:4]))
-			expectedDstPort := ClientPort
+			expectedDstPort := dhcpv4.ClientPort
 			if c.RemoteAddr != nil {
 				expectedDstPort = c.LocalAddr.(*net.UDPAddr).Port
 			}

--- a/dhcpv4/defaults.go
+++ b/dhcpv4/defaults.go
@@ -1,4 +1,4 @@
-package client4
+package dhcpv4
 
 const (
 	ServerPort = 67


### PR DESCRIPTION
This is going to be shared by the server and client code so it should be moved to the main directory. This also makes it consistent with what was done for dhcpv6.