### PR TITLE
fix golangci-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ language: go
 sudo: required
 
 go:
-  - "1.11"
-  - "1.12"
   - "1.13"
+  - "1.14"
 
 env:
   - TEST_SUITE=unit

--- a/.travis/linters.sh
+++ b/.travis/linters.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-go get github.com/golangci/golangci-lint/cmd/golangci-lint
-go install github.com/golangci/golangci-lint/cmd/golangci-lint
-golangci-lint run
+set -e
+
+GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint
+$GOPATH/bin/golangci-lint run


### PR DESCRIPTION
* bump Go versions
* use Go modules when downloading golangci-lint
* use $GOPATH when running golangci-lint bin