### PR TITLE
Changing Arista CircuitID regex for prepended type and length field

### DIFF
--- a/dhcpv4/ztpv4/parse_circuitid_test.go
+++ b/dhcpv4/ztpv4/parse_circuitid_test.go
@@ -86,7 +86,7 @@ func TestParseCircuitID(t *testing.T) {
 		{name: "Cisco pattern", circuit: []byte("Gi1/10:2020"), want: &CircuitID{Slot: "1", Port: "10", Vlan: "2020"}},
 		{name: "Cisco Nexus pattern", circuit: []byte("Ethernet1/3"), want: &CircuitID{Slot: "1", Port: "3"}},
 		{name: "Juniper Bundle Pattern", circuit: []byte("ae52.0"), want: &CircuitID{Port: "52", SubPort: "0"}},
-		{name: "Arista Vlan pattern 1 with SHIFT IN", circuit: []byte("\x00\x0fEthernet14:Vlan2001"), want: &CircuitID{Port: "14", Vlan: "Vlan2001"}},
+		{name: "Arista Vlan pattern 1 with circuitid type and length", circuit: []byte("\x00\x0fEthernet14:2001"), want: &CircuitID{Port: "14", Vlan: "2001"}},
 		{name: "juniperEX pattern", circuit: []byte("ge-0/0/0.0:RANDOMCHAR"), want: &CircuitID{Slot: "0", Module: "0", Port: "0", SubPort: "0"}},
 	}
 	for _, tc := range tt {


### PR DESCRIPTION
Sometimes Arista devices send CircuitID type (1byte) and Circuit ID Length (1 byte) in Relay Agent Option 82's Suboption 1 field's value. Therefore, changing Arista regex to not match with starts with "^" character to consider this.  (Earlier I thought the prepended bytes are just random characters, Arista devices are sending, and added a check to remove 0x00 0x0F. Removing that in this pull request too.)

tested with unit tests (modified unit tests accordingly.)
```
go test
PASS                                                                          
ok      _/home/navale/go/src/github.com/akshaynawale/dhcp/dhcpv4/ztpv4  0.004s
```

Signed-off-by: Akshay Navale <navale@fb.com>