### PR TITLE
Add Additional IANA Architecture Types

### DIFF
--- a/iana/archtype.go
+++ b/iana/archtype.go
@@ -10,7 +10,7 @@ import (
 // Arch encodes an architecture type per RFC 4578, Section 2.1.
 type Arch uint16
 
-// See RFC 4578.
+// See RFC 4578, 5970, and http://www.iana.org/assignments/dhcpv6-parameters/dhcpv6-parameters.xhtml#processor-architecture
 const (
 	INTEL_X86PC       Arch = 0
 	NEC_PC98          Arch = 1
@@ -19,9 +19,36 @@ const (
 	ARC_X86           Arch = 4
 	INTEL_LEAN_CLIENT Arch = 5
 	EFI_IA32          Arch = 6
-	EFI_BC            Arch = 7
+	EFI_X86_64        Arch = 7
 	EFI_XSCALE        Arch = 8
-	EFI_X86_64        Arch = 9
+	EFI_BC            Arch = 9
+	EFI_ARM32         Arch = 10
+	EFI_ARM64         Arch = 11
+	PPC_OPEN_FIRMWARE Arch = 12
+	PPC_EPAPR         Arch = 13
+	PPC_OPAL          Arch = 14
+	EFI_X86_HTTP      Arch = 15
+	EFI_X86_64_HTTP   Arch = 16
+	EFI_BC_HTTP       Arch = 17
+	EFI_ARM32_HTTP    Arch = 18
+	EFI_ARM64_HTTP    Arch = 19
+	INTEL_X86PC_HTTP  Arch = 20
+	UBOOT_ARM32       Arch = 21
+	UBOOT_ARM64       Arch = 22
+	UBOOT_ARM32_HTTP  Arch = 23
+	UBOOT_ARM64_HTTP  Arch = 24
+	EFI_RISCV32       Arch = 25
+	EFI_RISCV32_HTTP  Arch = 26
+	EFI_RISCV64       Arch = 27
+	EFI_RISCV64_HTTP  Arch = 28
+	EFI_RISCV128      Arch = 29
+	EFI_RISCV128_HTTP Arch = 30
+	S390_BASIC        Arch = 31
+	S390_EXTENDED     Arch = 32
+	EFI_MIPS32        Arch = 33
+	EFI_MIPS64        Arch = 34
+	EFI_SUNWAY32      Arch = 35
+	EFI_SUNWAY64      Arch = 36
 )
 
 // archTypeToStringMap maps an Arch to a mnemonic name
@@ -33,9 +60,36 @@ var archTypeToStringMap = map[Arch]string{
 	ARC_X86:           "Arc x86",
 	INTEL_LEAN_CLIENT: "Intel Lean Client",
 	EFI_IA32:          "EFI IA32",
-	EFI_BC:            "EFI BC",
 	EFI_XSCALE:        "EFI Xscale",
 	EFI_X86_64:        "EFI x86-64",
+	EFI_BC:            "EFI BC",
+	EFI_ARM32:         "EFI ARM32",
+	EFI_ARM64:         "EFI ARM64",
+	PPC_OPEN_FIRMWARE: "PowerPC Open Firmware",
+	PPC_EPAPR:         "PowerPC ePAPR",
+	PPC_OPAL:          "POWER OPAL v3",
+	EFI_X86_HTTP:      "EFI x86 boot from HTTP",
+	EFI_X86_64_HTTP:   "EFI x86-64 boot from HTTP",
+	EFI_BC_HTTP:       "EFI BC boot from HTTP",
+	EFI_ARM32_HTTP:    "EFI ARM32 boot from HTTP",
+	EFI_ARM64_HTTP:    "EFI ARM64 boot from HTTP",
+	INTEL_X86PC_HTTP:  "Intel x86PC boot from HTTP",
+	UBOOT_ARM32:       "U-Boot ARM32",
+	UBOOT_ARM64:       "U-Boot ARM64",
+	UBOOT_ARM32_HTTP:  "U-boot ARM32 boot from HTTP",
+	UBOOT_ARM64_HTTP:  "U-Boot ARM64 boot from HTTP",
+	EFI_RISCV32:       "EFI RISC-V 32-bit",
+	EFI_RISCV32_HTTP:  "EFI RISC-V 32-bit boot from HTTP",
+	EFI_RISCV64:       "EFI RISC-V 64-bit",
+	EFI_RISCV64_HTTP:  "EFI RISC-V 64-bit boot from HTTP",
+	EFI_RISCV128:      "EFI RISC-V 128-bit",
+	EFI_RISCV128_HTTP: "EFI RISC-V 128-bit boot from HTTP",
+	S390_BASIC:        "s390 Basic",
+	S390_EXTENDED:     "s390 Extended",
+	EFI_MIPS32:        "EFI MIPS32",
+	EFI_MIPS64:        "EFI MIPS64",
+	EFI_SUNWAY32:      "EFI Sunway 32-bit",
+	EFI_SUNWAY64:      "EFI Sunway 64-bit",
 }
 
 // String returns a mnemonic name for a given architecture type.


### PR DESCRIPTION
Adds the additional architecture types as defined by IANA
http://www.iana.org/assignments/dhcpv6-parameters/dhcpv6-parameters.xhtml#processor-architecture.

Note, RFC4578 errata, https://www.rfc-editor.org/errata_search.php?rfc=4578

"The values for EFI BC and EFI x86-64 should be swapped. UEFI implementations use value 7 to report EFI x86-64, not value 9."

IANA's list also agrees with this swap. Thus I've swapped these values here to match.

I took some liberty with the new architecture's mnemonic names compared to the descriptions from IANA. This was an attempt to standardize wording, capitalization, and match the existing style.