### PR TITLE
Remove SHIFT IN character bytes from Circuit ID

### DIFF
--- a/dhcpv4/ztpv4/parse_circuitid.go
+++ b/dhcpv4/ztpv4/parse_circuitid.go
@@ -51,9 +51,7 @@ func ParseCircuitID(packet *dhcpv4.DHCPv4) (*CircuitID, error) {
 	cid := relayOptions.Options.Get(dhcpv4.AgentCircuitIDSubOption)
 	// Some Vendor like Arista sends SHIFT IN character i.e. 0x000f before circuitid
 	// remove it before matching against regexps.
-	if bytes.HasPrefix(cid, []byte{0x00, 0x0f}) {
-		cid = bytes.TrimPrefix(cid, []byte{0x00, 0x0f}) 
-	}
+	cid = bytes.TrimPrefix(cid, []byte{0x00, 0x0f}) 
 	circuitIdStr := string(cid)
 	if circuitIdStr == "" {
 		return nil, fmt.Errorf("no circuit-id suboption found in dhcpv4 packet")

--- a/dhcpv4/ztpv4/parse_circuitid_test.go
+++ b/dhcpv4/ztpv4/parse_circuitid_test.go
@@ -1,7 +1,6 @@
 package ztpv4
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
@@ -86,7 +85,7 @@ func TestParseCircuitID(t *testing.T) {
 		{name: "Cisco pattern", circuit: []byte("Gi1/10:2020"), want: &CircuitID{Slot: "1", Port: "10", Vlan: "2020"}},
 		{name: "Cisco Nexus pattern", circuit: []byte("Ethernet1/3"), want: &CircuitID{Slot: "1", Port: "3"}},
 		{name: "Juniper Bundle Pattern", circuit: []byte("ae52.0"), want: &CircuitID{Port: "52", SubPort: "0"}},
-		{name: "Arista Vlan pattern 1 with SHIFT IN", circuit: bytes.Join([][]byte{[]byte{0x00, 0x0f}, []byte("Ethernet14:Vlan2001")}, []byte{}), want: &CircuitID{Port: "14", Vlan: "Vlan2001"}},
+		{name: "Arista Vlan pattern 1 with SHIFT IN", circuit: []byte("\x00\x0fEthernet14:Vlan2001"), want: &CircuitID{Port: "14", Vlan: "Vlan2001"}},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {

--- a/dhcpv4/ztpv4/parse_circuitid_test.go
+++ b/dhcpv4/ztpv4/parse_circuitid_test.go
@@ -1,6 +1,7 @@
 package ztpv4
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
@@ -85,6 +86,7 @@ func TestParseCircuitID(t *testing.T) {
 		{name: "Cisco pattern", circuit: []byte("Gi1/10:2020"), want: &CircuitID{Slot: "1", Port: "10", Vlan: "2020"}},
 		{name: "Cisco Nexus pattern", circuit: []byte("Ethernet1/3"), want: &CircuitID{Slot: "1", Port: "3"}},
 		{name: "Juniper Bundle Pattern", circuit: []byte("ae52.0"), want: &CircuitID{Port: "52", SubPort: "0"}},
+		{name: "Arista Vlan pattern 1 with SHIFT IN", circuit: bytes.Join([][]byte{[]byte{0x00, 0x0f}, []byte("Ethernet14:Vlan2001")}, []byte{}), want: &CircuitID{Port: "14", Vlan: "Vlan2001"}},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Some Vendors like Arista sends SHIFT IN (0x000f) prefix to the circuit id. This used to fail the circuit id parsing logic. This check will remove the 0x000f bytes prefix from the circuit id field if present. 
Added unit test for the same.
Signed-off-by: Akshay Navale <navale@fb.com>

```
go test
PASS
ok      _/home/navale/go/src/github.com/akshaynawale/dhcp/dhcpv4/ztpv4  0.004s
```
