### PR TITLE
[dhcpv6] Solicit messages derive default IAID from MAC address

### DIFF
--- a/dhcpv6/async/client_test.go
+++ b/dhcpv6/async/client_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/insomniacslk/dhcp/dhcpv6"
 	"github.com/insomniacslk/dhcp/dhcpv6/client6"
-	"github.com/insomniacslk/dhcp/iana"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,13 +19,7 @@ func solicit(input string) (*dhcpv6.Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	duid := dhcpv6.Duid{
-		Type:          dhcpv6.DUID_LLT,
-		HwType:        iana.HWTypeEthernet,
-		Time:          dhcpv6.GetTime(),
-		LinkLayerAddr: mac,
-	}
-	return dhcpv6.NewSolicitWithCID(duid)
+	return dhcpv6.NewSolicit(mac)
 }
 
 // server creates a server which responds with a predefined response

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -197,7 +197,7 @@ func TestNewReplyFromMessage(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestNewMessageTypeSolicitWithCID(t *testing.T) {
+func TestNewMessageTypeSolicit(t *testing.T) {
 	hwAddr, err := net.ParseMAC("24:0A:9E:9F:EB:2B")
 	require.NoError(t, err)
 
@@ -207,7 +207,7 @@ func TestNewMessageTypeSolicitWithCID(t *testing.T) {
 		LinkLayerAddr: hwAddr,
 	}
 
-	s, err := NewSolicitWithCID(duid)
+	s, err := NewSolicit(hwAddr, WithClientID(duid))
 	require.NoError(t, err)
 
 	require.Equal(t, s.Type(), MessageTypeSolicit)
@@ -227,6 +227,14 @@ func TestNewMessageTypeSolicitWithCID(t *testing.T) {
 	require.Contains(t, opts, OptionDNSRecursiveNameServer)
 	require.Contains(t, opts, OptionDomainSearchList)
 	require.Equal(t, len(opts), 2)
+
+	// Check IA_NA
+	iaid := [4]byte{hwAddr[2], hwAddr[3], hwAddr[4], hwAddr[5]}
+	iaNaOption := s.GetOneOption(OptionIANA)
+	require.NotNil(t, iaNaOption)
+	iaNa, ok := iaNaOption.(*OptIANA)
+	require.True(t, ok)
+	require.Equal(t, iaid, iaNa.IaId)
 }
 
 func TestIsUsingUEFIArchTypeTrue(t *testing.T) {

--- a/dhcpv6/modifiers.go
+++ b/dhcpv6/modifiers.go
@@ -77,6 +77,21 @@ func WithIANA(addrs ...OptIAAddress) Modifier {
 	}
 }
 
+// WithIAID updates an OptIANA option with the provided IAID
+func WithIAID(iaid [4]byte) Modifier {
+	return func(d DHCPv6) {
+		opt := d.GetOneOption(OptionIANA)
+		if opt == nil {
+			opt = &OptIANA{
+				Options: Options{},
+			}
+		}
+		iaNa := opt.(*OptIANA)
+		copy(iaNa.IaId[:], iaid[:])
+		d.UpdateOption(iaNa)
+	}
+}
+
 // WithDNS adds or updates an OptDNSRecursiveNameServer
 func WithDNS(dnses ...net.IP) Modifier {
 	return func(d DHCPv6) {

--- a/netboot/netconf_test.go
+++ b/netboot/netconf_test.go
@@ -7,27 +7,20 @@ import (
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/insomniacslk/dhcp/iana"
 	"github.com/stretchr/testify/require"
 )
 
-func getAdv(modifiers ...dhcpv6.Modifier) *dhcpv6.Message {
+func getAdv(advModifiers ...dhcpv6.Modifier) *dhcpv6.Message {
 	hwaddr, err := net.ParseMAC("aa:bb:cc:dd:ee:ff")
 	if err != nil {
 		log.Panic(err)
 	}
 
-	duid := dhcpv6.Duid{
-		Type:          dhcpv6.DUID_LLT,
-		HwType:        iana.HWTypeEthernet,
-		Time:          dhcpv6.GetTime(),
-		LinkLayerAddr: hwaddr,
-	}
-	sol, err := dhcpv6.NewSolicitWithCID(duid, modifiers...)
+	sol, err := dhcpv6.NewSolicit(hwaddr)
 	if err != nil {
 		log.Panic(err)
 	}
-	d, err := dhcpv6.NewAdvertiseFromSolicit(sol, modifiers...)
+	d, err := dhcpv6.NewAdvertiseFromSolicit(sol, advModifiers...)
 	if err != nil {
 		log.Panic(err)
 	}


### PR DESCRIPTION
IAID must be set by the client. This patch generates the IAID from the
MAC address of the interface. To do so, a new WithIAID modifier is
added, the interface of NewSolicitWithCID now requires a hwaddr
parameter, and NewAdvertiseFromSolicit copies the IA_NA option from the
solicit if present.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>