### PR TITLE
dhcpv4: Mark all options as requested absent ParameterRequestList

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -430,7 +430,20 @@ func (d *DHCPv4) Summary() string {
 // IsOptionRequested returns true if that option is within the requested
 // options of the DHCPv4 message.
 func (d *DHCPv4) IsOptionRequested(requested OptionCode) bool {
-	for _, o := range d.ParameterRequestList() {
+	rq := d.ParameterRequestList()
+	if rq == nil {
+		// RFC2131§3.5
+		// Not all clients require initialization of all parameters [...]
+		// Two techniques are used to reduce the number of parameters transmitted from
+		// the server to the client. [...] Second, in its initial DHCPDISCOVER or
+		// DHCPREQUEST message, a client may provide the server with a list of specific
+		// parameters the client is interested in.
+		// We interpret this to say that all available parameters should be sent if
+		// the parameter request list is not sent at all.
+		return true
+	}
+
+	for _, o := range rq {
 		if o == requested {
 			return true
 		}

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -310,9 +310,13 @@ func TestNewInform(t *testing.T) {
 func TestIsOptionRequested(t *testing.T) {
 	pkt, err := New()
 	require.NoError(t, err)
+	require.True(t, pkt.IsOptionRequested(OptionDomainNameServer))
+
+	optprl := OptParameterRequestList(OptionRouter, OptionDomainName)
+	pkt.UpdateOption(optprl)
 	require.False(t, pkt.IsOptionRequested(OptionDomainNameServer))
 
-	optprl := OptParameterRequestList(OptionDomainNameServer)
+	optprl = OptParameterRequestList(OptionDomainNameServer)
 	pkt.UpdateOption(optprl)
 	require.True(t, pkt.IsOptionRequested(OptionDomainNameServer))
 }


### PR DESCRIPTION
In DHCPv4, when the ParameterRequestList option is not present in a request, I believe it should be assumed that the client wants to receive all the options that the server is able to send.
This changes the IsOptionRequested method of dhcpv4.DHCPv4 to return true for any request in that situation.

The reasoning is based on this wording in [RFC2131§3.5](https://tools.ietf.org/html/rfc2131#section-3.5):
> Not all clients require initialization of all parameters listed in
> Appendix A. Two techniques are used to reduce the number of
> parameters transmitted from the server to the client. [...] Second, in
> its initial DHCPDISCOVER or DHCPREQUEST message, a client may provide
> the server with a list of specific parameters the client is interested
> in.

Initially raised in https://github.com/coredhcp/coredhcp/pull/54#discussion_r324712528

I've included the reason as a comment inline in the code, which may or may not be a good idea; I can remove it and leave the commit message as only documentation instead if preferred; or move the comment to the official documentation comment for the function