### PR TITLE
Proposed removal of some logging from Serve() function

### DIFF
--- a/dhcpv4/server4/server.go
+++ b/dhcpv4/server4/server.go
@@ -72,18 +72,13 @@ type Server struct {
 
 // Serve serves requests.
 func (s *Server) Serve() error {
-	log.Printf("Server listening on %s", s.conn.LocalAddr())
-	log.Print("Ready to handle requests")
-
 	defer s.Close()
 	for {
 		rbuf := make([]byte, 4096) // FIXME this is bad
 		n, peer, err := s.conn.ReadFrom(rbuf)
 		if err != nil {
-			log.Printf("Error reading from packet conn: %v", err)
 			return err
 		}
-		log.Printf("Handling request from %v", peer)
 
 		m, err := dhcpv4.FromBytes(rbuf[:n])
 		if err != nil {


### PR DESCRIPTION
I propose that the stdout logging at startup, before error return, and on each connection should be removed from the Serve() function.  Since it is a library logging does not seem appropriate in those areas.  I left the logging in the two areas that continue instead of error return for discussion on whether it would be appropriate to remove those and just silently drop packets/connections with errors.