### PR TITLE
server4: make conn public

### DIFF
--- a/dhcpv4/server4/server.go
+++ b/dhcpv4/server4/server.go
@@ -66,19 +66,19 @@ type Handler func(conn net.PacketConn, peer net.Addr, m *dhcpv4.DHCPv4)
 
 // Server represents a DHCPv4 server object
 type Server struct {
-	conn    net.PacketConn
+	Conn    net.PacketConn
 	Handler Handler
 }
 
 // Serve serves requests.
 func (s *Server) Serve() error {
-	log.Printf("Server listening on %s", s.conn.LocalAddr())
+	log.Printf("Server listening on %s", s.Conn.LocalAddr())
 	log.Print("Ready to handle requests")
 
 	defer s.Close()
 	for {
 		rbuf := make([]byte, 4096) // FIXME this is bad
-		n, peer, err := s.conn.ReadFrom(rbuf)
+		n, peer, err := s.Conn.ReadFrom(rbuf)
 		if err != nil {
 			log.Printf("Error reading from packet conn: %v", err)
 			return err
@@ -103,13 +103,13 @@ func (s *Server) Serve() error {
 				Port: upeer.Port,
 			}
 		}
-		go s.Handler(s.conn, upeer, m)
+		go s.Handler(s.Conn, upeer, m)
 	}
 }
 
 // Close sends a termination request to the server, and closes the UDP listener.
 func (s *Server) Close() error {
-	return s.conn.Close()
+	return s.Conn.Close()
 }
 
 // ServerOpt adds optional configuration to a server.
@@ -118,7 +118,7 @@ type ServerOpt func(s *Server)
 // WithConn configures the server with the given connection.
 func WithConn(c net.PacketConn) ServerOpt {
 	return func(s *Server) {
-		s.conn = c
+		s.Conn = c
 	}
 }
 

--- a/dhcpv4/server4/server.go
+++ b/dhcpv4/server4/server.go
@@ -131,13 +131,13 @@ func NewServer(ifname string, addr *net.UDPAddr, handler Handler, opt ...ServerO
 	for _, o := range opt {
 		o(s)
 	}
-	if s.conn == nil {
+	if s.Conn == nil {
 		var err error
 		conn, err := NewIPv4UDPConn(ifname, addr.Port)
 		if err != nil {
 			return nil, err
 		}
-		s.conn = conn
+		s.Conn = conn
 	}
 	return s, nil
 }


### PR DESCRIPTION
Use case: When writing a DHCP relay we create 2 `dhcpv4.Server`s. One for communicating with downstream clients and one for communicating with upstream servers. Each one binds to a different interface. In this diff we expose the connection so the opposite handler could reach the opposite bound interface.