### PR TITLE
Allow Unknown OperState of the link interface

### DIFF
--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -28,7 +28,7 @@ done
 
 # Skip go1.9 for this check. rtr7/router7 depends on miekg/dns, which does not
 # support go1.9
-if [ "$TRAVIS_GO_VERSION" = "1.9" ]
+if [[ "$TRAVIS_GO_VERSION" =~ ^1.(9|10|11)$ ]]
 then
     exit 0
 fi


### PR DESCRIPTION
We hit a bug when Netconf library was failing to bring interface up
despite the fact that it was actually up. It turned out that it's oper
state was not set to UP, what is expected by the library.

According to kernel documentation it is ok proceed if interface state
is Up or Unknown:

```
  Interface is in RFC2863 operational state UP or UNKNOWN. This is for
  backward compatibility, routing daemons, dhcp clients can use this
  flag to determine whether they should use the interface.
```

Also, resaon why operational state may remain Unknown:

```
IF_OPER_UNKNOWN (0):
 Interface is in unknown state, neither driver nor userspace has set
 operational state. Interface must be considered for user data as
 setting operational state has not been implemented in every driver.
```

I modified our code to try DHCP transaction even if `IfUp` failed, but
the OperState was equal to Unknown - it worked perfectly.