### PR TITLE
dhcpv6: always write 16-byte IPs

### DIFF
--- a/dhcpv6/dhcpv6relay.go
+++ b/dhcpv6/dhcpv6relay.go
@@ -20,6 +20,15 @@ type RelayMessage struct {
 	Options     Options
 }
 
+func write16(b *uio.Lexer, ip net.IP) {
+	if ip == nil || ip.To16() == nil {
+		var zeros [net.IPv6len]byte
+		b.WriteBytes(zeros[:])
+	} else {
+		b.WriteBytes(ip.To16())
+	}
+}
+
 // Type is this relay message's types.
 func (r *RelayMessage) Type() MessageType {
 	return r.MessageType
@@ -58,8 +67,8 @@ func (r *RelayMessage) ToBytes() []byte {
 	buf := uio.NewBigEndianBuffer(make([]byte, 0, RelayHeaderSize))
 	buf.Write8(byte(r.MessageType))
 	buf.Write8(r.HopCount)
-	buf.WriteBytes(r.LinkAddr.To16())
-	buf.WriteBytes(r.PeerAddr.To16())
+	write16(buf, r.LinkAddr)
+	write16(buf, r.PeerAddr)
 	buf.WriteBytes(r.Options.ToBytes())
 	return buf.Data()
 }

--- a/dhcpv6/dhcpv6relay_test.go
+++ b/dhcpv6/dhcpv6relay_test.go
@@ -36,6 +36,17 @@ func TestRelayMessage(t *testing.T) {
 	}
 }
 
+func TestRelayMessageToBytesDefault(t *testing.T) {
+	want := []byte{
+		12,                                             // MessageTypeRelayForward
+		0,                                              // hop count
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // link addr
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // peer addr
+	}
+	r := RelayMessage{MessageType: MessageTypeRelayForward}
+	require.Equal(t, r.ToBytes(), want)
+}
+
 func TestRelayMessageToBytes(t *testing.T) {
 	expected := []byte{
 		12,                                                      // MessageTypeRelayForward

--- a/dhcpv6/option_iaaddress.go
+++ b/dhcpv6/option_iaaddress.go
@@ -27,7 +27,7 @@ func (op *OptIAAddress) Code() OptionCode {
 // ToBytes serializes the option and returns it as a sequence of bytes
 func (op *OptIAAddress) ToBytes() []byte {
 	buf := uio.NewBigEndianBuffer(nil)
-	buf.WriteBytes(op.IPv6Addr.To16())
+	write16(buf, op.IPv6Addr)
 
 	t1 := Duration{op.PreferredLifetime}
 	t1.Marshal(buf)

--- a/dhcpv6/option_iaaddress_test.go
+++ b/dhcpv6/option_iaaddress_test.go
@@ -43,6 +43,16 @@ func TestOptIAAddressParseInvalidBrokenOptions(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestOptIAAddressToBytesDefault(t *testing.T) {
+	want := []byte{
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // IP
+		0, 0, 0, 0, // preferred lifetime
+		0, 0, 0, 0, // valid lifetime
+	}
+	opt := OptIAAddress{}
+	require.Equal(t, opt.ToBytes(), want)
+}
+
 func TestOptIAAddressToBytes(t *testing.T) {
 	ipBytes := []byte{0x24, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	expected := append(ipBytes, []byte{

--- a/dhcpv6/option_iaprefix.go
+++ b/dhcpv6/option_iaprefix.go
@@ -34,12 +34,7 @@ func (op *OptIAPrefix) ToBytes() []byte {
 	t2.Marshal(buf)
 
 	buf.Write8(op.prefixLength)
-	prefix := op.ipv6Prefix.To16()
-	if prefix != nil {
-		buf.WriteBytes(prefix)
-	} else {
-		buf.WriteBytes(make([]byte, net.IPv6len))
-	}
+	write16(buf, op.ipv6Prefix)
 	buf.WriteBytes(op.Options.ToBytes())
 	return buf.Data()
 }


### PR DESCRIPTION
Signed-off-by: Chris Koch <chrisko@google.com>