### PR TITLE
nclient6: listen on link-local addr

### DIFF
--- a/dhcpv6/nclient6/client.go
+++ b/dhcpv6/nclient6/client.go
@@ -113,7 +113,13 @@ func (d debugLogger) PrintMessage(prefix string, message *dhcpv6.Message) {
 // NewIPv6UDPConn returns a UDP connection bound to both the interface and port
 // given based on a IPv6 DGRAM socket.
 func NewIPv6UDPConn(iface string, port int) (net.PacketConn, error) {
+	ip, err := dhcpv6.GetLinkLocalAddr(iface)
+	if err != nil {
+		return nil, err
+	}
+
 	return net.ListenUDP("udp6", &net.UDPAddr{
+		IP:   ip,
 		Port: port,
 		Zone: iface,
 	})


### PR DESCRIPTION
This allows for multi-NIC DHCPv6 in parallel.

Otherwise:

2020/02/20 05:01:34 Could not configure eth1 for IPv6: listen udp6 %eth1:546: bind: address already in use
2020/02/20 05:01:34 Could not configure eth4 for IPv6: listen udp6 %eth4:546: bind: address already in use
2020/02/20 05:01:34 Attempting to get DHCPv6 lease on eth2
2020/02/20 05:01:34 Could not configure eth0 for IPv6: listen udp6 %eth0:546: bind: address already in use
2020/02/20 05:01:34 Could not configure eth3 for IPv6: listen udp6 %eth3:546: bind: address already in use