### PR TITLE
[dhcpv4] Do not set Gateway IP address on packets sent by clients

### DIFF
--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -256,7 +256,6 @@ func TestNewReplyFromRequest(t *testing.T) {
 	reply, err := NewReplyFromRequest(discover)
 	require.NoError(t, err)
 	require.Equal(t, discover.TransactionID, reply.TransactionID)
-	require.Equal(t, discover.GatewayIPAddr, reply.GatewayIPAddr)
 }
 
 func TestNewReplyFromRequestWithModifier(t *testing.T) {
@@ -267,7 +266,6 @@ func TestNewReplyFromRequestWithModifier(t *testing.T) {
 	reply, err := NewReplyFromRequest(discover, userClass)
 	require.NoError(t, err)
 	require.Equal(t, discover.TransactionID, reply.TransactionID)
-	require.Equal(t, discover.GatewayIPAddr, reply.GatewayIPAddr)
 }
 
 func TestDHCPv4MessageTypeNil(t *testing.T) {

--- a/dhcpv4/modifiers.go
+++ b/dhcpv4/modifiers.go
@@ -49,7 +49,6 @@ func WithReply(request *DHCPv4) Modifier {
 		d.TransactionID = request.TransactionID
 		d.ClientHWAddr = request.ClientHWAddr
 		d.Flags = request.Flags
-		d.GatewayIPAddr = request.GatewayIPAddr
 	}
 }
 


### PR DESCRIPTION
Relays might drop packets coming from clients if they have the Gateway IP set. This modifier is supposed to be used by relays: `WithReply` is used only by clients.