### PR TITLE
revert modifiers definition

### DIFF
--- a/dhcpv6/async/client.go
+++ b/dhcpv6/async/client.go
@@ -210,7 +210,7 @@ func (c *Client) remoteAddr() (*net.UDPAddr, error) {
 // Returns a future which resolves to response and error.
 func (c *Client) Send(message dhcpv6.DHCPv6, modifiers ...dhcpv6.Modifier) *promise.Future {
 	for _, mod := range modifiers {
-		mod(message)
+		message = mod(message)
 	}
 
 	transactionID, err := dhcpv6.GetTransactionID(message)

--- a/dhcpv6/async/client_test.go
+++ b/dhcpv6/async/client_test.go
@@ -26,7 +26,8 @@ func solicit(input string) (*dhcpv6.Message, error) {
 		Time:          dhcpv6.GetTime(),
 		LinkLayerAddr: mac,
 	}
-	return dhcpv6.NewSolicitWithCID(duid)
+	s, _ := dhcpv6.NewSolicitWithCID(duid)
+	return s.(*Message), nil
 }
 
 // server creates a server which responds with a predefined response

--- a/dhcpv6/async/client_test.go
+++ b/dhcpv6/async/client_test.go
@@ -27,7 +27,7 @@ func solicit(input string) (*dhcpv6.Message, error) {
 		LinkLayerAddr: mac,
 	}
 	s, _ := dhcpv6.NewSolicitWithCID(duid)
-	return s.(*Message), nil
+	return s.(*dhcpv6.Message), nil
 }
 
 // server creates a server which responds with a predefined response

--- a/dhcpv6/client6/client.go
+++ b/dhcpv6/client6/client.go
@@ -196,7 +196,7 @@ func (c *Client) Solicit(ifname string, modifiers ...dhcpv6.Modifier) (dhcpv6.DH
 		return nil, nil, err
 	}
 	for _, mod := range modifiers {
-		mod(solicit)
+		solicit = mod(solicit)
 	}
 	advertise, err := c.sendReceive(ifname, solicit, dhcpv6.MessageTypeNone)
 	return solicit, advertise, err
@@ -211,7 +211,7 @@ func (c *Client) Request(ifname string, advertise *dhcpv6.Message, modifiers ...
 		return nil, nil, err
 	}
 	for _, mod := range modifiers {
-		mod(request)
+		request = mod(request)
 	}
 	reply, err := c.sendReceive(ifname, request, dhcpv6.MessageTypeNone)
 	return request, reply, err

--- a/dhcpv6/dhcpv6.go
+++ b/dhcpv6/dhcpv6.go
@@ -83,7 +83,7 @@ func FromBytes(data []byte) (DHCPv6, error) {
 }
 
 // NewMessage creates a new DHCPv6 message with default options
-func NewMessage(modifiers ...Modifier) (*Message, error) {
+func NewMessage(modifiers ...Modifier) (DHCPv6, error) {
 	tid, err := GenerateTransactionID()
 	if err != nil {
 		return nil, err
@@ -93,10 +93,11 @@ func NewMessage(modifiers ...Modifier) (*Message, error) {
 		TransactionID: tid,
 	}
 	// apply modifiers
+	d := DHCPv6(msg)
 	for _, mod := range modifiers {
-		mod(msg)
+		d = mod(d)
 	}
-	return msg, nil
+	return d, nil
 }
 
 // DecapsulateRelay extracts the content of a relay message. It does not recurse

--- a/dhcpv6/dhcpv6.go
+++ b/dhcpv6/dhcpv6.go
@@ -26,7 +26,7 @@ type DHCPv6 interface {
 
 // Modifier defines the signature for functions that can modify DHCPv6
 // structures. This is used to simplify packet manipulation
-type Modifier func(d DHCPv6)
+type Modifier func(d DHCPv6) DHCPv6
 
 // MessageFromBytes parses a DHCPv6 message from a byte stream.
 func MessageFromBytes(data []byte) (*Message, error) {

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -63,8 +63,8 @@ func TestNewMessage(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, d)
 	require.Equal(t, MessageTypeSolicit, d.Type())
-	require.NotEqual(t, 0, d.TransactionID)
-	require.Empty(t, d.Options)
+	require.NotEqual(t, 0, d.(*Message).TransactionID)
+	require.Empty(t, d.(*Message).Options)
 }
 
 func TestDecapsulateRelayIndex(t *testing.T) {
@@ -148,7 +148,7 @@ func TestNewAdvertiseFromSolicit(t *testing.T) {
 
 	a, err := NewAdvertiseFromSolicit(&s, WithServerID(duid))
 	require.NoError(t, err)
-	require.Equal(t, a.TransactionID, s.TransactionID)
+	require.Equal(t, a.(*Message).TransactionID, s.TransactionID)
 	require.Equal(t, a.Type(), MessageTypeAdvertise)
 }
 
@@ -166,31 +166,31 @@ func TestNewReplyFromMessage(t *testing.T) {
 
 	rep, err := NewReplyFromMessage(&msg, WithServerID(duid))
 	require.NoError(t, err)
-	require.Equal(t, rep.TransactionID, msg.TransactionID)
+	require.Equal(t, rep.(*Message).TransactionID, msg.TransactionID)
 	require.Equal(t, rep.Type(), MessageTypeReply)
 
 	msg.MessageType = MessageTypeRenew
 	rep, err = NewReplyFromMessage(&msg, WithServerID(duid))
 	require.NoError(t, err)
-	require.Equal(t, rep.TransactionID, msg.TransactionID)
+	require.Equal(t, rep.(*Message).TransactionID, msg.TransactionID)
 	require.Equal(t, rep.Type(), MessageTypeReply)
 
 	msg.MessageType = MessageTypeRebind
 	rep, err = NewReplyFromMessage(&msg, WithServerID(duid))
 	require.NoError(t, err)
-	require.Equal(t, rep.TransactionID, msg.TransactionID)
+	require.Equal(t, rep.(*Message).TransactionID, msg.TransactionID)
 	require.Equal(t, rep.Type(), MessageTypeReply)
 
 	msg.MessageType = MessageTypeRelease
 	rep, err = NewReplyFromMessage(&msg, WithServerID(duid))
 	require.NoError(t, err)
-	require.Equal(t, rep.TransactionID, msg.TransactionID)
+	require.Equal(t, rep.(*Message).TransactionID, msg.TransactionID)
 	require.Equal(t, rep.Type(), MessageTypeReply)
 
 	msg.MessageType = MessageTypeInformationRequest
 	rep, err = NewReplyFromMessage(&msg, WithServerID(duid))
 	require.NoError(t, err)
-	require.Equal(t, rep.TransactionID, msg.TransactionID)
+	require.Equal(t, rep.(*Message).TransactionID, msg.TransactionID)
 	require.Equal(t, rep.Type(), MessageTypeReply)
 
 	msg.MessageType = MessageTypeSolicit
@@ -263,7 +263,7 @@ func TestGetTransactionIDMessage(t *testing.T) {
 	require.NoError(t, err)
 	transactionID, err := GetTransactionID(message)
 	require.NoError(t, err)
-	require.Equal(t, transactionID, message.TransactionID)
+	require.Equal(t, transactionID, message.(*Message).TransactionID)
 }
 
 func TestGetTransactionIDRelay(t *testing.T) {
@@ -273,7 +273,7 @@ func TestGetTransactionIDRelay(t *testing.T) {
 	require.NoError(t, err)
 	transactionID, err := GetTransactionID(relay)
 	require.NoError(t, err)
-	require.Equal(t, transactionID, message.TransactionID)
+	require.Equal(t, transactionID, message.(*Message).TransactionID)
 }
 
 // TODO test NewMessageTypeSolicit

--- a/dhcpv6/dhcpv6relay_test.go
+++ b/dhcpv6/dhcpv6relay_test.go
@@ -87,8 +87,8 @@ func TestNewRelayRepFromRelayForw(t *testing.T) {
 	rf.AddOption(&OptRemoteId{})
 
 	// create the inner message
-	s, err := NewMessage()
-	require.NoError(t, err)
+	s := &Message{}
+	s.MessageType = MessageTypeSolicit
 	s.AddOption(&OptClientId{})
 	orm := OptRelayMsg{}
 	orm.SetRelayMessage(s)
@@ -96,7 +96,7 @@ func TestNewRelayRepFromRelayForw(t *testing.T) {
 
 	a, err := NewAdvertiseFromSolicit(s)
 	require.NoError(t, err)
-	rr, err := NewRelayReplFromRelayForw(&rf, a)
+	rr, err := NewRelayReplFromRelayForw(&rf, a.(*Message))
 	require.NoError(t, err)
 	relay := rr.(*RelayMessage)
 	require.Equal(t, rr.Type(), MessageTypeRelayReply)
@@ -109,7 +109,7 @@ func TestNewRelayRepFromRelayForw(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, m, a)
 
-	rr, err = NewRelayReplFromRelayForw(nil, a)
+	rr, err = NewRelayReplFromRelayForw(nil, a.(*Message))
 	require.Error(t, err)
 	rr, err = NewRelayReplFromRelayForw(&rf, nil)
 	require.Error(t, err)

--- a/dhcpv6/modifiers.go
+++ b/dhcpv6/modifiers.go
@@ -10,26 +10,28 @@ import (
 
 // WithClientID adds a client ID option to a DHCPv6 packet
 func WithClientID(duid Duid) Modifier {
-	return func(d DHCPv6) {
+	return func(d DHCPv6) DHCPv6 {
 		cid := OptClientId{Cid: duid}
 		d.UpdateOption(&cid)
+		return d
 	}
 }
 
 // WithServerID adds a client ID option to a DHCPv6 packet
 func WithServerID(duid Duid) Modifier {
-	return func(d DHCPv6) {
+	return func(d DHCPv6) DHCPv6 {
 		sid := OptServerId{Sid: duid}
 		d.UpdateOption(&sid)
+		return d
 	}
 }
 
 // WithNetboot adds bootfile URL and bootfile param options to a DHCPv6 packet.
-func WithNetboot(d DHCPv6) {
+func WithNetboot(d DHCPv6) DHCPv6 {
 	msg, ok := d.(*Message)
 	if !ok {
 		log.Printf("WithNetboot: not a Message")
-		return
+		return d
 	}
 	// add OptionBootfileURL and OptionBootfileParam
 	opt := msg.GetOneOption(OptionORO)
@@ -41,30 +43,32 @@ func WithNetboot(d DHCPv6) {
 	oro.AddRequestedOption(OptionBootfileURL)
 	oro.AddRequestedOption(OptionBootfileParam)
 	msg.UpdateOption(oro)
-	return
+	return d
 }
 
 // WithUserClass adds a user class option to the packet
 func WithUserClass(uc []byte) Modifier {
 	// TODO let the user specify multiple user classes
-	return func(d DHCPv6) {
+	return func(d DHCPv6) DHCPv6 {
 		ouc := OptUserClass{UserClasses: [][]byte{uc}}
 		d.AddOption(&ouc)
+		return d
 	}
 }
 
 // WithArchType adds an arch type option to the packet
 func WithArchType(at iana.Arch) Modifier {
-	return func(d DHCPv6) {
+	return func(d DHCPv6) DHCPv6 {
 		ao := OptClientArchType{ArchTypes: []iana.Arch{at}}
 		d.AddOption(&ao)
+		return d
 	}
 }
 
 // WithIANA adds or updates an OptIANA option with the provided IAAddress
 // options
 func WithIANA(addrs ...OptIAAddress) Modifier {
-	return func(d DHCPv6) {
+	return func(d DHCPv6) DHCPv6 {
 		opt := d.GetOneOption(OptionIANA)
 		if opt == nil {
 			opt = &OptIANA{}
@@ -74,34 +78,37 @@ func WithIANA(addrs ...OptIAAddress) Modifier {
 			iaNa.AddOption(&addr)
 		}
 		d.UpdateOption(iaNa)
+		return d
 	}
 }
 
 // WithDNS adds or updates an OptDNSRecursiveNameServer
 func WithDNS(dnses ...net.IP) Modifier {
-	return func(d DHCPv6) {
+	return func(d DHCPv6) DHCPv6 {
 		odns := OptDNSRecursiveNameServer{
 			NameServers: append([]net.IP{}, dnses[:]...),
 		}
 		d.UpdateOption(&odns)
+		return d
 	}
 }
 
 // WithDomainSearchList adds or updates an OptDomainSearchList
 func WithDomainSearchList(searchlist ...string) Modifier {
-	return func(d DHCPv6) {
+	return func(d DHCPv6) DHCPv6 {
 		osl := OptDomainSearchList{
 			DomainSearchList: &rfc1035label.Labels{
 				Labels: searchlist,
 			},
 		}
 		d.UpdateOption(&osl)
+		return d
 	}
 }
 
 // WithRequestedOptions adds requested options to the packet
 func WithRequestedOptions(optionCodes ...OptionCode) Modifier {
-	return func(d DHCPv6) {
+	return func(d DHCPv6) DHCPv6 {
 		opt := d.GetOneOption(OptionORO)
 		if opt == nil {
 			opt = &OptRequestedOption{}
@@ -111,5 +118,6 @@ func WithRequestedOptions(optionCodes ...OptionCode) Modifier {
 			oro.AddRequestedOption(optionCode)
 		}
 		d.UpdateOption(oro)
+		return d
 	}
 }

--- a/dhcpv6/modifiers_test.go
+++ b/dhcpv6/modifiers_test.go
@@ -46,7 +46,7 @@ func TestWithRequestedOptions(t *testing.T) {
 	oro := opt.(*OptRequestedOption)
 	require.ElementsMatch(t, oro.RequestedOptions(), []OptionCode{OptionClientID})
 	// Check if already set options are preserved
-	WithRequestedOptions(OptionServerID)(m)
+	m = WithRequestedOptions(OptionServerID)(m)
 	opt = m.GetOneOption(OptionORO)
 	require.NotNil(t, opt)
 	oro = opt.(*OptRequestedOption)
@@ -54,24 +54,22 @@ func TestWithRequestedOptions(t *testing.T) {
 }
 
 func TestWithIANA(t *testing.T) {
-	var d Message
-	WithIANA(OptIAAddress{
+	d := WithIANA(OptIAAddress{
 		IPv6Addr:          net.ParseIP("::1"),
 		PreferredLifetime: 3600,
 		ValidLifetime:     5200,
-	})(&d)
-	require.Equal(t, 1, len(d.Options))
-	require.Equal(t, OptionIANA, d.Options[0].Code())
+	})(&Message{})
+	require.Equal(t, 1, len(d.(*Message).Options))
+	require.Equal(t, OptionIANA, d.(*Message).Options[0].Code())
 }
 
 func TestWithDNS(t *testing.T) {
-	var d Message
-	WithDNS([]net.IP{
+	d := WithDNS([]net.IP{
 		net.ParseIP("fe80::1"),
 		net.ParseIP("fe80::2"),
-	}...)(&d)
-	require.Equal(t, 1, len(d.Options))
-	dns := d.Options[0].(*OptDNSRecursiveNameServer)
+	}...)(&Message{})
+	require.Equal(t, 1, len(d.(*Message).Options))
+	dns := d.(*Message).Options[0].(*OptDNSRecursiveNameServer)
 	log.Printf("DNS %+v", dns)
 	require.Equal(t, OptionDNSRecursiveNameServer, dns.Code())
 	require.Equal(t, 2, len(dns.NameServers))
@@ -81,13 +79,12 @@ func TestWithDNS(t *testing.T) {
 }
 
 func TestWithDomainSearchList(t *testing.T) {
-	var d Message
-	WithDomainSearchList([]string{
+	d := WithDomainSearchList([]string{
 		"slackware.it",
 		"dhcp.slackware.it",
-	}...)(&d)
-	require.Equal(t, 1, len(d.Options))
-	osl := d.Options[0].(*OptDomainSearchList)
+	}...)(&Message{})
+	require.Equal(t, 1, len(d.(*Message).Options))
+	osl := d.(*Message).Options[0].(*OptDomainSearchList)
 	require.Equal(t, OptionDomainSearchList, osl.Code())
 	require.NotNil(t, osl.DomainSearchList)
 	labels := osl.DomainSearchList.Labels

--- a/netboot/netconf_test.go
+++ b/netboot/netconf_test.go
@@ -31,7 +31,7 @@ func getAdv(modifiers ...dhcpv6.Modifier) *dhcpv6.Message {
 	if err != nil {
 		log.Panic(err)
 	}
-	adv := d.(*dhcpv6.DHCPv6Message)
+	adv := d.(*dhcpv6.Message)
 	return adv
 }
 

--- a/netboot/netconf_test.go
+++ b/netboot/netconf_test.go
@@ -27,12 +27,11 @@ func getAdv(modifiers ...dhcpv6.Modifier) *dhcpv6.Message {
 	if err != nil {
 		log.Panic(err)
 	}
-	d, err := dhcpv6.NewAdvertiseFromSolicit(sol, modifiers...)
+	adv, err := dhcpv6.NewAdvertiseFromSolicit(sol.(*Message), modifiers...)
 	if err != nil {
 		log.Panic(err)
 	}
-	adv := d.(*dhcpv6.Message)
-	return adv
+	return adv.(*dhcpv6.Message)
 }
 
 func TestGetNetConfFromPacketv6Invalid(t *testing.T) {

--- a/netboot/netconf_test.go
+++ b/netboot/netconf_test.go
@@ -31,7 +31,8 @@ func getAdv(modifiers ...dhcpv6.Modifier) *dhcpv6.Message {
 	if err != nil {
 		log.Panic(err)
 	}
-	return d
+	adv := d.(*dhcpv6.DHCPv6Message)
+	return adv
 }
 
 func TestGetNetConfFromPacketv6Invalid(t *testing.T) {

--- a/netboot/netconf_test.go
+++ b/netboot/netconf_test.go
@@ -27,7 +27,7 @@ func getAdv(modifiers ...dhcpv6.Modifier) *dhcpv6.Message {
 	if err != nil {
 		log.Panic(err)
 	}
-	adv, err := dhcpv6.NewAdvertiseFromSolicit(sol.(*Message), modifiers...)
+	adv, err := dhcpv6.NewAdvertiseFromSolicit(sol.(*dhcpv6.Message), modifiers...)
 	if err != nil {
 		log.Panic(err)
 	}


### PR DESCRIPTION
Revert the change to the modifiers so that we can have a modifier that encapsulates packets.

The PR in question is https://github.com/insomniacslk/dhcp/pull/253.