### PR TITLE
server4: set peer to broadcast if client IP is zero

### DIFF
--- a/dhcpv4/nclient4/client_test.go
+++ b/dhcpv4/nclient4/client_test.go
@@ -50,7 +50,7 @@ func serveAndClient(ctx context.Context, responses [][]*dhcpv4.DHCPv4, opts ...C
 		panic(err)
 	}
 
-	clientConn := NewBroadcastUDPConn(clientRawConn, &net.UDPAddr{IP: net.IPv4zero, Port: ClientPort})
+	clientConn := NewBroadcastUDPConn(clientRawConn, &net.UDPAddr{Port: ClientPort})
 	serverConn := NewBroadcastUDPConn(serverRawConn, &net.UDPAddr{Port: ServerPort})
 
 	o := []ClientOpt{WithRetry(1), WithTimeout(2 * time.Second)}

--- a/dhcpv4/server4/server.go
+++ b/dhcpv4/server4/server.go
@@ -90,11 +90,24 @@ func (s *Server) Serve() error {
 			log.Printf("Error parsing DHCPv4 request: %v", err)
 			continue
 		}
-		go s.Handler(s.conn, peer, m)
+
+		upeer, ok := peer.(*net.UDPAddr)
+		if !ok {
+			log.Printf("Not a UDP connection? Peer is %s", peer)
+			continue
+		}
+		// Set peer to broadcast if the client did not have an IP.
+		if upeer.IP == nil || upeer.IP.Equal(net.IPv4zero) {
+			upeer = &net.UDPAddr{
+				IP:   net.IPv4bcast,
+				Port: upeer.Port,
+			}
+		}
+		go s.Handler(s.conn, upeer, m)
 	}
 }
 
-// Close sends a termination request to the server, and closes the UDP listener
+// Close sends a termination request to the server, and closes the UDP listener.
 func (s *Server) Close() error {
 	return s.conn.Close()
 }


### PR DESCRIPTION
Clients without an IP set their source address to 0.0.0.0, so the peer
returned by ReadFrom may not actually be the address to send to.

Clients without an IP should have their response broadcast.

Signed-off-by: Chris Koch <chrisko@google.com>