### PR TITLE
Attempt at "failing gracefully" for dhcpv6

### DIFF
--- a/dhcpv6/option_generic_parse_failure.go
+++ b/dhcpv6/option_generic_parse_failure.go
@@ -1,0 +1,24 @@
+package dhcpv6
+
+import (
+	"fmt"
+)
+
+type OptionGenericParseFailure struct {
+	OptionCode OptionCode
+	OptionData []byte
+	Option     Option
+	Error      error
+}
+
+func (og *OptionGenericParseFailure) Code() OptionCode {
+	return og.OptionCode
+}
+
+func (og *OptionGenericParseFailure) ToBytes() []byte {
+	return og.OptionData
+}
+
+func (og *OptionGenericParseFailure) String() string {
+	return fmt.Sprintf("GenericParseFailure(%v): %v, Error=%v", og.OptionCode, og.Option, og.Error)
+}

--- a/dhcpv6/option_generic_parse_failure.go
+++ b/dhcpv6/option_generic_parse_failure.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 )
 
+// OptionGenericParseFailure represents an option that failed to be parsed correctly
 type OptionGenericParseFailure struct {
 	OptionCode OptionCode
 	OptionData []byte
@@ -11,10 +12,12 @@ type OptionGenericParseFailure struct {
 	Error      error
 }
 
+// Code returns the option's code
 func (og *OptionGenericParseFailure) Code() OptionCode {
 	return og.OptionCode
 }
 
+// ToBytes serializes the option and returns it as a sequence of bytes
 func (og *OptionGenericParseFailure) ToBytes() []byte {
 	return og.OptionData
 }

--- a/dhcpv6/option_generic_parse_failure_test.go
+++ b/dhcpv6/option_generic_parse_failure_test.go
@@ -1,0 +1,37 @@
+package dhcpv6
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptGenericParseFailure(t *testing.T) {
+	buf := []byte{
+		0xaa, 0xbb, 0xcc, 0xdd, // EnterpriseNumber
+		12, 0, // length is little-endian - should be big-endian
+		'd', 's', 'l', 'f', 'o', 'r', 'u', 'm', '.', 'o', 'r', 'g',
+	}
+	opt, _ := ParseOption(OptionVendorClass, buf)
+	require.IsType(t, &OptionGenericParseFailure{}, opt)
+	failedOpt, ok := opt.(*OptionGenericParseFailure)
+	require.True(t, ok)
+	require.Contains(
+		t,
+		failedOpt.Error.Error(),
+		"buffer too short",
+		"Error() should return the original parser error",
+	)
+	require.Contains(
+		t,
+		failedOpt.String(),
+		"GenericParseFailure(Vendor Class)",
+		"String() should include the Option Code",
+	)
+	require.Contains(
+		t,
+		failedOpt.String(),
+		"enterprisenum=2864434397",
+		"String() should include the details of the failed option",
+	)
+}

--- a/dhcpv6/options.go
+++ b/dhcpv6/options.go
@@ -107,9 +107,9 @@ func ParseOption(code OptionCode, optData []byte) (Option, error) {
 		opt = &OptionGeneric{OptionCode: code, OptionData: optData}
 	}
 	if err != nil {
-		return nil, err
+		opt = &OptionGenericParseFailure{OptionCode: code, OptionData: optData, Option: opt, Error: err}
 	}
-	return opt, nil
+	return opt, err
 }
 
 // Options is a collection of options.
@@ -205,10 +205,7 @@ func (o *Options) FromBytesWithParser(data []byte, parser OptionParser) error {
 		// pertinent data.
 		optData := buf.Consume(length)
 
-		opt, err := parser(code, optData)
-		if err != nil {
-			return err
-		}
+		opt, _ := parser(code, optData)
 		*o = append(*o, opt)
 	}
 	return buf.FinError()


### PR DESCRIPTION
@hugelgupf Something like this perhaps?

As mentioned in #395, the dhcpv6 library currently causes the whole packet processing to fail if there are any parsing errors in any of the Options. Whilst that MR dealt with a specific issue with a D-Link router, this MR allows processing to continue in general, instead capturing and storing the error in a new "OptionGenericParseFailure" type which includes the option code, option bytes, parser error and original option.

Because the option bytes are returned, it would therefore be possible to detect an OptionGenericParseFailure and write a custom implementation to deal with the specific parser error, if required.

By default, Summary() may therefore look something like this:

```
Message
  messageType=SOLICIT
  transactionid=0x123456
  options=[
    ClientID: DUID{type=DUID-LL hwtype=Ethernet hwaddr=00:11:22:33:44:55}
    IANA: {IAID=[0 0 0 1], t1=0s, t2=0s, options={[]}}
    Rapid Commit -> []
    ElapsedTime: 34.92s
    RequestedOptions: DNS Recursive Name Server, Domain Search List, SNTP Server List, Vendor Options, Max Solicit Timeout Value, Max Information-Request Timeout Value
    GenericParseFailure(Vendor Class): OptVendorClass{enterprisenum=3561, data=[, , , , , , ]}, Error=buffer too short at position 6: have 12 bytes, want 3072 bytes
    IAPD: {IAID=[0 0 0 0], t1=0s, t2=0s, Options=[{[]}]}
  ]
```