### PR TITLE
Adding Juniper EX pattern for circuit parsing

### DIFF
--- a/dhcpv4/ztpv4/parse_circuitid.go
+++ b/dhcpv4/ztpv4/parse_circuitid.go
@@ -22,6 +22,8 @@ var circuitRegexs = []*regexp.Regexp{
 	regexp.MustCompile("^et-(?P<slot>[0-9]+)/(?P<mod>[0-9]+)/(?P<port>[0-9]+):(?P<subport>[0-9]+).*$"),
 	// Juniper PTX et-0/0/0.0
 	regexp.MustCompile("^et-(?P<slot>[0-9]+)/(?P<mod>[0-9]+)/(?P<port>[0-9]+).(?P<subport>[0-9]+)$"),
+	// Juniper EX ge-0/0/0.0
+	regexp.MustCompile("^ge-(?P<slot>[0-9]+)/(?P<mod>[0-9]+)/(?P<port>[0-9]+).(?P<subport>[0-9]+).*"),
 	// Arista Ethernet3/17/1
 	regexp.MustCompile("^Ethernet(?P<slot>[0-9]+)/(?P<mod>[0-9]+)/(?P<port>[0-9]+)$"),
 	// Juniper QFX et-1/0/61

--- a/dhcpv4/ztpv4/parse_circuitid_test.go
+++ b/dhcpv4/ztpv4/parse_circuitid_test.go
@@ -24,6 +24,7 @@ func TestMatchCircuitID(t *testing.T) {
 		{name: "Cisco pattern", circuit: "Gi1/10:2020", want: &CircuitID{Slot: "1", Port: "10", Vlan: "2020"}},
 		{name: "Cisco Nexus pattern", circuit: "Ethernet1/3", want: &CircuitID{Slot: "1", Port: "3"}},
 		{name: "Juniper Bundle Pattern", circuit: "ae52.0", want: &CircuitID{Port: "52", SubPort: "0"}},
+		{name: "Juniper EX device pattern", circuit: "ge-0/0/0.0:RANDOMCHAR", want: &CircuitID{Slot: "0", Module: "0", Port: "0", SubPort: "0"}},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
@@ -86,6 +87,7 @@ func TestParseCircuitID(t *testing.T) {
 		{name: "Cisco Nexus pattern", circuit: []byte("Ethernet1/3"), want: &CircuitID{Slot: "1", Port: "3"}},
 		{name: "Juniper Bundle Pattern", circuit: []byte("ae52.0"), want: &CircuitID{Port: "52", SubPort: "0"}},
 		{name: "Arista Vlan pattern 1 with SHIFT IN", circuit: []byte("\x00\x0fEthernet14:Vlan2001"), want: &CircuitID{Port: "14", Vlan: "Vlan2001"}},
+		{name: "juniperEX pattern", circuit: []byte("ge-0/0/0.0:RANDOMCHAR"), want: &CircuitID{Slot: "0", Module: "0", Port: "0", SubPort: "0"}},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This change will allow us to parse Juniper EX series interface pattern. 
Adding the regex and unit test for the same.
Tested with unit tests.
```
go test
PASS
ok      _/home/navale/go/src/github.com/akshaynawale/dhcp/dhcpv4/ztpv4  0.004s
```

Signed-off-by: Akshay Navale <navale@fb.com>