### PR TITLE
[server] Serve returns an error, and closes when done

### DIFF
--- a/dhcpv6/server6/server.go
+++ b/dhcpv6/server6/server.go
@@ -1,5 +1,58 @@
 package server6
 
+/*
+  To use the DHCPv6 server code you have to call NewServer with two arguments:
+  - an address to listen on, and
+  - a handler function, that will be called every time a valid DHCPv6 packet is
+    received.
+
+  The address to listen on is used to know IP address, port and optionally the
+  scope to create and UDP socket to listen on for DHCPv6 traffic.
+
+  The handler is a function that takes as input a packet connection, that can be
+  used to reply to the client; a peer address, that identifies the client sending
+  the request, and the DHCPv6 packet itself. Just implement your custom logic in
+  the handler.
+
+  Optionally, NewServer can receive options that will modify the server object.
+  Some options already exist, for example WithConn. If this option is passed with
+  a valid connection, the listening address argument is ignored.
+
+  Example program:
+
+
+package main
+
+import (
+	"log"
+	"net"
+
+	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/insomniacslk/dhcp/dhcpv6/server6"
+)
+
+func handler(conn net.PacketConn, peer net.Addr, m dhcpv6.DHCPv6) {
+	// this function will just print the received DHCPv6 message, without replying
+	log.Print(m.Summary())
+}
+
+func main() {
+	laddr := net.UDPAddr{
+		IP:   net.ParseIP("::1"),
+		Port: 547,
+	}
+	server, err := server6.NewServer(&laddr, handler)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// This never returns. If you want to do other stuff, dump it into a
+	// goroutine.
+	server.Serve()
+}
+
+*/
+
 import (
 	"log"
 	"net"
@@ -19,16 +72,17 @@ type Server struct {
 
 // Serve starts the DHCPv6 server. The listener will run in background, and can
 // be interrupted with `Server.Close`.
-func (s *Server) Serve() {
+func (s *Server) Serve() error {
 	log.Printf("Server listening on %s", s.conn.LocalAddr())
 	log.Print("Ready to handle requests")
 
+	defer s.Close()
 	for {
 		rbuf := make([]byte, 4096) // FIXME this is bad
 		n, peer, err := s.conn.ReadFrom(rbuf)
 		if err != nil {
 			log.Printf("Error reading from packet conn: %v", err)
-			return
+			return err
 		}
 		log.Printf("Handling request from %v", peer)
 


### PR DESCRIPTION
Server6 and Server4 had Serve methods that return without reporting an
error, changed in this PR.
Serve now also closes the connection when done.


~~The Server6.Close and Server4.Close methods now also check for nil conn.~~

~~Doing this safely requires an RWLock around `conn`, and doesn't guarantee that the handler will properly lock around using `conn`. I am open to suggestions.~~ EDIT: will reconsider for another PR

Signed-off-by: Andrea Barberio <insomniac@slackware.it>