### PR TITLE
Fix "conn" leaking

### DIFF
--- a/netboot/rtnetlink_linux.go
+++ b/netboot/rtnetlink_linux.go
@@ -1,6 +1,10 @@
 package netboot
 
-import "github.com/jsimonetti/rtnetlink"
+import (
+	"log"
+
+	"github.com/jsimonetti/rtnetlink"
+)
 
 // getOperState returns the operational state for the given interface index.
 func getOperState(iface int) (rtnetlink.OperationalState, error) {
@@ -8,6 +12,13 @@ func getOperState(iface int) (rtnetlink.OperationalState, error) {
 	if err != nil {
 		return 0, err
 	}
+	defer func() {
+		err := conn.Close()
+		if err != nil {
+			log.Printf("failed to close rtnetlink connection: %v", err)
+		}
+	}()
+
 	msg, err := conn.Link.Get(uint32(iface))
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
On machines with many NICs, it can cause the golang runtime to run out of threads.