### PR TITLE
dhcpv6: allow using OptIAPrefix without initializing

### DIFF
--- a/dhcpv6/option_iaprefix.go
+++ b/dhcpv6/option_iaprefix.go
@@ -34,7 +34,12 @@ func (op *OptIAPrefix) ToBytes() []byte {
 	t2.Marshal(buf)
 
 	buf.Write8(op.prefixLength)
-	buf.WriteBytes(op.ipv6Prefix.To16())
+	prefix := op.ipv6Prefix.To16()
+	if prefix != nil {
+		buf.WriteBytes(prefix)
+	} else {
+		buf.WriteBytes(make([]byte, net.IPv6len))
+	}
 	buf.WriteBytes(op.Options.ToBytes())
 	return buf.Data()
 }

--- a/dhcpv6/option_iaprefix_test.go
+++ b/dhcpv6/option_iaprefix_test.go
@@ -56,6 +56,21 @@ func TestOptIAPrefixToBytes(t *testing.T) {
 	}
 }
 
+func TestOptIAPrefixToBytesDefault(t *testing.T) {
+	buf := []byte{
+		0, 0, 0, 0, // preferredLifetime
+		0, 0, 0, 0, // validLifetime
+		0,                                              // prefixLength
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // ipv6Prefix
+	}
+	opt := OptIAPrefix{
+	}
+	toBytes := opt.ToBytes()
+	if !bytes.Equal(toBytes, buf) {
+		t.Fatalf("Invalid ToBytes result. Expected %v, got %v", buf, toBytes)
+	}
+}
+
 func TestOptIAPrefixParseInvalidTooShort(t *testing.T) {
 	buf := []byte{
 		0xaa, 0xbb, 0xcc, 0xdd, // preferredLifetime


### PR DESCRIPTION
Don't require initialization of the prefix in an OptIAPrefix struct. Set the set the
IPv6 prefix field to zero in the message if the prefix in uninitialized or contains an invalid IPv6 address.