### PR TITLE
server6: allow nil IP in addition to unspecified

### DIFF
--- a/dhcpv6/server6/server.go
+++ b/dhcpv6/server6/server.go
@@ -164,7 +164,7 @@ func NewServer(ifname string, addr *net.UDPAddr, handler Handler, opt ...ServerO
 		if err := p.JoinGroup(iface, addr); err != nil {
 			return nil, err
 		}
-	} else if addr.IP.IsUnspecified() && addr.Port == dhcpv6.DefaultServerPort {
+	} else if (addr.IP == nil || addr.IP.IsUnspecified()) && addr.Port == dhcpv6.DefaultServerPort {
 		// For wildcard addresses on the correct port, listen on both multicast
 		// addresses defined in the RFC as a "default" behaviour
 		for _, g := range []net.IP{dhcpv6.AllDHCPRelayAgentsAndServers, dhcpv6.AllDHCPServers} {


### PR DESCRIPTION
This way, you can use `&net.UDPAddr{Port: 547}` without having to actually put an IP down