### PR TITLE
server4 test: pick ports > 32k

### DIFF
--- a/dhcpv4/server4/server_test.go
+++ b/dhcpv4/server4/server_test.go
@@ -26,7 +26,7 @@ func randPort() int {
 	// can't use port 0 with raw sockets, so until we implement
 	// a non-raw-sockets client for non-static ports, we have to
 	// deal with this "randomness"
-	return 1024 + rand.Intn(65536-1024)
+	return 32*1024 + rand.Intn(65536-32*1024)
 }
 
 // DORAHandler is a server handler suitable for DORA transactions


### PR DESCRIPTION
This is dumb, but when I import this stuff to Google, I can only use ports 32k-64k. I'd like to avoid maintaining an internal patchset on top of dhcp... would y'all be fine taking this?