### PR TITLE
Add support for copying relay options

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -262,6 +262,7 @@ func NewReplyFromRequest(request *DHCPv4, modifiers ...Modifier) (*DHCPv4, error
 	return New(PrependModifiers(modifiers,
 		WithReply(request),
 		WithGatewayIP(request.GatewayIPAddr),
+		WithRelayOptions(request),
 	)...)
 }
 

--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -262,7 +262,7 @@ func NewReplyFromRequest(request *DHCPv4, modifiers ...Modifier) (*DHCPv4, error
 	return New(PrependModifiers(modifiers,
 		WithReply(request),
 		WithGatewayIP(request.GatewayIPAddr),
-		WithRelayOptions(request),
+		WithRelayAgentInfo(request),
 	)...)
 }
 

--- a/dhcpv4/modifiers.go
+++ b/dhcpv4/modifiers.go
@@ -43,14 +43,12 @@ func WithGatewayIP(ip net.IP) Modifier {
 	}
 }
 
-//WithRelayOptions copies the relay options from the request to the reply
-func WithRelayOptions(request *DHCPv4) Modifier {
+// WithRelayAgentInfo copies the relay options from the request to the reply.
+func WithRelayAgentInfo(request *DHCPv4) Modifier {
 	return func(d *DHCPv4) {
 		// If request has Relay Agent Info copy it to the reply
-		if request.Options.Has(OptionRelayAgentInformation) {
-			relayopt := request.Options.Get(OptionRelayAgentInformation)
-			opt := OptGeneric(OptionRelayAgentInformation, relayopt)
-			d.Options.Update(opt)
+		if relayOpt := request.RelayAgentInfo(); relayOpt != nil {
+			d.UpdateOption(dhcpv4.Option{Code: dhcpv4.OptionRelayAgentInformation, Value: relayOpt})
 		}
 	}
 }

--- a/dhcpv4/modifiers.go
+++ b/dhcpv4/modifiers.go
@@ -43,6 +43,18 @@ func WithGatewayIP(ip net.IP) Modifier {
 	}
 }
 
+//WithRelayOptions copies the relay options from the request to the reply
+func WithRelayOptions(request *DHCPv4) Modifier {
+	return func(d *DHCPv4) {
+		// If request has Relay Agent Info copy it to the reply
+		if request.Options.Has(OptionRelayAgentInformation) {
+			relayopt := request.Options.Get(OptionRelayAgentInformation)
+			opt := OptGeneric(OptionRelayAgentInformation, relayopt)
+			d.Options.Update(opt)
+		}
+	}
+}
+
 // WithReply fills in opcode, hwtype, xid, clienthwaddr, flags, and gateway ip
 // addr from the given packet.
 func WithReply(request *DHCPv4) Modifier {

--- a/dhcpv4/modifiers.go
+++ b/dhcpv4/modifiers.go
@@ -48,7 +48,7 @@ func WithRelayAgentInfo(request *DHCPv4) Modifier {
 	return func(d *DHCPv4) {
 		// If request has Relay Agent Info copy it to the reply
 		if relayOpt := request.RelayAgentInfo(); relayOpt != nil {
-			d.UpdateOption(dhcpv4.Option{Code: dhcpv4.OptionRelayAgentInformation, Value: relayOpt})
+			d.UpdateOption(Option{Code: OptionRelayAgentInformation, Value: relayOpt})
 		}
 	}
 }

--- a/dhcpv4/modifiers_test.go
+++ b/dhcpv4/modifiers_test.go
@@ -162,3 +162,22 @@ func TestWithRouter(t *testing.T) {
 	ortr := d.Router()
 	require.Equal(t, rtr, ortr[0])
 }
+
+func TestWithRelayAgentInfo(t *testing.T) {
+	req, _ := New(WithGeneric(OptionRelayAgentInformation, []byte{
+		1, 5, 'l', 'i', 'n', 'u', 'x',
+		2, 4, 'b', 'o', 'o', 't',
+	}))
+	req.OpCode = OpcodeBootRequest
+
+	resp, _ := NewReplyFromRequest(req)
+
+	opt := resp.RelayAgentInfo()
+	require.NotNil(t, opt)
+	require.Equal(t, len(opt.Options), 2)
+
+	circuit := opt.Get(GenericOptionCode(1))
+	remote := opt.Get(GenericOptionCode(2))
+	require.Equal(t, circuit, []byte("linux"))
+	require.Equal(t, remote, []byte("boot"))
+}


### PR DESCRIPTION
Here is an initial PR for adding support to copy relay options if they exist in a request to dhcpv4.NewReplyFromRequest.  RFC3046 section 2.2 specifies "DHCP servers claiming to support the Relay Agent Information option SHALL echo the entire contents of the Relay Agent Information option
 in all replies." so I think it is safe to add to the NewReplyFromRequest function.

Perhaps the new function should be name CopyRelayOptions instead of WithRelayOptions? 