### PR TITLE
[server6] Server should join multicast address

### DIFF
--- a/dhcpv6/async/client.go
+++ b/dhcpv6/async/client.go
@@ -197,7 +197,7 @@ func (c *Client) receive(_ dhcpv6.DHCPv6) {
 
 func (c *Client) remoteAddr() (*net.UDPAddr, error) {
 	if c.RemoteAddr == nil {
-		return &net.UDPAddr{IP: client6.AllDHCPRelayAgentsAndServers, Port: dhcpv6.DefaultServerPort}, nil
+		return &net.UDPAddr{IP: dhcpv6.AllDHCPRelayAgentsAndServers, Port: dhcpv6.DefaultServerPort}, nil
 	}
 
 	if addr, ok := c.RemoteAddr.(*net.UDPAddr); ok {

--- a/dhcpv6/client6/client.go
+++ b/dhcpv6/client6/client.go
@@ -17,12 +17,6 @@ const (
 	MaxUDPReceivedPacketSize  = 8192            // arbitrary size. Theoretically could be up to 65kb
 )
 
-// Broadcast destination IP addresses as defined by RFC 3315
-var (
-	AllDHCPRelayAgentsAndServers = net.ParseIP("ff02::1:2")
-	AllDHCPServers               = net.ParseIP("ff05::1:3")
-)
-
 // Client implements a DHCPv6 client
 type Client struct {
 	ReadTimeout   time.Duration
@@ -119,7 +113,7 @@ func (c *Client) sendReceive(ifname string, packet dhcpv6.DHCPv6, expectedType d
 	// if no RemoteAddr is specified, use AllDHCPRelayAgentsAndServers
 	var raddr net.UDPAddr
 	if c.RemoteAddr == nil {
-		raddr = net.UDPAddr{IP: AllDHCPRelayAgentsAndServers, Port: dhcpv6.DefaultServerPort}
+		raddr = net.UDPAddr{IP: dhcpv6.AllDHCPRelayAgentsAndServers, Port: dhcpv6.DefaultServerPort}
 	} else {
 		if addr, ok := c.RemoteAddr.(*net.UDPAddr); ok {
 			raddr = *addr

--- a/dhcpv6/defaults.go
+++ b/dhcpv6/defaults.go
@@ -1,6 +1,15 @@
 package dhcpv6
 
+import "net"
+
+// Default ports
 const (
 	DefaultClientPort = 546
 	DefaultServerPort = 547
+)
+
+// Default multicast groups
+var (
+	AllDHCPRelayAgentsAndServers = net.ParseIP("ff02::1:2")
+	AllDHCPServers               = net.ParseIP("ff05::1:3")
 )

--- a/dhcpv6/nclient6/client_test.go
+++ b/dhcpv6/nclient6/client_test.go
@@ -65,7 +65,7 @@ func serveAndClient(ctx context.Context, responses [][]*dhcpv6.Message, opt ...C
 	h := &handler{
 		responses: responses,
 	}
-	s, err := server6.NewServer(nil, h.handle, server6.WithConn(serverRawConn))
+	s, err := server6.NewServer("", nil, h.handle, server6.WithConn(serverRawConn))
 	if err != nil {
 		panic(err)
 	}

--- a/dhcpv6/server6/server_test.go
+++ b/dhcpv6/server6/server_test.go
@@ -33,7 +33,7 @@ func setUpClientAndServer(handler Handler) (*nclient6.Client, *Server) {
 		IP:   net.ParseIP("::1"),
 		Port: 0,
 	}
-	s, err := NewServer(laddr, handler)
+	s, err := NewServer("lo", laddr, handler)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/server6/main.go
+++ b/examples/server6/main.go
@@ -18,7 +18,7 @@ func main() {
 		IP:   net.ParseIP("::1"),
 		Port: dhcpv6.DefaultServerPort,
 	}
-	server, err := server6.NewServer(laddr, handler)
+	server, err := server6.NewServer("", laddr, handler)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The previous logic was wrong - there's no "listening" on multicast
address, the server should listen on the given address, and join the
multicast group. This PR fixes it.
Also moved the multicast addresses to a common package.

Tested with unit/integ tests, and with coredhcp.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>