### PR TITLE
netconf: apply v6 addresses as /128

### DIFF
--- a/netboot/netconf.go
+++ b/netboot/netconf.go
@@ -44,8 +44,17 @@ func GetNetConfFromPacketv6(d *dhcpv6.Message) (*NetConf, error) {
 	for _, iaaddr := range iana.Options.Addresses() {
 		netconf.Addresses = append(netconf.Addresses, AddrConf{
 			IPNet: net.IPNet{
-				IP:   iaaddr.IPv6Addr,
-				Mask: net.CIDRMask(64, 128),
+				IP: iaaddr.IPv6Addr,
+
+				// This mask tells Linux which addresses we know to be
+				// "on-link" (i.e., reachable on this interface without
+				// having to talk to a router).
+				//
+				// Since DHCPv6 does not give us that information, we
+				// have to assume that no addresses are on-link. To do
+				// that, we use /128. (See also RFC 5942 Section 5,
+				// "Observed Incorrect Implementation Behavior".)
+				Mask: net.CIDRMask(128, 128),
 			},
 			PreferredLifetime: iaaddr.PreferredLifetime,
 			ValidLifetime:     iaaddr.ValidLifetime,


### PR DESCRIPTION
Since we do not share this code at the moment, here's a dup of https://github.com/u-root/u-root/pull/1765

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=684009

"Note that the dhcpv6 protocol doesn't have an option for a netmask. So
it is always /128 and routing is left to icmpv6 router advertisements."

RFC 5942 is a good read here as well:

   An address could be acquired through the DHCPv6 identity association
   for non- temporary addresses (IA_NA) option from [RFC3315] (which
   does not include a prefix length), or through manual configuration
   (if no prefix length is specified).  The host incorrectly assumes an
   invented prefix is on-link.  This invented prefix typically is a /64
   that was written by the developer of the operating system network
   module API to any IPv6 application as a "default" prefix length when
   a length isn't specified.

As DHCP developers, we *HAVE* to assume that no prefix is on-link. The
correct way to do that is to specify the netmask as /128.

The kernel will RA/RS their way around to figure out what prefixes are
indeed on-link.