### PR TITLE
dhcpv6: add IA_PD to request from advertise

### DIFF
--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -378,6 +378,10 @@ func NewRequestFromAdvertise(adv *Message, modifiers ...Modifier) (*Message, err
 		return nil, fmt.Errorf("IA_NA cannot be nil in ADVERTISE when building REQUEST")
 	}
 	req.AddOption(iana)
+	// add IA_PD
+	if iaPd := adv.GetOneOption(OptionIAPD); iaPd != nil {
+		req.AddOption(iaPd)
+	}
 	req.AddOption(OptRequestedOption(
 		OptionDNSRecursiveNameServer,
 		OptionDomainSearchList,

--- a/dhcpv6/modifiers.go
+++ b/dhcpv6/modifiers.go
@@ -129,3 +129,22 @@ func WithDHCP4oDHCP6Server(addrs ...net.IP) Modifier {
 		d.UpdateOption(&opt)
 	}
 }
+
+// WithIAPD adds or updates an IAPD option with the provided IAID and
+// prefix options to a DHCPv6 packet.
+func WithIAPD(iaid [4]byte, prefixes ...OptIAPrefix) Modifier {
+	return func(d DHCPv6) {
+		opt := d.GetOneOption(OptionIAPD)
+		if opt == nil {
+			opt = &OptIAForPrefixDelegation{}
+		}
+		iaPd := opt.(*OptIAForPrefixDelegation)
+
+		copy(iaPd.IaId[:], iaid[:])
+
+		for _, prefix := range prefixes {
+			iaPd.Options.Add(&prefix)
+		}
+		d.UpdateOption(iaPd)
+	}
+}

--- a/dhcpv6/modifiers_test.go
+++ b/dhcpv6/modifiers_test.go
@@ -107,3 +107,17 @@ func TestWithDHCP4oDHCP6Server(t *testing.T) {
 	require.Equal(t, net.ParseIP("fe80::2"), opt.DHCP4oDHCP6Servers[1])
 	require.NotEqual(t, net.ParseIP("fe80::1"), opt.DHCP4oDHCP6Servers[1])
 }
+
+func TestWithIAPD(t *testing.T) {
+	var d Message
+	prefix := OptIAPrefix{
+		PreferredLifetime: 3600,
+		ValidLifetime:     5200,
+	}
+	prefix.SetPrefixLength(48)
+	prefix.SetIPv6Prefix(net.ParseIP("2001:DB8:7689::"))
+	WithIAPD([4]byte{1, 2, 3, 4}, prefix)(&d)
+	opt := d.Options.IAPD()
+	require.Equal(t, 1, len(opt))
+	require.Equal(t, OptionIAPD, opt[0].Code())
+}


### PR DESCRIPTION
Add the IA_PD option to the request from the advertise if present.
Add WithIAPD() as modifier and test.
