### PR TITLE
Use cancellable crypto RNG from u-root

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -17,7 +17,6 @@ package dhcpv4
 
 import (
 	"bytes"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"net"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/insomniacslk/dhcp/iana"
 	"github.com/insomniacslk/dhcp/rfc1035label"
+	"github.com/u-root/u-root/pkg/rand"
 	"github.com/u-root/u-root/pkg/uio"
 )
 

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -1,16 +1,15 @@
 package dhcpv6
 
 import (
-	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"net"
 	"testing"
 
+	"github.com/insomniacslk/dhcp/iana"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/u-root/u-root/pkg/rand"
 )
 
 func randomReadMock(value []byte, n int, err error) func([]byte) (int, error) {

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -1,13 +1,13 @@
 package dhcpv6
 
 import (
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"net"
 	"time"
 
 	"github.com/insomniacslk/dhcp/iana"
+	"github.com/u-root/u-root/pkg/rand"
 	"github.com/u-root/u-root/pkg/uio"
 )
 


### PR DESCRIPTION
Fixes #246

On QEmu:
* without VirtIO RNG it hangs, `sudo qemu-system-x86_64 -M q35 -kernel arch/x86/boot/bzImage -enable-kvm -nographic`
* with VirtIO RNG it cancels the request, `sudo qemu-system-x86_64 -M q35 -kernel arch/x86/boot/bzImage -enable-kvm -nographic -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0`

Signed-off-by: Andrea Barberio <insomniac@slackware.it>