### PR TITLE
Cater for bad client implementation of vendor class option length

### DIFF
--- a/dhcpv6/option_vendorclass.go
+++ b/dhcpv6/option_vendorclass.go
@@ -47,6 +47,10 @@ func ParseOptVendorClass(data []byte) (*OptVendorClass, error) {
 	opt.EnterpriseNumber = buf.Read32()
 	for buf.Has(2) {
 		len := buf.Read16()
+		// Assume little-endian if big-endian would have resulted in an error
+		if len > 0 && !buf.Has(int(len)) {
+			len = len>>8 | (len & 0xff << 8)
+		}
 		opt.Data = append(opt.Data, buf.CopyN(int(len)))
 	}
 	if len(opt.Data) < 1 {

--- a/dhcpv6/option_vendorclass_test.go
+++ b/dhcpv6/option_vendorclass_test.go
@@ -68,6 +68,15 @@ func TestOptVendorClassParseOptVendorClassMalformed(t *testing.T) {
 	require.Error(t, err, "ParseOptVendorClass() should error if given a truncated length")
 }
 
+func TestOptVendorClassSwappedByteOrder(t *testing.T) {
+	buf := []byte{
+		0xaa, 0xbb, 0xcc, 0xdd, // EnterpriseNumber
+		12, 0, 'd', 's', 'l', 'f', 'o', 'r', 'u', 'm', '.', 'o', 'r', 'g',
+	}
+	opt, _ := ParseOptVendorClass(buf)
+	require.Equal(t, []byte("dslforum.org"), opt.Data[0])
+}
+
 func TestOptVendorClassString(t *testing.T) {
 	data := []byte{
 		0xaa, 0xbb, 0xcc, 0xdd, // EnterpriseNumber


### PR DESCRIPTION
Hi team, long time no see.

I needed the attached pull request to cater for a bad client implementation of the vendor class option length using little-endian rather than big-endian that I am seeing in the wild on certain D-Link routers.

Cheers!