### PR TITLE
Modifying the writeIP function to always write IPv4 in 4 byte long format

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -429,6 +429,8 @@ func writeIP(b *uio.Lexer, ip net.IP) {
 	if ip == nil {
 		b.WriteBytes(zeros[:])
 	} else {
+		// Converting IP to 4 byte format
+		ip = ip.To4()
 		b.WriteBytes(ip[:net.IPv4len])
 	}
 }

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/insomniacslk/dhcp/iana"
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 func TestGetExternalIPv4Addrs(t *testing.T) {
@@ -335,4 +336,13 @@ func TestSummary(t *testing.T) {
 		"  options:\n" +
 		"    DHCP Message Type: INFORM\n"
 	require.Equal(t, want, packet.Summary())
+}
+
+func Test_withIP(t *testing.T) {
+	buff := uio.NewBigEndianBuffer(make([]byte, 0, 20))
+	// Converting a string into IP, ip1 will be in 16 byte format
+	ip1 := net.ParseIP("10.0.0.1")
+	writeIP(buff, ip1)
+	b := buff.Buffer
+	require.Equal(t, b.Len(), 4, "Testing no of bytes written by writeIP func")
 }


### PR DESCRIPTION
As in FromBytes function we are expecting that the version 4 IPs should have length of net.IPv4len which is 4 bytes long. This change will make sure that all the version 4 IPs are written into 4 bytes long format.

Written a unit test for same.

```
 go test -run Test_withIP -v
=== RUN   Test_withIP
--- PASS: Test_withIP (0.00s)
PASS
ok      github.com/akshaynawale/dhcp/dhcpv4     0.004s
```
All unit tests result: 
```
=== RUN   TestGetExternalIPv4Addrs
--- PASS: TestGetExternalIPv4Addrs (0.00s)
=== RUN   TestFromBytes
--- PASS: TestFromBytes (0.00s)
=== RUN   TestFromBytesZeroLength
--- PASS: TestFromBytesZeroLength (0.00s)
=== RUN   TestFromBytesShortLength
--- PASS: TestFromBytesShortLength (0.00s)
=== RUN   TestFromBytesInvalidOptions
--- PASS: TestFromBytesInvalidOptions (0.00s)
=== RUN   TestToStringMethods
--- PASS: TestToStringMethods (0.00s)
=== RUN   TestNewToBytes
--- PASS: TestNewToBytes (0.00s)
=== RUN   TestGetOption
--- PASS: TestGetOption (0.00s)
=== RUN   TestUpdateOption
--- PASS: TestUpdateOption (0.00s)
=== RUN   TestDHCPv4NewRequestFromOffer
--- PASS: TestDHCPv4NewRequestFromOffer (0.00s)
=== RUN   TestDHCPv4NewRequestFromOfferWithModifier
--- PASS: TestDHCPv4NewRequestFromOfferWithModifier (0.00s)
=== RUN   TestNewReplyFromRequest
--- PASS: TestNewReplyFromRequest (0.00s)
=== RUN   TestNewReplyFromRequestWithModifier
--- PASS: TestNewReplyFromRequestWithModifier (0.00s)
=== RUN   TestDHCPv4MessageTypeNil
--- PASS: TestDHCPv4MessageTypeNil (0.00s)
=== RUN   TestNewDiscovery
--- PASS: TestNewDiscovery (0.00s)
=== RUN   TestNewInform
--- PASS: TestNewInform (0.00s)
=== RUN   TestIsOptionRequested
--- PASS: TestIsOptionRequested (0.00s)
=== RUN   TestSummary
--- PASS: TestSummary (0.00s)
=== RUN   Test_withIP
--- PASS: Test_withIP (0.00s)
=== RUN   TestTransactionIDModifier
--- PASS: TestTransactionIDModifier (0.00s)
=== RUN   TestBroadcastModifier
--- PASS: TestBroadcastModifier (0.00s)
=== RUN   TestHwAddrModifier
--- PASS: TestHwAddrModifier (0.00s)
=== RUN   TestWithOptionModifier
--- PASS: TestWithOptionModifier (0.00s)
=== RUN   TestUserClassModifier
--- PASS: TestUserClassModifier (0.00s)
=== RUN   TestUserClassModifierRFC
--- PASS: TestUserClassModifierRFC (0.00s)
=== RUN   TestWithNetboot
--- PASS: TestWithNetboot (0.00s)
=== RUN   TestWithNetbootExistingTFTP
--- PASS: TestWithNetbootExistingTFTP (0.00s)
=== RUN   TestWithNetbootExistingBootfileName
--- PASS: TestWithNetbootExistingBootfileName (0.00s)
=== RUN   TestWithNetbootExistingBoth
--- PASS: TestWithNetbootExistingBoth (0.00s)
=== RUN   TestWithRequestedOptions
--- PASS: TestWithRequestedOptions (0.00s)
=== RUN   TestWithRelay
--- PASS: TestWithRelay (0.00s)
=== RUN   TestWithNetmask
--- PASS: TestWithNetmask (0.00s)
=== RUN   TestWithLeaseTime
--- PASS: TestWithLeaseTime (0.00s)
=== RUN   TestWithDNS
--- PASS: TestWithDNS (0.00s)
=== RUN   TestWithDomainSearchList
--- PASS: TestWithDomainSearchList (0.00s)
=== RUN   TestWithRouter
--- PASS: TestWithRouter (0.00s)
=== RUN   TestParseOptClientArchType
--- PASS: TestParseOptClientArchType (0.00s)
=== RUN   TestParseOptClientArchTypeMultiple
--- PASS: TestParseOptClientArchTypeMultiple (0.00s)
=== RUN   TestParseOptClientArchTypeInvalid
--- PASS: TestParseOptClientArchTypeInvalid (0.00s)
=== RUN   TestGetClientArchEmpty
--- PASS: TestGetClientArchEmpty (0.00s)
=== RUN   TestOptClientArchTypeParseAndToBytesMultiple
--- PASS: TestOptClientArchTypeParseAndToBytesMultiple (0.00s)
=== RUN   TestGetDomainSearch
--- PASS: TestGetDomainSearch (0.00s)
=== RUN   TestOptDomainSearchToBytes
--- PASS: TestOptDomainSearchToBytes (0.00s)
=== RUN   TestOptionGenericCode
--- PASS: TestOptionGenericCode (0.00s)
=== RUN   TestOptionGenericStringUnknown
--- PASS: TestOptionGenericStringUnknown (0.00s)
=== RUN   TestOptIPAddressLeaseTime
--- PASS: TestOptIPAddressLeaseTime (0.00s)
=== RUN   TestGetIPAddressLeaseTime
--- PASS: TestGetIPAddressLeaseTime (0.00s)
=== RUN   TestOptBroadcastAddress
--- PASS: TestOptBroadcastAddress (0.00s)
=== RUN   TestGetIPs
--- PASS: TestGetIPs (0.00s)
=== RUN   TestParseIP
--- PASS: TestParseIP (0.00s)
=== RUN   TestOptRequestedIPAddress
--- PASS: TestOptRequestedIPAddress (0.00s)
=== RUN   TestOptServerIdentifier
--- PASS: TestOptServerIdentifier (0.00s)
=== RUN   TestParseIPs
--- PASS: TestParseIPs (0.00s)
=== RUN   TestOptDomainNameServer
--- PASS: TestOptDomainNameServer (0.00s)
=== RUN   TestGetDomainNameServer
--- PASS: TestGetDomainNameServer (0.00s)
=== RUN   TestOptNTPServers
--- PASS: TestOptNTPServers (0.00s)
=== RUN   TestGetNTPServers
--- PASS: TestGetNTPServers (0.00s)
=== RUN   TestOptRouter
--- PASS: TestOptRouter (0.00s)
=== RUN   TestGetRouter
--- PASS: TestGetRouter (0.00s)
=== RUN   TestOptMaximumDHCPMessageSize
--- PASS: TestOptMaximumDHCPMessageSize (0.00s)
=== RUN   TestGetMaximumDHCPMessageSize
--- PASS: TestGetMaximumDHCPMessageSize (0.00s)
=== RUN   TestOptMessageType
--- PASS: TestOptMessageType (0.00s)
=== RUN   TestParseOptMessageType
--- PASS: TestParseOptMessageType (0.00s)
=== RUN   TestGetMessageType
--- PASS: TestGetMessageType (0.00s)
=== RUN   TestOptParameterRequestListInterfaceMethods
--- PASS: TestOptParameterRequestListInterfaceMethods (0.00s)
=== RUN   TestParseOptParameterRequestList
--- PASS: TestParseOptParameterRequestList (0.00s)
=== RUN   TestGetRelayAgentInformation
--- PASS: TestGetRelayAgentInformation (0.00s)
=== RUN   TestOptRelayAgentInfo
--- PASS: TestOptRelayAgentInfo (0.00s)
=== RUN   TestOptDomainName
--- PASS: TestOptDomainName (0.00s)
=== RUN   TestParseOptDomainName
--- PASS: TestParseOptDomainName (0.00s)
=== RUN   TestOptHostName
--- PASS: TestOptHostName (0.00s)
=== RUN   TestParseOptHostName
--- PASS: TestParseOptHostName (0.00s)
=== RUN   TestOptRootPath
--- PASS: TestOptRootPath (0.00s)
=== RUN   TestParseOptRootPath
--- PASS: TestParseOptRootPath (0.00s)
=== RUN   TestOptBootFileName
--- PASS: TestOptBootFileName (0.00s)
=== RUN   TestParseOptBootFileName
--- PASS: TestParseOptBootFileName (0.00s)
=== RUN   TestOptTFTPServerName
--- PASS: TestOptTFTPServerName (0.00s)
=== RUN   TestParseOptTFTPServerName
--- PASS: TestParseOptTFTPServerName (0.00s)
=== RUN   TestOptClassIdentifier
--- PASS: TestOptClassIdentifier (0.00s)
=== RUN   TestParseOptClassIdentifier
--- PASS: TestParseOptClassIdentifier (0.00s)
=== RUN   TestOptUserClass
--- PASS: TestOptUserClass (0.00s)
=== RUN   TestParseOptUserClass
--- PASS: TestParseOptUserClass (0.00s)
=== RUN   TestParseStringsMultiple
--- PASS: TestParseStringsMultiple (0.00s)
=== RUN   TestParseStringsNone
--- PASS: TestParseStringsNone (0.00s)
=== RUN   TestParseStrings
--- PASS: TestParseStrings (0.00s)
=== RUN   TestParseStringsZeroLength
--- PASS: TestParseStringsZeroLength (0.00s)
=== RUN   TestOptRFC3004UserClass
--- PASS: TestOptRFC3004UserClass (0.00s)
=== RUN   TestOptRFC3004UserClassMultiple
--- PASS: TestOptRFC3004UserClassMultiple (0.00s)
=== RUN   TestOptSubnetMask
--- PASS: TestOptSubnetMask (0.00s)
=== RUN   TestGetSubnetMask
--- PASS: TestGetSubnetMask (0.00s)
=== RUN   TestOptVIVCInterfaceMethods
--- PASS: TestOptVIVCInterfaceMethods (0.00s)
=== RUN   TestParseOptVICO
--- PASS: TestParseOptVICO (0.00s)
=== RUN   TestParseOption
--- PASS: TestParseOption (0.00s)
=== RUN   TestOptionToBytes
--- PASS: TestOptionToBytes (0.00s)
=== RUN   TestOptionString
--- PASS: TestOptionString (0.00s)
=== RUN   TestOptionStringUnknown
--- PASS: TestOptionStringUnknown (0.00s)
=== RUN   TestOptionsMarshal
=== RUN   TestOptionsMarshal/Test_00
=== RUN   TestOptionsMarshal/Test_01
=== RUN   TestOptionsMarshal/Test_02
=== RUN   TestOptionsMarshal/Test_03
--- PASS: TestOptionsMarshal (0.00s)
    --- PASS: TestOptionsMarshal/Test_00 (0.00s)
    --- PASS: TestOptionsMarshal/Test_01 (0.00s)
    --- PASS: TestOptionsMarshal/Test_02 (0.00s)
    --- PASS: TestOptionsMarshal/Test_03 (0.00s)
=== RUN   TestOptionsUnmarshal
=== RUN   TestOptionsUnmarshal/Test_00
=== RUN   TestOptionsUnmarshal/Test_01
=== RUN   TestOptionsUnmarshal/Test_02
=== RUN   TestOptionsUnmarshal/Test_03
=== RUN   TestOptionsUnmarshal/Test_04
=== RUN   TestOptionsUnmarshal/Test_05
=== RUN   TestOptionsUnmarshal/Test_06
=== RUN   TestOptionsUnmarshal/Test_07
=== RUN   TestOptionsUnmarshal/Test_08
--- PASS: TestOptionsUnmarshal (0.00s)
    --- PASS: TestOptionsUnmarshal/Test_00 (0.00s)
    --- PASS: TestOptionsUnmarshal/Test_01 (0.00s)
    --- PASS: TestOptionsUnmarshal/Test_02 (0.00s)
    --- PASS: TestOptionsUnmarshal/Test_03 (0.00s)
    --- PASS: TestOptionsUnmarshal/Test_04 (0.00s)
    --- PASS: TestOptionsUnmarshal/Test_05 (0.00s)
    --- PASS: TestOptionsUnmarshal/Test_06 (0.00s)
    --- PASS: TestOptionsUnmarshal/Test_07 (0.00s)
    --- PASS: TestOptionsUnmarshal/Test_08 (0.00s)
PASS
ok      github.com/akshaynawale/dhcp/dhcpv4     0.008s
```