### PR TITLE
dhcpv6: Basic fuzzing support and fixes for discovered bugs

### DIFF
--- a/dhcpv6/dhcpv6.go
+++ b/dhcpv6/dhcpv6.go
@@ -46,6 +46,9 @@ func MessageFromBytes(data []byte) (*Message, error) {
 		MessageType: messageType,
 	}
 	buf.ReadBytes(d.TransactionID[:])
+	if buf.Error() != nil {
+		return nil, fmt.Errorf("Error parsing DHCPv6 header: %v", buf.Error())
+	}
 	if err := d.Options.FromBytes(buf.Data()); err != nil {
 		return nil, err
 	}
@@ -68,6 +71,9 @@ func RelayMessageFromBytes(data []byte) (*RelayMessage, error) {
 	d.LinkAddr = net.IP(buf.CopyN(net.IPv6len))
 	d.PeerAddr = net.IP(buf.CopyN(net.IPv6len))
 
+	if buf.Error() != nil {
+		return nil, fmt.Errorf("Error parsing RelayMessage header: %v", buf.Error())
+	}
 	// TODO: fail if no OptRelayMessage is present.
 	if err := d.Options.FromBytes(buf.Data()); err != nil {
 		return nil, err

--- a/dhcpv6/dhcpv6.go
+++ b/dhcpv6/dhcpv6.go
@@ -79,6 +79,9 @@ func RelayMessageFromBytes(data []byte) (*RelayMessage, error) {
 func FromBytes(data []byte) (DHCPv6, error) {
 	buf := uio.NewBigEndianBuffer(data)
 	messageType := MessageType(buf.Read8())
+	if buf.Error() != nil {
+		return nil, buf.Error()
+	}
 
 	if messageType == MessageTypeRelayForward || messageType == MessageTypeRelayReply {
 		return RelayMessageFromBytes(data)

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"net"
+	"strconv"
 	"testing"
 
 	"github.com/insomniacslk/dhcp/iana"
@@ -134,6 +135,19 @@ func TestFromAndToBytes(t *testing.T) {
 	require.NoError(t, err)
 	toBytes := d.ToBytes()
 	require.Equal(t, expected, toBytes)
+}
+
+func TestFromBytesInvalid(t *testing.T) {
+	expected := [][]byte{
+		{},
+	}
+	t.Parallel()
+	for i, packet := range expected {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			_, err := FromBytes(packet)
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestNewAdvertiseFromSolicit(t *testing.T) {

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -130,11 +130,19 @@ func TestToBytes(t *testing.T) {
 }
 
 func TestFromAndToBytes(t *testing.T) {
-	expected := []byte{01, 0xab, 0xcd, 0xef, 0x00, 0x00, 0x00, 0x00}
-	d, err := FromBytes(expected)
-	require.NoError(t, err)
-	toBytes := d.ToBytes()
-	require.Equal(t, expected, toBytes)
+	expected := [][]byte{
+		{01, 0xab, 0xcd, 0xef, 0x00, 0x00, 0x00, 0x00},
+		[]byte("0000\x00\x01\x00\x0e\x00\x01000000000000"),
+	}
+	t.Parallel()
+	for i, packet := range expected {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			d, err := FromBytes(packet)
+			require.NoError(t, err)
+			toBytes := d.ToBytes()
+			require.Equal(t, packet, toBytes)
+		})
+	}
 }
 
 func TestFromBytesInvalid(t *testing.T) {

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -140,6 +140,8 @@ func TestFromAndToBytes(t *testing.T) {
 func TestFromBytesInvalid(t *testing.T) {
 	expected := [][]byte{
 		{},
+		{30},
+		{12},
 	}
 	t.Parallel()
 	for i, packet := range expected {

--- a/dhcpv6/fuzz.go
+++ b/dhcpv6/fuzz.go
@@ -1,0 +1,33 @@
+// +build gofuzz
+
+package dhcpv6
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Fuzz is an entrypoint for go-fuzz (github.com/dvyukov/go-fuzz)
+func Fuzz(data []byte) int {
+	msg, err := FromBytes(data)
+	if err != nil {
+		return 0
+	}
+
+	serialized := msg.ToBytes()
+	if !bytes.Equal(data, serialized) {
+		rtMsg, err := FromBytes(serialized)
+		fmt.Printf("Input:      %x\n", data)
+		fmt.Printf("Round-trip: %x\n", serialized)
+		fmt.Println("Message: ", msg.Summary())
+		fmt.Printf("Go repr: %#v\n", msg)
+		fmt.Println("round-trip reserialized: ", rtMsg.Summary())
+		fmt.Printf("Go repr: %#v\n", rtMsg)
+		if err != nil {
+			fmt.Printf("failed to parse after deserialize-serialize: %v\n", err)
+		}
+		panic("round-trip different")
+	}
+
+	return 1
+}

--- a/iana/hwtypes.go
+++ b/iana/hwtypes.go
@@ -1,7 +1,7 @@
 package iana
 
 // HWType is a hardware type as per RFC 2132 and defined by the IANA.
-type HWType uint8
+type HWType uint16
 
 // See IANA for values.
 const (


### PR DESCRIPTION
Since this library parses sometimes untrusted data, I thought it would be relevant to add fuzzing support to make sure we act reasonably whatever the data.

This adds a fairly simple fuzzing entrypoint for dhcpv6 (I have the same in the pipe for dhcpv4, but it needs a bit more work), which parses a message, then writes it back out, and compares them.
This is fairly limited obviously: 
 * Maybe not all messages don't need to be byte-for-byte identical after being deserialized-serialized, causing some false-positives. This hasn't caused issues yet though
 * It would only catch bugs in messages that come from deserializing, not from messages being crafted using the library

See the page for go-fuzz for usage instructions: https://github.com/dvyukov/go-fuzz; but basically:
```
go get github.com/dvyukov/go-fuzz/go-fuzz{,-build}
cd dhcpv6 && go-fuzz-build
go-fuzz -bin dhcpv6-fuzz.zip /path/to/working/directory
```

It has already caught a couple bugs when run for some time on my desktop without even a source corpus. With an initial corpus built from real traffic and some more processing power I think it could be useful.
If you do not want this support upstream, I can remove this first commit and only submit the bugfixes instead: 

There are 2 bugfixes from missing error checks, causing invalid (truncated) messages to be accepted (empty messages, and 1-byte messages).
There is one bugfix for the iana.HWType encoding: it is declared as 8bits, but both the field in the packet, and the [IANA table](https://www.iana.org/assignments/arp-parameters/arp-parameters.xml#arp-parameters-2) are 16bits; and there exists one value >255 in that table. This changes a type definition, so downstream users may need to apply some changes if they were relying on iana.HWType being 8bits