### PR TITLE
v6: introduce RelayOptions and getters

### DIFF
--- a/dhcpv6/dhcpv6relay.go
+++ b/dhcpv6/dhcpv6relay.go
@@ -42,6 +42,18 @@ func (ro RelayOptions) InterfaceID() []byte {
 	return nil
 }
 
+// RemoteID returns the remote ID in this relay message.
+func (ro RelayOptions) RemoteID() *OptRemoteID {
+	opt := ro.Options.GetOne(OptionRemoteID)
+	if opt == nil {
+		return nil
+	}
+	if rid, ok := opt.(*OptRemoteID); ok {
+		return rid
+	}
+	return nil
+}
+
 // RelayMessage is a DHCPv6 relay agent message as defined by RFC 3315 Section
 // 7.
 type RelayMessage struct {

--- a/dhcpv6/dhcpv6relay.go
+++ b/dhcpv6/dhcpv6relay.go
@@ -30,6 +30,18 @@ func (ro RelayOptions) RelayMessage() DHCPv6 {
 	return nil
 }
 
+// InterfaceID returns the interface ID of this relay message.
+func (ro RelayOptions) InterfaceID() []byte {
+	opt := ro.Options.GetOne(OptionInterfaceID)
+	if opt == nil {
+		return nil
+	}
+	if iid, ok := opt.(*optInterfaceID); ok {
+		return iid.ID
+	}
+	return nil
+}
+
 // RelayMessage is a DHCPv6 relay agent message as defined by RFC 3315 Section
 // 7.
 type RelayMessage struct {

--- a/dhcpv6/dhcpv6relay.go
+++ b/dhcpv6/dhcpv6relay.go
@@ -10,6 +10,26 @@ import (
 
 const RelayHeaderSize = 34
 
+// RelayOptions are the options valid for RelayForw and RelayRepl messages.
+//
+// RFC 3315 Appendix B defines them to be InterfaceID and RelayMsg options; RFC
+// 4649 also adds the RemoteID option.
+type RelayOptions struct {
+	Options
+}
+
+// RelayMessage returns the message embedded.
+func (ro RelayOptions) RelayMessage() DHCPv6 {
+	opt := ro.Options.GetOne(OptionRelayMsg)
+	if opt == nil {
+		return nil
+	}
+	if relayOpt, ok := opt.(*optRelayMsg); ok {
+		return relayOpt.Msg
+	}
+	return nil
+}
+
 // RelayMessage is a DHCPv6 relay agent message as defined by RFC 3315 Section
 // 7.
 type RelayMessage struct {
@@ -17,7 +37,7 @@ type RelayMessage struct {
 	HopCount    uint8
 	LinkAddr    net.IP
 	PeerAddr    net.IP
-	Options     Options
+	Options     RelayOptions
 }
 
 // Type is this relay message's types.
@@ -29,7 +49,7 @@ func (r *RelayMessage) Type() MessageType {
 func (r *RelayMessage) String() string {
 	ret := fmt.Sprintf(
 		"RelayMessage(messageType=%s hopcount=%d, linkaddr=%s, peeraddr=%s, %d options)",
-		r.Type(), r.HopCount, r.LinkAddr, r.PeerAddr, len(r.Options),
+		r.Type(), r.HopCount, r.LinkAddr, r.PeerAddr, len(r.Options.Options),
 	)
 	return ret
 }

--- a/dhcpv6/dhcpv6relay_test.go
+++ b/dhcpv6/dhcpv6relay_test.go
@@ -80,7 +80,7 @@ func TestNewRelayRepFromRelayForw(t *testing.T) {
 	rf.PeerAddr = net.IPv6linklocalallrouters
 	rf.LinkAddr = net.IPv6interfacelocalallnodes
 	rf.AddOption(OptInterfaceID(nil))
-	rf.AddOption(&OptRemoteId{})
+	rf.AddOption(&OptRemoteID{})
 
 	// create the inner message
 	s, err := NewMessage()

--- a/dhcpv6/dhcpv6relay_test.go
+++ b/dhcpv6/dhcpv6relay_test.go
@@ -31,7 +31,7 @@ func TestRelayMessage(t *testing.T) {
 	if pa := r.PeerAddr; !pa.Equal(ma) {
 		t.Fatalf("Invalid peer address. Expected %v, got %v", ma, pa)
 	}
-	if opts := r.Options; len(opts) != 0 {
+	if opts := r.Options.Options; len(opts) != 0 {
 		t.Fatalf("Invalid options. Expected none, got %v", opts)
 	}
 }
@@ -59,18 +59,14 @@ func TestRelayMessageToBytes(t *testing.T) {
 		LinkAddr:    net.IPv6interfacelocalallnodes,
 		PeerAddr:    net.IPv6linklocalallrouters,
 	}
-	opt := OptRelayMsg{
-		relayMessage: &Message{
-			MessageType:   MessageTypeSolicit,
-			TransactionID: TransactionID{0xaa, 0xbb, 0xcc},
-			Options: MessageOptions{
-				Options: []Option{
-					OptElapsedTime(0),
-				},
-			},
-		},
-	}
-	r.AddOption(&opt)
+	opt := OptRelayMessage(&Message{
+		MessageType:   MessageTypeSolicit,
+		TransactionID: TransactionID{0xaa, 0xbb, 0xcc},
+		Options: MessageOptions{[]Option{
+			OptElapsedTime(0),
+		}},
+	})
+	r.AddOption(opt)
 	relayBytes := r.ToBytes()
 	if !bytes.Equal(expected, relayBytes) {
 		t.Fatalf("Invalid ToBytes result. Expected %v, got %v", expected, relayBytes)
@@ -90,9 +86,7 @@ func TestNewRelayRepFromRelayForw(t *testing.T) {
 	s, err := NewMessage()
 	require.NoError(t, err)
 	s.AddOption(OptClientID(Duid{}))
-	orm := OptRelayMsg{}
-	orm.SetRelayMessage(s)
-	rf.AddOption(&orm)
+	rf.AddOption(OptRelayMessage(s))
 
 	a, err := NewAdvertiseFromSolicit(s)
 	require.NoError(t, err)

--- a/dhcpv6/dhcpv6relay_test.go
+++ b/dhcpv6/dhcpv6relay_test.go
@@ -79,7 +79,7 @@ func TestNewRelayRepFromRelayForw(t *testing.T) {
 	rf.MessageType = MessageTypeRelayForward
 	rf.PeerAddr = net.IPv6linklocalallrouters
 	rf.LinkAddr = net.IPv6interfacelocalallnodes
-	rf.AddOption(&OptInterfaceId{})
+	rf.AddOption(OptInterfaceID(nil))
 	rf.AddOption(&OptRemoteId{})
 
 	// create the inner message

--- a/dhcpv6/option_interfaceid.go
+++ b/dhcpv6/option_interfaceid.go
@@ -4,39 +4,32 @@ import (
 	"fmt"
 )
 
-// OptInterfaceId implements the interface-id option as defined by RFC 3315,
+// OptInterfaceID returns an interface id option as defined by RFC 3315,
 // Section 22.18.
-//
-// This module defines the OptInterfaceId structure.
-// https://www.ietf.org/rfc/rfc3315.txt
-type OptInterfaceId struct {
-	interfaceId []byte
+func OptInterfaceID(id []byte) Option {
+	return &optInterfaceID{ID: id}
 }
 
-func (op *OptInterfaceId) Code() OptionCode {
+type optInterfaceID struct {
+	ID []byte
+}
+
+func (*optInterfaceID) Code() OptionCode {
 	return OptionInterfaceID
 }
 
-func (op *OptInterfaceId) ToBytes() []byte {
-	return op.interfaceId
+func (op *optInterfaceID) ToBytes() []byte {
+	return op.ID
 }
 
-func (op *OptInterfaceId) InterfaceID() []byte {
-	return op.interfaceId
+func (op *optInterfaceID) String() string {
+	return fmt.Sprintf("InterfaceID: %v", op.ID)
 }
 
-func (op *OptInterfaceId) SetInterfaceID(interfaceId []byte) {
-	op.interfaceId = append([]byte(nil), interfaceId...)
-}
-
-func (op *OptInterfaceId) String() string {
-	return fmt.Sprintf("OptInterfaceId{interfaceid=%v}", op.interfaceId)
-}
-
-// build an OptInterfaceId structure from a sequence of bytes.
+// build an optInterfaceID structure from a sequence of bytes.
 // The input data does not include option code and length bytes.
-func ParseOptInterfaceId(data []byte) (*OptInterfaceId, error) {
-	var opt OptInterfaceId
-	opt.interfaceId = append([]byte(nil), data...)
+func parseOptInterfaceID(data []byte) (*optInterfaceID, error) {
+	var opt optInterfaceID
+	opt.ID = append([]byte(nil), data...)
 	return &opt, nil
 }

--- a/dhcpv6/option_interfaceid_test.go
+++ b/dhcpv6/option_interfaceid_test.go
@@ -7,31 +7,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOptInterfaceId(t *testing.T) {
+func TestParseOptInterfaceID(t *testing.T) {
 	expected := []byte("DSLAM01 eth2/1/01/21")
-	opt, err := ParseOptInterfaceId(expected)
+	opt, err := parseOptInterfaceID(expected)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if url := opt.InterfaceID(); !bytes.Equal(url, expected) {
+	if url := opt.ID; !bytes.Equal(url, expected) {
 		t.Fatalf("Invalid Interface ID. Expected %v, got %v", expected, url)
 	}
 }
 
-func TestOptInterfaceIdToBytes(t *testing.T) {
-	interfaceId := []byte("DSLAM01 eth2/1/01/21")
-	opt := OptInterfaceId{}
-	opt.SetInterfaceID(interfaceId)
-	toBytes := opt.ToBytes()
-	if !bytes.Equal(toBytes, interfaceId) {
-		t.Fatalf("Invalid ToBytes result. Expected %v, got %v", interfaceId, toBytes)
+func TestOptInterfaceID(t *testing.T) {
+	want := []byte("DSLAM01 eth2/1/01/21")
+	opt := OptInterfaceID(want)
+	if got := opt.ToBytes(); !bytes.Equal(got, want) {
+		t.Fatalf("%s.ToBytes() = %v, want %v", opt, got, want)
 	}
-}
 
-func TestOptInterfaceIdString(t *testing.T) {
-	interfaceId := []byte("DSLAM01 eth2/1/01/21")
-	opt := OptInterfaceId{}
-	opt.SetInterfaceID(interfaceId)
 	require.Contains(
 		t,
 		opt.String(),

--- a/dhcpv6/option_relaymsg.go
+++ b/dhcpv6/option_relaymsg.go
@@ -1,42 +1,39 @@
 package dhcpv6
 
-// This module defines the OptRelayMsg structure.
+// This module defines the optRelayMsg structure.
 // https://www.ietf.org/rfc/rfc3315.txt
 
 import (
 	"fmt"
 )
 
-type OptRelayMsg struct {
-	relayMessage DHCPv6
+// OptRelayMessage embeds a message in a relay option.
+func OptRelayMessage(msg DHCPv6) Option {
+	return &optRelayMsg{Msg: msg}
 }
 
-func (op *OptRelayMsg) Code() OptionCode {
+type optRelayMsg struct {
+	Msg DHCPv6
+}
+
+func (op *optRelayMsg) Code() OptionCode {
 	return OptionRelayMsg
 }
 
-func (op *OptRelayMsg) ToBytes() []byte {
-	return op.relayMessage.ToBytes()
+func (op *optRelayMsg) ToBytes() []byte {
+	return op.Msg.ToBytes()
 }
 
-func (op *OptRelayMsg) RelayMessage() DHCPv6 {
-	return op.relayMessage
+func (op *optRelayMsg) String() string {
+	return fmt.Sprintf("RelayMsg: %v", op.Msg)
 }
 
-func (op *OptRelayMsg) SetRelayMessage(relayMessage DHCPv6) {
-	op.relayMessage = relayMessage
-}
-
-func (op *OptRelayMsg) String() string {
-	return fmt.Sprintf("OptRelayMsg{relaymsg=%v}", op.relayMessage)
-}
-
-// build an OptRelayMsg structure from a sequence of bytes.
+// build an optRelayMsg structure from a sequence of bytes.
 // The input data does not include option code and length bytes.
-func ParseOptRelayMsg(data []byte) (*OptRelayMsg, error) {
+func parseOptRelayMsg(data []byte) (*optRelayMsg, error) {
 	var err error
-	var opt OptRelayMsg
-	opt.relayMessage, err = FromBytes(data)
+	var opt optRelayMsg
+	opt.Msg, err = FromBytes(data)
 	if err != nil {
 		return nil, err
 	}

--- a/dhcpv6/option_relaymsg_test.go
+++ b/dhcpv6/option_relaymsg_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRelayMsgParseOptRelayMsg(t *testing.T) {
-	opt, err := ParseOptRelayMsg([]byte{
+	opt, err := parseOptRelayMsg([]byte{
 		1,                // MessageTypeSolicit
 		0xaa, 0xbb, 0xcc, // transaction ID
 		0, 8, // option: elapsed time
@@ -77,22 +77,14 @@ func TestRelayMsgParseOptRelayMsgSingleEncapsulation(t *testing.T) {
 	if mType := r.Type(); mType != MessageTypeRelayForward {
 		t.Fatalf("Invalid messge type for relay. Expected %v, got %v", MessageTypeRelayForward, mType)
 	}
-	if len(r.Options) != 1 {
-		t.Fatalf("Invalid number of options. Expected 1, got %v", len(r.Options))
+	if len(r.Options.Options) != 1 {
+		t.Fatalf("Invalid number of options. Expected 1, got %v", len(r.Options.Options))
 	}
-	if code := r.Options[0].Code(); code != OptionRelayMsg {
-		t.Fatalf("Invalid option code. Expected OptionRelayMsg (%v), got %v",
-			OptionRelayMsg, code,
-		)
+	ro := r.Options.RelayMessage()
+	if ro == nil {
+		t.Fatalf("No relay message")
 	}
-	opt := r.Options[0]
-	ro, ok := opt.(*OptRelayMsg)
-	if !ok {
-		t.Fatalf("Invalid option type. Expected OptRelayMsg, got %v",
-			reflect.TypeOf(ro),
-		)
-	}
-	innerDHCP, ok := ro.RelayMessage().(*Message)
+	innerDHCP, ok := ro.(*Message)
 	if !ok {
 		t.Fatalf("Invalid relay message type. Expected Message, got %v",
 			reflect.TypeOf(innerDHCP),
@@ -156,7 +148,7 @@ func TestSample(t *testing.T) {
 }
 
 func TestRelayMsgParseOptRelayMsgTooShort(t *testing.T) {
-	_, err := ParseOptRelayMsg([]byte{
+	_, err := parseOptRelayMsg([]byte{
 		1,                // MessageTypeSolicit
 		0xaa, 0xbb, 0xcc, // transaction ID
 		0, 8, // option: elapsed time
@@ -166,7 +158,7 @@ func TestRelayMsgParseOptRelayMsgTooShort(t *testing.T) {
 }
 
 func TestRelayMsgString(t *testing.T) {
-	opt, err := ParseOptRelayMsg([]byte{
+	opt, err := parseOptRelayMsg([]byte{
 		1,                // MessageTypeSolicit
 		0xaa, 0xbb, 0xcc, // transaction ID
 		0, 8, // option: elapsed time
@@ -177,7 +169,7 @@ func TestRelayMsgString(t *testing.T) {
 	require.Contains(
 		t,
 		opt.String(),
-		"relaymsg=Message",
+		"RelayMsg: Message",
 		"String() should contain the relaymsg contents",
 	)
 }

--- a/dhcpv6/option_remoteid.go
+++ b/dhcpv6/option_remoteid.go
@@ -6,54 +6,37 @@ import (
 	"github.com/u-root/u-root/pkg/uio"
 )
 
-// OptRemoteId implemens the Remote ID option.
-//
-// https://www.ietf.org/rfc/rfc4649.txt
-type OptRemoteId struct {
-	enterpriseNumber uint32
-	remoteId         []byte
+// OptRemoteID implemens the Remote ID option as defined by RFC 4649.
+type OptRemoteID struct {
+	EnterpriseNumber uint32
+	RemoteID         []byte
 }
 
-func (op *OptRemoteId) Code() OptionCode {
+// Code implements Option.Code.
+func (*OptRemoteID) Code() OptionCode {
 	return OptionRemoteID
 }
 
 // ToBytes serializes this option to a byte stream.
-func (op *OptRemoteId) ToBytes() []byte {
+func (op *OptRemoteID) ToBytes() []byte {
 	buf := uio.NewBigEndianBuffer(nil)
-	buf.Write32(op.enterpriseNumber)
-	buf.WriteBytes(op.remoteId)
+	buf.Write32(op.EnterpriseNumber)
+	buf.WriteBytes(op.RemoteID)
 	return buf.Data()
 }
 
-func (op *OptRemoteId) EnterpriseNumber() uint32 {
-	return op.enterpriseNumber
-}
-
-func (op *OptRemoteId) SetEnterpriseNumber(enterpriseNumber uint32) {
-	op.enterpriseNumber = enterpriseNumber
-}
-
-func (op *OptRemoteId) RemoteID() []byte {
-	return op.remoteId
-}
-
-func (op *OptRemoteId) SetRemoteID(remoteId []byte) {
-	op.remoteId = append([]byte(nil), remoteId...)
-}
-
-func (op *OptRemoteId) String() string {
-	return fmt.Sprintf("OptRemoteId{enterprisenum=%v, remoteid=%v}",
-		op.enterpriseNumber, op.remoteId,
+func (op *OptRemoteID) String() string {
+	return fmt.Sprintf("RemoteID: EnterpriseNumber %d RemoteID %v",
+		op.EnterpriseNumber, op.RemoteID,
 	)
 }
 
 // ParseOptRemoteId builds an OptRemoteId structure from a sequence of bytes.
 // The input data does not include option code and length bytes.
-func ParseOptRemoteId(data []byte) (*OptRemoteId, error) {
-	var opt OptRemoteId
+func ParseOptRemoteID(data []byte) (*OptRemoteID, error) {
+	var opt OptRemoteID
 	buf := uio.NewBigEndianBuffer(data)
-	opt.enterpriseNumber = buf.Read32()
-	opt.remoteId = buf.ReadAll()
+	opt.EnterpriseNumber = buf.Read32()
+	opt.RemoteID = buf.ReadAll()
 	return &opt, buf.FinError()
 }

--- a/dhcpv6/option_remoteid_test.go
+++ b/dhcpv6/option_remoteid_test.go
@@ -7,27 +7,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOptRemoteId(t *testing.T) {
+func TestOptRemoteID(t *testing.T) {
 	expected := []byte{0xaa, 0xbb, 0xcc, 0xdd}
 	remoteId := []byte("DSLAM01 eth2/1/01/21")
 	expected = append(expected, remoteId...)
-	opt, err := ParseOptRemoteId(expected)
+	opt, err := ParseOptRemoteID(expected)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if en := opt.EnterpriseNumber(); en != 0xaabbccdd {
+	if en := opt.EnterpriseNumber; en != 0xaabbccdd {
 		t.Fatalf("Invalid Enterprise Number. Expected 0xaabbccdd, got %v", en)
 	}
-	if rid := opt.RemoteID(); !bytes.Equal(rid, remoteId) {
+	if rid := opt.RemoteID; !bytes.Equal(rid, remoteId) {
 		t.Fatalf("Invalid Remote ID. Expected %v, got %v", expected, rid)
 	}
 }
 
-func TestOptRemoteIdToBytes(t *testing.T) {
+func TestOptRemoteIDToBytes(t *testing.T) {
 	remoteId := []byte("DSLAM01 eth2/1/01/21")
 	expected := append([]byte{0, 0, 0, 0}, remoteId...)
-	opt := OptRemoteId{
-		remoteId: remoteId,
+	opt := OptRemoteID{
+		RemoteID: remoteId,
 	}
 	toBytes := opt.ToBytes()
 	if !bytes.Equal(toBytes, expected) {
@@ -35,41 +35,30 @@ func TestOptRemoteIdToBytes(t *testing.T) {
 	}
 }
 
-func TestOptRemoteIdSet(t *testing.T) {
-	enterpriseNumber := uint32(12345)
-	remoteID := []byte("DSLAM01 eth2/1/01/21")
-	opt := OptRemoteId{}
-	opt.SetEnterpriseNumber(enterpriseNumber)
-	opt.SetRemoteID(remoteID)
-
-	require.Equal(t, uint32(12345), opt.EnterpriseNumber())
-	require.Equal(t, []byte("DSLAM01 eth2/1/01/21"), opt.RemoteID())
-}
-
-func TestOptRemoteIdParseOptRemoteIdTooShort(t *testing.T) {
+func TestOptRemoteIDParseOptRemoteIDTooShort(t *testing.T) {
 	buf := []byte{0xaa, 0xbb, 0xcc}
-	_, err := ParseOptRemoteId(buf)
+	_, err := ParseOptRemoteID(buf)
 	require.Error(t, err, "A short option should return an error")
 }
 
-func TestOptRemoteIdString(t *testing.T) {
+func TestOptRemoteIDString(t *testing.T) {
 	buf := []byte{0xaa, 0xbb, 0xcc, 0xdd}
 	remoteId := []byte("Test1234")
 	buf = append(buf, remoteId...)
 
-	opt, err := ParseOptRemoteId(buf)
+	opt, err := ParseOptRemoteID(buf)
 	require.NoError(t, err)
 	str := opt.String()
 	require.Contains(
 		t,
 		str,
-		"enterprisenum=2864434397",
+		"EnterpriseNumber 2864434397",
 		"String() should contain the enterprisenum",
 	)
 	require.Contains(
 		t,
 		str,
-		"remoteid=[84 101 115 116 49 50 51 52]",
+		"RemoteID [84 101 115 116 49 50 51 52]",
 		"String() should contain the remoteid bytes",
 	)
 }

--- a/dhcpv6/options.go
+++ b/dhcpv6/options.go
@@ -54,7 +54,7 @@ func ParseOption(code OptionCode, optData []byte) (Option, error) {
 	case OptionElapsedTime:
 		opt, err = parseOptElapsedTime(optData)
 	case OptionRelayMsg:
-		opt, err = ParseOptRelayMsg(optData)
+		opt, err = parseOptRelayMsg(optData)
 	case OptionStatusCode:
 		opt, err = ParseOptStatusCode(optData)
 	case OptionUserClass:

--- a/dhcpv6/options.go
+++ b/dhcpv6/options.go
@@ -64,7 +64,7 @@ func ParseOption(code OptionCode, optData []byte) (Option, error) {
 	case OptionVendorOpts:
 		opt, err = ParseOptVendorOpts(optData)
 	case OptionInterfaceID:
-		opt, err = ParseOptInterfaceId(optData)
+		opt, err = parseOptInterfaceID(optData)
 	case OptionDNSRecursiveNameServer:
 		opt, err = parseOptDNS(optData)
 	case OptionDomainSearchList:

--- a/dhcpv6/options.go
+++ b/dhcpv6/options.go
@@ -74,7 +74,7 @@ func ParseOption(code OptionCode, optData []byte) (Option, error) {
 	case OptionIAPrefix:
 		opt, err = ParseOptIAPrefix(optData)
 	case OptionRemoteID:
-		opt, err = ParseOptRemoteId(optData)
+		opt, err = ParseOptRemoteID(optData)
 	case OptionFQDN:
 		opt, err = ParseOptFQDN(optData)
 	case OptionBootfileURL:

--- a/dhcpv6/ztpv6/parse_remote_id_test.go
+++ b/dhcpv6/ztpv6/parse_remote_id_test.go
@@ -64,16 +64,14 @@ func TestParseRemoteID(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			packet, err := dhcpv6.NewMessage()
-			if err != nil {
-				t.Fatalf("failed to creat dhcpv6 packet object: %v", err)
+			m := &dhcpv6.RelayMessage{
+				MessageType: dhcpv6.MessageTypeRelayForward,
 			}
-			opt := dhcpv6.OptRemoteId{}
-			opt.SetRemoteID(tc.circuit)
-			opt.SetEnterpriseNumber(1234)
-			packet.AddOption(&opt)
+			// Has to be a well-formed relay message with the OptRelayMsg.
+			m.Options.Add(dhcpv6.OptRelayMessage(&dhcpv6.Message{}))
+			m.Options.Add(&dhcpv6.OptRemoteID{RemoteID: tc.circuit, EnterpriseNumber: 1234})
 
-			circuit, err := ParseRemoteId(packet)
+			circuit, err := ParseRemoteID(m)
 			if err != nil && !tc.fail {
 				t.Errorf("unexpected failure: %v", err)
 			}


### PR DESCRIPTION
According to RFC 8415 Appendix C, RelayForw and RelayRepl messages may have the following options:

- RelayMessage
- InterfaceID
- Vendor Info (unimplemented)

RFC 4649 also adds a RemoteID to relay messages.

This adds a `RelayOptions` type with Getters for RelayMessage, InterfaceID, and RemoteID.