### PR TITLE
Adding RemoteID option while creating a Relayed Encapsulated Packet 

### DIFF
--- a/dhcpv6/client6/client.go
+++ b/dhcpv6/client6/client.go
@@ -92,7 +92,7 @@ func (c *Client) sendReceive(ifname string, packet dhcpv6.DHCPv6, expectedType d
 	}
 	if c.SimulateRelay {
 		var err error
-		encapPacket, err = dhcpv6.EncapsulateRelay(packet, dhcpv6.MessageTypeRelayForward, net.IPv6zero, laddr.IP)
+		encapPacket, err := dhcpv6.EncapsulateRelay(packet, dhcpv6.MessageTypeRelayForward, net.IPv6zero, laddr.IP)
 		if err != nil {
 			return nil, err
 		}

--- a/dhcpv6/client6/client.go
+++ b/dhcpv6/client6/client.go
@@ -92,10 +92,15 @@ func (c *Client) sendReceive(ifname string, packet dhcpv6.DHCPv6, expectedType d
 	}
 	if c.SimulateRelay {
 		var err error
-		packet, err = dhcpv6.EncapsulateRelay(packet, dhcpv6.MessageTypeRelayForward, net.IPv6zero, laddr.IP)
+		encapPacket, err = dhcpv6.EncapsulateRelay(packet, dhcpv6.MessageTypeRelayForward, net.IPv6zero, laddr.IP)
 		if err != nil {
 			return nil, err
 		}
+		// Add RemoteID option to ecapsulated Packet 
+		if remOpt := packet.GetOneOption(dhcpv6.OptionRemoteID); remOpt != nil {
+			encapPacket.AddOption(remOpt)
+		}
+		packet = encapPacket
 	}
 	if expectedType == dhcpv6.MessageTypeNone {
 		// infer the expected type from the packet being sent

--- a/dhcpv6/client6/client.go
+++ b/dhcpv6/client6/client.go
@@ -96,7 +96,7 @@ func (c *Client) sendReceive(ifname string, packet dhcpv6.DHCPv6, expectedType d
 		if err != nil {
 			return nil, err
 		}
-		// Add RemoteID option to ecapsulated Packet 
+		// Add RemoteID option to ecapsulated Packet
 		if remOpt := packet.GetOneOption(dhcpv6.OptionRemoteID); remOpt != nil {
 			encapPacket.AddOption(remOpt)
 		}


### PR DESCRIPTION
The dhcpv6 client was not updating the Remote ID option to the outer encapsulated packet, for SimulateRelay Flag. This was causing problems in testing dhcp requests with Remote ID. As Remote ID is set by the Relay Agent so it should be present at the outer encapsulated packet. This change will copy the inner message's Remote ID option if present, to the outer encapsulated message.

Tested by running unit tests. 
```
go test 
2019/05/07 15:58:22 DNS OptDNSRecursiveNameServer{nameservers=[fe80::1 fe80::2]}
PASS
ok      _/home/navale/go/src/github.com/akshaynawale/dhcp/dhcpv6        0.009s
```