### PR TITLE
Generate new TransactionID for Request

### DIFF
--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -354,10 +354,11 @@ func NewRequestFromAdvertise(adv *Message, modifiers ...Modifier) (*Message, err
 		return nil, fmt.Errorf("The passed ADVERTISE must have ADVERTISE type set")
 	}
 	// build REQUEST from ADVERTISE
-	req := &Message{
-		MessageType:   MessageTypeRequest,
-		TransactionID: adv.TransactionID,
+	req, err := NewMessage()
+	if err != nil {
+		return nil, err
 	}
+	req.MessageType = MessageTypeRequest
 	// add Client ID
 	cid := adv.GetOneOption(OptionClientID)
 	if cid == nil {


### PR DESCRIPTION
Per the RFC each new Exchange should have a new TransactionID. Clients should not reuse the same transaction ID for a new REQUEST from a SOLICIT