### PR TITLE
nclient6: small fixes

### DIFF
--- a/dhcpv6/nclient6/client_test.go
+++ b/dhcpv6/nclient6/client_test.go
@@ -55,9 +55,9 @@ func serveAndClient(ctx context.Context, responses [][]*dhcpv6.Message, opt ...C
 		panic(err)
 	}
 
-	o := []ClientOpt{WithConn(clientRawConn), WithRetry(1), WithTimeout(2 * time.Second)}
+	o := []ClientOpt{WithRetry(1), WithTimeout(2 * time.Second)}
 	o = append(o, opt...)
-	mc, err := New(net.HardwareAddr{0xa, 0xb, 0xc, 0xd, 0xe, 0xf}, o...)
+	mc, err := NewWithConn(clientRawConn, net.HardwareAddr{0xa, 0xb, 0xc, 0xd, 0xe, 0xf}, o...)
 	if err != nil {
 		panic(err)
 	}

--- a/dhcpv6/server6/server_test.go
+++ b/dhcpv6/server6/server_test.go
@@ -12,15 +12,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type fakeUnconnectedConn struct {
+// Turns a connected UDP conn into an "unconnected" UDP conn.
+type unconnectedConn struct {
 	*net.UDPConn
 }
 
-func (f fakeUnconnectedConn) WriteTo(b []byte, _ net.Addr) (int, error) {
+func (f unconnectedConn) WriteTo(b []byte, _ net.Addr) (int, error) {
 	return f.UDPConn.Write(b)
 }
 
-func (f fakeUnconnectedConn) ReadFrom(b []byte) (int, net.Addr, error) {
+func (f unconnectedConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	n, err := f.Read(b)
 	return n, nil, err
 }
@@ -43,12 +44,10 @@ func setUpClientAndServer(handler Handler) (*nclient6.Client, *Server) {
 		panic(err)
 	}
 
-	c, err := nclient6.New(net.HardwareAddr{1, 2, 3, 4, 5, 6},
-		nclient6.WithConn(fakeUnconnectedConn{clientConn}))
+	c, err := nclient6.NewWithConn(unconnectedConn{clientConn}, net.HardwareAddr{1, 2, 3, 4, 5, 6})
 	if err != nil {
 		panic(err)
 	}
-
 	return c, s
 }
 


### PR DESCRIPTION
- RapidCommit solicits wait for Reply messages, not Advertise.
- Default recipient should be all relay agents and servers, not just
  servers.
- Make New() and NewWithConn() interface same as in nclient4.