### PR TITLE
NewReplyFromRequest: copy gw ip

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -247,7 +247,10 @@ func NewRequestFromOffer(offer *DHCPv4, modifiers ...Modifier) (*DHCPv4, error) 
 
 // NewReplyFromRequest builds a DHCPv4 reply from a request.
 func NewReplyFromRequest(request *DHCPv4, modifiers ...Modifier) (*DHCPv4, error) {
-	return New(PrependModifiers(modifiers, WithReply(request))...)
+	return New(PrependModifiers(modifiers,
+		WithReply(request),
+		WithGatewayIP(request.GatewayIPAddr),
+	)...)
 }
 
 // FromBytes encodes the DHCPv4 packet into a sequence of bytes, and returns an

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -256,6 +256,7 @@ func TestNewReplyFromRequest(t *testing.T) {
 	reply, err := NewReplyFromRequest(discover)
 	require.NoError(t, err)
 	require.Equal(t, discover.TransactionID, reply.TransactionID)
+	require.Equal(t, discover.GatewayIPAddr, reply.GatewayIPAddr)
 }
 
 func TestNewReplyFromRequestWithModifier(t *testing.T) {

--- a/dhcpv4/modifiers.go
+++ b/dhcpv4/modifiers.go
@@ -36,6 +36,13 @@ func WithServerIP(ip net.IP) Modifier {
 	}
 }
 
+// WithGatewayIP sets the Gateway IP for the DHCPv4 packet.
+func WithGatewayIP(ip net.IP) Modifier {
+	return func(d *DHCPv4) {
+		d.GatewayIPAddr = ip
+	}
+}
+
 // WithReply fills in opcode, hwtype, xid, clienthwaddr, flags, and gateway ip
 // addr from the given packet.
 func WithReply(request *DHCPv4) Modifier {


### PR DESCRIPTION
After PR #287 we no longer copy the gw ip. However that is needed on server replies.