### PR TITLE
v4 discover: don't ask for broadcast

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -175,7 +175,6 @@ func NewDiscoveryForInterface(ifname string, modifiers ...Modifier) (*DHCPv4, er
 // HW type and specified hardware address.
 func NewDiscovery(hwaddr net.HardwareAddr, modifiers ...Modifier) (*DHCPv4, error) {
 	return New(PrependModifiers(modifiers,
-		WithBroadcast(true),
 		WithHwAddr(hwaddr),
 		WithRequestedOptions(
 			OptionSubnetMask,

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -291,7 +291,6 @@ func TestNewDiscovery(t *testing.T) {
 	require.Equal(t, OpcodeBootRequest, m.OpCode)
 	require.Equal(t, iana.HWTypeEthernet, m.HWType)
 	require.Equal(t, hwAddr, m.ClientHWAddr)
-	require.True(t, m.IsBroadcast())
 	require.True(t, m.Options.Has(OptionParameterRequestList))
 }
 


### PR DESCRIPTION
Usually this is used for clients that don't know how to receive any
other packets. We can deal with both a unicast or broadcast response
packet, so let's let the server decide on its own.

Signed-off-by: Chris Koch <chrisko@google.com>