### PR TITLE
Improve compatibility with some ipv4 networks.

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -242,6 +242,12 @@ func NewRequestFromOffer(offer *DHCPv4, modifiers ...Modifier) (*DHCPv4, error) 
 		WithClientIP(offer.ClientIPAddr),
 		WithOption(OptRequestedIPAddress(offer.YourIPAddr)),
 		WithOption(OptServerIdentifier(serverIP)),
+		WithRequestedOptions(
+			OptionSubnetMask,
+			OptionRouter,
+			OptionDomainName,
+			OptionDomainNameServer,
+		),
 	)...)
 }
 
@@ -574,14 +580,16 @@ func (d *DHCPv4) RootPath() string {
 //
 // The Bootfile Name option is described by RFC 2132, Section 9.5.
 func (d *DHCPv4) BootFileNameOption() string {
-	return GetString(OptionBootfileName, d.Options)
+	name := GetString(OptionBootfileName, d.Options)
+	return strings.TrimRight(name, "\x00")
 }
 
 // TFTPServerName parses the DHCPv4 TFTP Server Name option if present.
 //
 // The TFTP Server Name option is described by RFC 2132, Section 9.4.
 func (d *DHCPv4) TFTPServerName() string {
-	return GetString(OptionTFTPServerName, d.Options)
+	name := GetString(OptionTFTPServerName, d.Options)
+	return strings.TrimRight(name, "\x00")
 }
 
 // ClassIdentifier parses the DHCPv4 Class Identifier option if present.

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -229,6 +229,12 @@ func TestDHCPv4NewRequestFromOffer(t *testing.T) {
 	require.Equal(t, MessageTypeRequest, req.MessageType())
 	require.False(t, req.IsUnicast())
 	require.True(t, req.IsBroadcast())
+	// Following options are standard in other dhcp clients (isc-dhclient/udhcp) and required
+	// for final ACK to have all info for a proper lease setup (like used in u-root/pkgs/dhclient).
+	require.True(t, req.IsOptionRequested(OptionRouter))
+	require.True(t, req.IsOptionRequested(OptionSubnetMask))
+	require.True(t, req.IsOptionRequested(OptionDomainName))
+	require.True(t, req.IsOptionRequested(OptionDomainNameServer))
 
 	// Unicast request
 	offer.SetUnicast()

--- a/dhcpv4/option_string_test.go
+++ b/dhcpv4/option_string_test.go
@@ -64,6 +64,9 @@ func TestParseOptBootFileName(t *testing.T) {
 
 	m, _ = New()
 	require.Equal(t, "", m.BootFileNameOption())
+
+	m, _ = New(WithGeneric(OptionBootfileName, []byte{'t', 'e', 's', 't', 0}))
+	require.Equal(t, "test", m.BootFileNameOption())
 }
 
 func TestOptTFTPServerName(t *testing.T) {
@@ -79,6 +82,9 @@ func TestParseOptTFTPServerName(t *testing.T) {
 
 	m, _ = New()
 	require.Equal(t, "", m.TFTPServerName())
+
+	m, _ = New(WithGeneric(OptionTFTPServerName, []byte{'t', 'e', 's', 't', 0}))
+	require.Equal(t, "test", m.TFTPServerName())
 }
 
 func TestOptClassIdentifier(t *testing.T) {


### PR DESCRIPTION
- dnsmasq has been seen to null-terminate the bootfile option.
- for the gateway/dns information to be present in final packet,
the Router option should be queried again in request as
in discover (which matches behavior of udhcpc/dhclient).

Tested: pxeboot with u-root on dnsmask/ipv4 client.