### PR TITLE
dhcpv4: pad v4 messages to a 300 byte minimum

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -16,6 +16,7 @@
 package dhcpv4
 
 import (
+	"bytes"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -39,6 +40,9 @@ const (
 
 	// MaxMessageSize is the maximum size in bytes that a DHCPv4 packet can hold.
 	MaxMessageSize = 576
+
+	// Per RFC 951, the minimum length of a packet is 300 bytes.
+	bootpMinLen = 300
 )
 
 // magicCookie is the magic 4-byte value at the beginning of the list of options
@@ -468,8 +472,20 @@ func (d *DHCPv4) ToBytes() []byte {
 	// Write all options.
 	d.Options.Marshal(buf)
 
+	// DHCP is based on BOOTP, and BOOTP messages have a minimum length of
+	// 300 bytes per RFC 951. This not stated explicitly, but if you sum up
+	// all the bytes in the message layout, you'll get 300 bytes.
+	//
+	// Some DHCP servers and relay agents care about this BOOTP legacy B.S.
+	// and "conveniently" drop messages that are less than 300 bytes long.
+	//
+	// We subtract one byte for the OptionEnd option.
+	if buf.Len()+1 < bootpMinLen {
+		buf.WriteBytes(bytes.Repeat([]byte{OptionPad.Code()}, bootpMinLen-1-buf.Len()))
+	}
+
 	// Finish the packet.
-	buf.Write8(uint8(OptionEnd))
+	buf.Write8(OptionEnd.Code())
 
 	return buf.Data()
 }

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -1,6 +1,7 @@
 package dhcpv4
 
 import (
+	"bytes"
 	"net"
 	"testing"
 
@@ -152,15 +153,18 @@ func TestNewToBytes(t *testing.T) {
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // ClientHwAddr
 	}
 	// ServerHostName
-	for i := 0; i < 64; i++ {
-		expected = append(expected, 0)
-	}
+	expected = append(expected, bytes.Repeat([]byte{0}, 64)...)
 	// BootFileName
-	for i := 0; i < 128; i++ {
-		expected = append(expected, 0)
-	}
+	expected = append(expected, bytes.Repeat([]byte{0}, 128)...)
+
 	// Magic Cookie
 	expected = append(expected, magicCookie[:]...)
+
+	// Minimum message length padding.
+	//
+	// 236 + 4 byte cookie + 59 bytes padding + 1 byte end.
+	expected = append(expected, bytes.Repeat([]byte{0}, 59)...)
+
 	// End
 	expected = append(expected, 0xff)
 


### PR DESCRIPTION
Certain older DHCP servers and relay agents follow the RFC 951 BOOTP
standard in which BOOTP/DHCP messages have a 300 byte minimum length.

cc @ganshun

I'd appreciate the fast path on this review :)