### PR TITLE
Abort parsing options with 0 length

### DIFF
--- a/dhcpv6/options.go
+++ b/dhcpv6/options.go
@@ -201,6 +201,11 @@ func (o *Options) FromBytesWithParser(data []byte, parser OptionParser) error {
 		code := OptionCode(buf.Read16())
 		length := int(buf.Read16())
 
+		// Abort trying to parse options with zero length
+		if length <= 0 {
+			return nil
+		}
+
 		// Consume, but do not Copy. Each parser will make a copy of
 		// pertinent data.
 		optData := buf.Consume(length)


### PR DESCRIPTION
Found a case where DNSmasq sends an option with length set to zero which causes the parser to error on the packet. Does seem redundant to send a zero length option, however it seemed pragmatic to add a guard against parsing them which avoids  failing on the packet.

Cannot find anything in the RFC that explicitly says an option with length set to zero is invalid