### PR TITLE
[dhcpv6] Adding opt 16 when parsing vendor data

### DIFF
--- a/dhcpv6/ztpv6/parse_vendor_options.go
+++ b/dhcpv6/ztpv6/parse_vendor_options.go
@@ -16,24 +16,36 @@ type VendorData struct {
 	VendorName, Model, Serial string
 }
 
-// ParseVendorData will try to parse dhcp6 Vendor Specific Information options data
-// looking for more specific vendor data (like model, serial number, etc).
-// If the options are missing we will just return nil
+// ParseVendorData will try to parse dhcp6 Vendor Specific Information options
+// ( 16 and 17) data looking for more specific vendor data (like model, serial
+// number, etc). If the options are missing we will just return nil
 func ParseVendorData(packet dhcpv6.DHCPv6) (*VendorData, error) {
-	opt := packet.GetOneOption(dhcpv6.OptionVendorOpts)
-	if opt == nil {
-		return nil, errors.New("vendor options not found")
+	// check for both options 16 and 17 if both are present will use opt 17
+	opt16 := packet.GetOneOption(dhcpv6.OptionVendorClass)
+	opt17 := packet.GetOneOption(dhcpv6.OptionVendorOpts)
+	if (opt16 == nil) && (opt17 == nil) {
+		return nil, errors.New("no vendor options or vendor class found")
 	}
 
 	vd := VendorData{}
-	vo := opt.(*dhcpv6.OptVendorOpts).VendorOpts
+	vData := []string{}
 
-	for _, opt := range vo {
-		optData := string(opt.(*dhcpv6.OptionGeneric).OptionData)
+	if opt17 != nil {
+		vo := opt17.(*dhcpv6.OptVendorOpts).VendorOpts
+		for _, opt := range vo {
+			vData = append(vData, string(opt.(*dhcpv6.OptionGeneric).OptionData))
+		}
+	} else {
+		data := opt16.(*dhcpv6.OptVendorClass).Data
+		for _, d := range data {
+			vData = append(vData, string(d))
+		}
+	}
+	for _, d := range vData {
 		switch {
 		// Arista;DCS-0000;00.00;ZZZ00000000
-		case strings.HasPrefix(optData, "Arista;"):
-			p := strings.Split(optData, ";")
+		case strings.HasPrefix(d, "Arista;"):
+			p := strings.Split(d, ";")
 			if len(p) < 4 {
 				return nil, errVendorOptionMalformed
 			}
@@ -44,8 +56,8 @@ func ParseVendorData(packet dhcpv6.DHCPv6) (*VendorData, error) {
 			return &vd, nil
 
 		// ZPESystems:NSC:000000000
-		case strings.HasPrefix(optData, "ZPESystems:"):
-			p := strings.Split(optData, ":")
+		case strings.HasPrefix(d, "ZPESystems:"):
+			p := strings.Split(d, ":")
 			if len(p) < 3 {
 				return nil, errVendorOptionMalformed
 			}

--- a/dhcpv6/ztpv6/parse_vendor_options_test.go
+++ b/dhcpv6/ztpv6/parse_vendor_options_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseVendorData(t *testing.T) {
+func TestParseVendorDataWithVendorOpts(t *testing.T) {
 	tt := []struct {
 		name string
 		vc   string
@@ -49,6 +49,52 @@ func TestParseVendorData(t *testing.T) {
 				require.Equal(t, *tc.want, *vd, "comparing vendor option data")
 			} else {
 				require.Equal(t, tc.want, vd, "comparing vendor option data")
+			}
+		})
+	}
+}
+
+func TestParseVendorDataWithVendorClass(t *testing.T) {
+	tt := []struct {
+		name string
+		vc   string
+		want *VendorData
+		fail bool
+	}{
+		{name: "empty", fail: true},
+		{name: "unknownVendor", vc: "VendorX;BFR10K;XX12345", fail: true, want: nil},
+		{name: "truncatedArista", vc: "Arista;1234", fail: true, want: nil},
+		{name: "truncatedZPE", vc: "ZPESystems:1234", fail: true, want: nil},
+		{
+			name: "arista",
+			vc:   "Arista;DCS-7050S-64;01.23;JPE12345678",
+			want: &VendorData{VendorName: "Arista", Model: "DCS-7050S-64", Serial: "JPE12345678"},
+		}, {
+			name: "zpe",
+			vc:   "ZPESystems:NSC:001234567",
+			want: &VendorData{VendorName: "ZPESystems", Model: "NSC", Serial: "001234567"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			packet, err := dhcpv6.NewMessage()
+			if err != nil {
+				t.Fatalf("failed to creat dhcpv6 packet object: %v", err)
+			}
+
+			packet.AddOption(&dhcpv6.OptVendorClass{
+				EnterpriseNumber: 0000, Data: [][]byte{[]byte(tc.vc)}})
+
+			vd, err := ParseVendorData(packet)
+			if err != nil && !tc.fail {
+				t.Errorf("unexpected failure: %v", err)
+			}
+
+			if vd != nil {
+				require.Equal(t, *tc.want, *vd, "comparing vendor class data")
+			} else {
+				require.Equal(t, tc.want, vd, "comparing vendor class data")
 			}
 		})
 	}


### PR DESCRIPTION
Some network vendors (like ZPE) use Opt 16 (VendorClass) instead of Opt17 (VendorOptions) to send vendor data. This change will allow us to consider data in option 16 for such devices for ParseVendorData function. Added new unit tests for this scenario as well. 

Test Results:
```
go test -v                      
=== RUN   TestCircuitID
=== RUN   TestCircuitID/Bogus_string
=== RUN   TestCircuitID/Arista_Port_Vlan_Pattern
=== RUN   TestCircuitID/Arista_Slot_Module_Port_Pattern
--- PASS: TestCircuitID (0.00s)
    --- PASS: TestCircuitID/Bogus_string (0.00s)
    --- PASS: TestCircuitID/Arista_Port_Vlan_Pattern (0.00s)
    --- PASS: TestCircuitID/Arista_Slot_Module_Port_Pattern (0.00s)
=== RUN   TestFormatCircuitID
=== RUN   TestFormatCircuitID/empty
=== RUN   TestFormatCircuitID/Arista_format_Port/Vlan
=== RUN   TestFormatCircuitID/Arista_format_Slot/Module/Port
--- PASS: TestFormatCircuitID (0.00s)
    --- PASS: TestFormatCircuitID/empty (0.00s)
    --- PASS: TestFormatCircuitID/Arista_format_Port/Vlan (0.00s)
    --- PASS: TestFormatCircuitID/Arista_format_Slot/Module/Port (0.00s)
=== RUN   TestParseRemoteID
=== RUN   TestParseRemoteID/Bogus_string
=== RUN   TestParseRemoteID/Arista_Port_Vlan_Pattern
=== RUN   TestParseRemoteID/Arista_Slot_Module_Port_Pattern
--- PASS: TestParseRemoteID (0.00s)
    --- PASS: TestParseRemoteID/Bogus_string (0.00s)
    --- PASS: TestParseRemoteID/Arista_Port_Vlan_Pattern (0.00s)
    --- PASS: TestParseRemoteID/Arista_Slot_Module_Port_Pattern (0.00s)
=== RUN   TestParseVendorDataWithVendorOpts
=== RUN   TestParseVendorDataWithVendorOpts/empty
=== RUN   TestParseVendorDataWithVendorOpts/unknownVendor
=== RUN   TestParseVendorDataWithVendorOpts/truncatedArista
=== RUN   TestParseVendorDataWithVendorOpts/truncatedZPE
=== RUN   TestParseVendorDataWithVendorOpts/arista
=== RUN   TestParseVendorDataWithVendorOpts/zpe
--- PASS: TestParseVendorDataWithVendorOpts (0.00s)
    --- PASS: TestParseVendorDataWithVendorOpts/empty (0.00s)
    --- PASS: TestParseVendorDataWithVendorOpts/unknownVendor (0.00s)
    --- PASS: TestParseVendorDataWithVendorOpts/truncatedArista (0.00s)
    --- PASS: TestParseVendorDataWithVendorOpts/truncatedZPE (0.00s)
    --- PASS: TestParseVendorDataWithVendorOpts/arista (0.00s)
    --- PASS: TestParseVendorDataWithVendorOpts/zpe (0.00s)
=== RUN   TestParseVendorDataWithVendorClass
=== RUN   TestParseVendorDataWithVendorClass/empty
=== RUN   TestParseVendorDataWithVendorClass/unknownVendor
=== RUN   TestParseVendorDataWithVendorClass/truncatedArista
=== RUN   TestParseVendorDataWithVendorClass/truncatedZPE
=== RUN   TestParseVendorDataWithVendorClass/arista
=== RUN   TestParseVendorDataWithVendorClass/zpe
--- PASS: TestParseVendorDataWithVendorClass (0.00s)
    --- PASS: TestParseVendorDataWithVendorClass/empty (0.00s)
    --- PASS: TestParseVendorDataWithVendorClass/unknownVendor (0.00s)
    --- PASS: TestParseVendorDataWithVendorClass/truncatedArista (0.00s)
    --- PASS: TestParseVendorDataWithVendorClass/truncatedZPE (0.00s)
    --- PASS: TestParseVendorDataWithVendorClass/arista (0.00s)
    --- PASS: TestParseVendorDataWithVendorClass/zpe (0.00s)
PASS
ok  	github.com/akshaynawale/dhcp/dhcpv6/ztpv6	0.002s
```