### PR TITLE
adding fallback logic to remote id parsing

### DIFF
--- a/dhcpv6/ztpv6/parse_remote_id_test.go
+++ b/dhcpv6/ztpv6/parse_remote_id_test.go
@@ -17,6 +17,7 @@ func TestCircuitID(t *testing.T) {
 		{name: "Bogus string", circuit: "ope/1/2/3:ope", fail: true, want: nil},
 		{name: "Arista Port Vlan Pattern", circuit: "Ethernet13:2001", want: &CircuitID{Port: "13", Vlan: "2001"}},
 		{name: "Arista Slot Module Port Pattern", circuit: "Ethernet1/3/4", want: &CircuitID{Slot: "1", Module: "3", Port: "4"}},
+		{name: "Arista Slot Module Port Pattern InterfaceID", circuit: "Ethernet1/3/4:default", want: &CircuitID{Slot: "1", Module: "3", Port: "4"}},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
@@ -71,6 +72,37 @@ func TestParseRemoteID(t *testing.T) {
 			m.Options.Add(dhcpv6.OptRelayMessage(&dhcpv6.Message{}))
 			m.Options.Add(&dhcpv6.OptRemoteID{RemoteID: tc.circuit, EnterpriseNumber: 1234})
 
+			circuit, err := ParseRemoteID(m)
+			if err != nil && !tc.fail {
+				t.Errorf("unexpected failure: %v", err)
+			}
+			if circuit != nil {
+				require.Equal(t, *tc.want, *circuit, "ZTPRemoteID data")
+			} else {
+				require.Equal(t, tc.want, circuit, "ZTPRemoteID data")
+			}
+		})
+	}
+}
+
+func TestParseRemoteIDWithInterfaceID(t *testing.T) {
+	tt := []struct {
+		name    string
+		circuit []byte
+		want    *CircuitID
+		fail    bool
+	}{
+		{name: "Bogus string", circuit: []byte("ope/1/2/3:ope.1"), fail: true, want: nil},
+		{name: "Arista Slot Module Port Pattern", circuit: []byte("Ethernet1/3/4:default"), want: &CircuitID{Slot: "1", Module: "3", Port: "4"}},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &dhcpv6.RelayMessage{
+				MessageType: dhcpv6.MessageTypeRelayForward,
+			}
+			// Has to be a well-formed relay message with the OptRelayMsg.
+			m.Options.Add(dhcpv6.OptRelayMessage(&dhcpv6.Message{}))
+			m.Options.Add(dhcpv6.OptInterfaceID(tc.circuit))
 			circuit, err := ParseRemoteID(m)
 			if err != nil && !tc.fail {
 				t.Errorf("unexpected failure: %v", err)


### PR DESCRIPTION
Arista Devices for DHCPv6 send circuit id information in option 18 when the relay interface is L3 interface (not vlan interface) so adding this logic. If we dont find circuit id from option 37 ( remote id ) then look for option 18 (interface id). 

unit rest result
```
➜ /home/navale/go/src/github.com/akshaynawale/dhcp/dhcpv6/ztpv6 git:(master) go test -v
=== RUN   TestCircuitID                                                                                                                                                                                                                       
=== RUN   TestCircuitID/Bogus_string                                                                                                                                                                                                          
=== RUN   TestCircuitID/Arista_Port_Vlan_Pattern                                                                                                                                                                                              
=== RUN   TestCircuitID/Arista_Slot_Module_Port_Pattern                                                                                                                                                                                       
=== RUN   TestCircuitID/Arista_Slot_Module_Port_Pattern_InterfaceID                                                                                                                                                                           
--- PASS: TestCircuitID (0.00s)                                                                                                                                                                                                               
    --- PASS: TestCircuitID/Bogus_string (0.00s)                                                                                                                                                                                              
    --- PASS: TestCircuitID/Arista_Port_Vlan_Pattern (0.00s)                                                                                                                                                                                  
    --- PASS: TestCircuitID/Arista_Slot_Module_Port_Pattern (0.00s)                                                                                                                                                                           
    --- PASS: TestCircuitID/Arista_Slot_Module_Port_Pattern_InterfaceID (0.00s)                                                                                                                                                               
=== RUN   TestFormatCircuitID                                                                                                                                                                                                                 
=== RUN   TestFormatCircuitID/empty                                                                                                                                                                                                           
=== RUN   TestFormatCircuitID/Arista_format_Port/Vlan
=== RUN   TestFormatCircuitID/Arista_format_Slot/Module/Port
--- PASS: TestFormatCircuitID (0.00s)
    --- PASS: TestFormatCircuitID/empty (0.00s)
    --- PASS: TestFormatCircuitID/Arista_format_Port/Vlan (0.00s)
    --- PASS: TestFormatCircuitID/Arista_format_Slot/Module/Port (0.00s)
=== RUN   TestParseRemoteID
=== RUN   TestParseRemoteID/Bogus_string
=== RUN   TestParseRemoteID/Arista_Port_Vlan_Pattern
=== RUN   TestParseRemoteID/Arista_Slot_Module_Port_Pattern 
--- PASS: TestParseRemoteID (0.00s)
    --- PASS: TestParseRemoteID/Bogus_string (0.00s)
    --- PASS: TestParseRemoteID/Arista_Port_Vlan_Pattern (0.00s)
    --- PASS: TestParseRemoteID/Arista_Slot_Module_Port_Pattern (0.00s)
=== RUN   TestParseRemoteIDWithInterfaceID
=== RUN   TestParseRemoteIDWithInterfaceID/Bogus_string
=== RUN   TestParseRemoteIDWithInterfaceID/Arista_Slot_Module_Port_Pattern
--- PASS: TestParseRemoteIDWithInterfaceID (0.00s)
    --- PASS: TestParseRemoteIDWithInterfaceID/Bogus_string (0.00s)
    --- PASS: TestParseRemoteIDWithInterfaceID/Arista_Slot_Module_Port_Pattern (0.00s)
=== RUN   TestParseVendorDataWithVendorOpts
=== RUN   TestParseVendorDataWithVendorOpts/empty
=== RUN   TestParseVendorDataWithVendorOpts/unknownVendor
=== RUN   TestParseVendorDataWithVendorOpts/truncatedArista 
=== RUN   TestParseVendorDataWithVendorOpts/truncatedZPE
=== RUN   TestParseVendorDataWithVendorOpts/arista
=== RUN   TestParseVendorDataWithVendorOpts/zpe
--- PASS: TestParseVendorDataWithVendorOpts (0.00s)
    --- PASS: TestParseVendorDataWithVendorOpts/empty (0.00s)
    --- PASS: TestParseVendorDataWithVendorOpts/unknownVendor (0.00s)
    --- PASS: TestParseVendorDataWithVendorOpts/truncatedArista (0.00s)
    --- PASS: TestParseVendorDataWithVendorOpts/truncatedZPE (0.00s)
    --- PASS: TestParseVendorDataWithVendorOpts/arista (0.00s)
    --- PASS: TestParseVendorDataWithVendorOpts/zpe (0.00s) 
=== RUN   TestParseVendorDataWithVendorClass
=== RUN   TestParseVendorDataWithVendorClass/empty
=== RUN   TestParseVendorDataWithVendorClass/unknownVendor
=== RUN   TestParseVendorDataWithVendorClass/truncatedArista
=== RUN   TestParseVendorDataWithVendorClass/truncatedZPE
=== RUN   TestParseVendorDataWithVendorClass/arista
=== RUN   TestParseVendorDataWithVendorClass/zpe
--- PASS: TestParseVendorDataWithVendorClass (0.00s)
    --- PASS: TestParseVendorDataWithVendorClass/empty (0.00s)
    --- PASS: TestParseVendorDataWithVendorClass/unknownVendor (0.00s)
    --- PASS: TestParseVendorDataWithVendorClass/truncatedArista (0.00s)
    --- PASS: TestParseVendorDataWithVendorClass/truncatedZPE (0.00s)
    --- PASS: TestParseVendorDataWithVendorClass/arista (0.00s)
    --- PASS: TestParseVendorDataWithVendorClass/zpe (0.00s)
PASS
ok      github.com/akshaynawale/dhcp/dhcpv6/ztpv6       0.003s

```
Signed-off-by: akshay navale <akshaynawale@gmail.com>