### PR TITLE
switch from u-root/pkg/rand to crypto/rand

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -17,6 +17,7 @@ package dhcpv4
 
 import (
 	"bytes"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"net"
@@ -25,7 +26,6 @@ import (
 
 	"github.com/insomniacslk/dhcp/iana"
 	"github.com/insomniacslk/dhcp/rfc1035label"
-	"github.com/u-root/u-root/pkg/rand"
 	"github.com/u-root/u-root/pkg/uio"
 )
 

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -1,6 +1,7 @@
 package dhcpv6
 
 import (
+	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"net"
@@ -9,7 +10,6 @@ import (
 	"github.com/insomniacslk/dhcp/iana"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/u-root/u-root/pkg/rand"
 )
 
 func randomReadMock(value []byte, n int, err error) func([]byte) (int, error) {

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -1,13 +1,13 @@
 package dhcpv6
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"net"
 	"time"
 
 	"github.com/insomniacslk/dhcp/iana"
-	"github.com/u-root/u-root/pkg/rand"
 	"github.com/u-root/u-root/pkg/uio"
 )
 


### PR DESCRIPTION
As per its documentation, u-root’s rand package implements cancelable reads,
which is not something that this DHCP client uses.

The crypto/rand package has the advantage of using getrandom(2) on platforms
where that is possible, and otherwise behaves exactly like u-root/pkg/rand.

Notably, this commit fixes the build when running with GO111MODULES=on, so it’s
related to issue #123.