### PR TITLE
Pad packets after the 'end' option to be more conformant

### DIFF
--- a/dhcpv4/async/client.go
+++ b/dhcpv4/async/client.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	promise "github.com/fanliao/go-promise"
-	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/insomniacslk/dhcp/dhcpv4/client4"
+	"github.com/xcllnt/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4/client4"
 )
 
 // Default ports
@@ -22,7 +22,7 @@ const (
 // Client implements an asynchronous DHCPv4 client
 // It doesn't use the broadcast socket! Which means it should be used only when
 // the network is already established.
-// https://github.com/insomniacslk/dhcp/issues/143
+// https://github.com/xcllnt/dhcp/issues/143
 type Client struct {
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration

--- a/dhcpv4/async/client_test.go
+++ b/dhcpv4/async/client_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/insomniacslk/dhcp/dhcpv4/client4"
+	"github.com/xcllnt/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4/client4"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv4/bindtointerface.go
+++ b/dhcpv4/bindtointerface.go
@@ -1,7 +1,7 @@
 package dhcpv4
 
 import (
-	"github.com/insomniacslk/dhcp/interfaces"
+	"github.com/xcllnt/dhcp/interfaces"
 )
 
 // BindToInterface (deprecated) redirects to interfaces.BindToInterface

--- a/dhcpv4/bsdp/boot_image.go
+++ b/dhcpv4/bsdp/boot_image.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/xcllnt/dhcp/dhcpv4"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // BootImageType represents the different BSDP boot image types.

--- a/dhcpv4/bsdp/boot_image.go
+++ b/dhcpv4/bsdp/boot_image.go
@@ -3,7 +3,7 @@ package bsdp
 import (
 	"fmt"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 	"github.com/u-root/u-root/pkg/uio"
 )
 

--- a/dhcpv4/bsdp/boot_image_test.go
+++ b/dhcpv4/bsdp/boot_image_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 func TestBootImageIDToBytes(t *testing.T) {

--- a/dhcpv4/bsdp/bsdp.go
+++ b/dhcpv4/bsdp/bsdp.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 )
 
 // MaxDHCPMessageSize is the size set in DHCP option 57 (DHCP Maximum Message Size).

--- a/dhcpv4/bsdp/bsdp_option_boot_image_list.go
+++ b/dhcpv4/bsdp/bsdp_option_boot_image_list.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/xcllnt/dhcp/dhcpv4"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // BootImageList contains a list of boot images presented by a netboot server.

--- a/dhcpv4/bsdp/bsdp_option_boot_image_list.go
+++ b/dhcpv4/bsdp/bsdp_option_boot_image_list.go
@@ -3,7 +3,7 @@ package bsdp
 import (
 	"strings"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 	"github.com/u-root/u-root/pkg/uio"
 )
 

--- a/dhcpv4/bsdp/bsdp_option_message_type.go
+++ b/dhcpv4/bsdp/bsdp_option_message_type.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/xcllnt/dhcp/dhcpv4"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // MessageType represents the different BSDP message types.

--- a/dhcpv4/bsdp/bsdp_option_message_type.go
+++ b/dhcpv4/bsdp/bsdp_option_message_type.go
@@ -3,7 +3,7 @@ package bsdp
 import (
 	"fmt"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 	"github.com/u-root/u-root/pkg/uio"
 )
 

--- a/dhcpv4/bsdp/bsdp_option_misc.go
+++ b/dhcpv4/bsdp/bsdp_option_misc.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 	"github.com/u-root/u-root/pkg/uio"
 )
 

--- a/dhcpv4/bsdp/bsdp_option_misc.go
+++ b/dhcpv4/bsdp/bsdp_option_misc.go
@@ -5,7 +5,7 @@ import (
 	"net"
 
 	"github.com/xcllnt/dhcp/dhcpv4"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptReplyPort returns a new BSDP reply port option.

--- a/dhcpv4/bsdp/bsdp_option_misc_test.go
+++ b/dhcpv4/bsdp/bsdp_option_misc_test.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv4/bsdp/bsdp_test.go
+++ b/dhcpv4/bsdp/bsdp_test.go
@@ -4,8 +4,8 @@ import (
 	"net"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv4/bsdp/client.go
+++ b/dhcpv4/bsdp/client.go
@@ -3,8 +3,8 @@ package bsdp
 import (
 	"errors"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/insomniacslk/dhcp/dhcpv4/client4"
+	"github.com/xcllnt/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4/client4"
 )
 
 // Client represents a BSDP client that can perform BSDP exchanges via the

--- a/dhcpv4/bsdp/option_vendor_specific_information.go
+++ b/dhcpv4/bsdp/option_vendor_specific_information.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 )
 
 // VendorOptions is like dhcpv4.Options, but stringifies using BSDP-specific

--- a/dhcpv4/bsdp/option_vendor_specific_information_test.go
+++ b/dhcpv4/bsdp/option_vendor_specific_information_test.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv4/client4/client.go
+++ b/dhcpv4/client4/client.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/sys/unix"
 )

--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -17,7 +17,7 @@ package dhcpv4
 
 import (
 	"bytes"
-	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"net"
@@ -26,7 +26,6 @@ import (
 
 	"github.com/xcllnt/dhcp/iana"
 	"github.com/xcllnt/dhcp/rfc1035label"
-	"github.com/u-root/u-root/pkg/rand"
 	"github.com/u-root/u-root/pkg/uio"
 )
 
@@ -45,10 +44,6 @@ const (
 	// Per RFC 951, the minimum length of a packet is 300 bytes.
 	bootpMinLen = 300
 )
-
-// RandomTimeout is the amount of time to wait until random number generation
-// is canceled.
-var RandomTimeout = 2 * time.Minute
 
 // magicCookie is the magic 4-byte value at the beginning of the list of options
 // in a DHCPv4 packet.
@@ -120,9 +115,7 @@ func GetExternalIPv4Addrs(addrs []net.Addr) ([]net.IP, error) {
 // TransactionID
 func GenerateTransactionID() (TransactionID, error) {
 	var xid TransactionID
-	ctx, cancel := context.WithTimeout(context.Background(), RandomTimeout)
-	defer cancel()
-	n, err := rand.ReadContext(ctx, xid[:])
+	n, err := rand.Read(xid[:])
 	if err != nil {
 		return xid, fmt.Errorf("could not get random number: %v", err)
 	}

--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -520,20 +520,18 @@ func (d *DHCPv4) ToBytes() []byte {
 	// Write all options.
 	d.Options.Marshal(buf)
 
+	// Finish the options.
+	buf.Write8(OptionEnd.Code())
+
 	// DHCP is based on BOOTP, and BOOTP messages have a minimum length of
 	// 300 bytes per RFC 951. This not stated explicitly, but if you sum up
 	// all the bytes in the message layout, you'll get 300 bytes.
 	//
 	// Some DHCP servers and relay agents care about this BOOTP legacy B.S.
 	// and "conveniently" drop messages that are less than 300 bytes long.
-	//
-	// We subtract one byte for the OptionEnd option.
-	if buf.Len()+1 < bootpMinLen {
-		buf.WriteBytes(bytes.Repeat([]byte{OptionPad.Code()}, bootpMinLen-1-buf.Len()))
+	if buf.Len() < bootpMinLen {
+		buf.WriteBytes(bytes.Repeat([]byte{OptionPad.Code()}, bootpMinLen-buf.Len()))
 	}
-
-	// Finish the packet.
-	buf.Write8(OptionEnd.Code())
 
 	return buf.Data()
 }

--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/xcllnt/dhcp/iana"
 	"github.com/xcllnt/dhcp/rfc1035label"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 const (

--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/insomniacslk/dhcp/iana"
-	"github.com/insomniacslk/dhcp/rfc1035label"
+	"github.com/xcllnt/dhcp/iana"
+	"github.com/xcllnt/dhcp/rfc1035label"
 	"github.com/u-root/u-root/pkg/rand"
 	"github.com/u-root/u-root/pkg/uio"
 )

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/xcllnt/dhcp/iana"
 	"github.com/stretchr/testify/require"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 func TestGetExternalIPv4Addrs(t *testing.T) {

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/stretchr/testify/require"
 	"github.com/u-root/u-root/pkg/uio"
 )

--- a/dhcpv4/modifiers.go
+++ b/dhcpv4/modifiers.go
@@ -4,8 +4,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/insomniacslk/dhcp/iana"
-	"github.com/insomniacslk/dhcp/rfc1035label"
+	"github.com/xcllnt/dhcp/iana"
+	"github.com/xcllnt/dhcp/rfc1035label"
 )
 
 // WithTransactionID sets the Transaction ID for the DHCPv4 packet

--- a/dhcpv4/nclient4/client.go
+++ b/dhcpv4/nclient4/client.go
@@ -22,7 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 )
 
 const (

--- a/dhcpv4/nclient4/client_test.go
+++ b/dhcpv4/nclient4/client_test.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	"github.com/hugelgupf/socketpair"
-	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/insomniacslk/dhcp/dhcpv4/server4"
+	"github.com/xcllnt/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4/server4"
 )
 
 type handler struct {

--- a/dhcpv4/nclient4/conn_linux.go
+++ b/dhcpv4/nclient4/conn_linux.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/mdlayher/ethernet"
 	"github.com/mdlayher/raw"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 var (

--- a/dhcpv4/nclient4/ipv4.go
+++ b/dhcpv4/nclient4/ipv4.go
@@ -22,7 +22,7 @@ import (
 	"encoding/binary"
 	"net"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 const (

--- a/dhcpv4/nclient4/lease.go
+++ b/dhcpv4/nclient4/lease.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 )
 
 // Lease contains a DHCPv4 lease after DORA.

--- a/dhcpv4/nclient4/lease_test.go
+++ b/dhcpv4/nclient4/lease_test.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/hugelgupf/socketpair"
-	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/insomniacslk/dhcp/dhcpv4/server4"
+	"github.com/xcllnt/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4/server4"
 )
 
 type testLeaseKey struct {

--- a/dhcpv4/option_ip.go
+++ b/dhcpv4/option_ip.go
@@ -3,7 +3,7 @@ package dhcpv4
 import (
 	"net"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // IP implements DHCPv4 IP option marshaling and unmarshaling as described by

--- a/dhcpv4/option_ip_address_lease_time.go
+++ b/dhcpv4/option_ip_address_lease_time.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // MaxLeaseTime is the maximum lease time that can be encoded.

--- a/dhcpv4/option_ips.go
+++ b/dhcpv4/option_ips.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // IPs are IPv4 addresses from a DHCP packet as used and specified by options

--- a/dhcpv4/option_maximum_dhcp_message_size.go
+++ b/dhcpv4/option_maximum_dhcp_message_size.go
@@ -3,7 +3,7 @@ package dhcpv4
 import (
 	"fmt"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // Uint16 implements encoding and decoding functions for a uint16 as used in

--- a/dhcpv4/option_misc.go
+++ b/dhcpv4/option_misc.go
@@ -1,8 +1,8 @@
 package dhcpv4
 
 import (
-	"github.com/insomniacslk/dhcp/iana"
-	"github.com/insomniacslk/dhcp/rfc1035label"
+	"github.com/xcllnt/dhcp/iana"
+	"github.com/xcllnt/dhcp/rfc1035label"
 )
 
 // OptDomainSearch returns a new domain search option.

--- a/dhcpv4/option_misc_test.go
+++ b/dhcpv4/option_misc_test.go
@@ -3,8 +3,8 @@ package dhcpv4
 import (
 	"testing"
 
-	"github.com/insomniacslk/dhcp/iana"
-	"github.com/insomniacslk/dhcp/rfc1035label"
+	"github.com/xcllnt/dhcp/iana"
+	"github.com/xcllnt/dhcp/rfc1035label"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv4/option_parameter_request_list.go
+++ b/dhcpv4/option_parameter_request_list.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptionCodeList is a list of DHCP option codes.

--- a/dhcpv4/option_routes.go
+++ b/dhcpv4/option_routes.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // Route is a classless static route as per RFC 3442.

--- a/dhcpv4/option_strings.go
+++ b/dhcpv4/option_strings.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // Strings represents an option encapsulating a list of strings in IPv4 DHCP as

--- a/dhcpv4/option_subnet_mask.go
+++ b/dhcpv4/option_subnet_mask.go
@@ -3,7 +3,7 @@ package dhcpv4
 import (
 	"net"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // IPMask represents an option encapsulating the subnet mask.

--- a/dhcpv4/option_vivc.go
+++ b/dhcpv4/option_vivc.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // VIVCIdentifier implements the vendor-identifying vendor class option

--- a/dhcpv4/options.go
+++ b/dhcpv4/options.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/xcllnt/dhcp/iana"
 	"github.com/xcllnt/dhcp/rfc1035label"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 var (

--- a/dhcpv4/options.go
+++ b/dhcpv4/options.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/insomniacslk/dhcp/iana"
-	"github.com/insomniacslk/dhcp/rfc1035label"
+	"github.com/xcllnt/dhcp/iana"
+	"github.com/xcllnt/dhcp/rfc1035label"
 	"github.com/u-root/u-root/pkg/uio"
 )
 

--- a/dhcpv4/options_test.go
+++ b/dhcpv4/options_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 func TestParseOption(t *testing.T) {

--- a/dhcpv4/server4/conn.go
+++ b/dhcpv4/server4/conn.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 	"golang.org/x/sys/unix"
 )
 

--- a/dhcpv4/server4/logger.go
+++ b/dhcpv4/server4/logger.go
@@ -1,7 +1,7 @@
 package server4
 
 import (
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 )
 
 // Logger is a handler which will be used to output logging messages

--- a/dhcpv4/server4/logger_test.go
+++ b/dhcpv4/server4/logger_test.go
@@ -5,7 +5,7 @@ import(
 	"os"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv4/server4/server.go
+++ b/dhcpv4/server4/server.go
@@ -26,8 +26,8 @@
 //		"log"
 //		"net"
 //
-//		"github.com/insomniacslk/dhcp/dhcpv4"
-//		"github.com/insomniacslk/dhcp/dhcpv4/server4"
+//		"github.com/xcllnt/dhcp/dhcpv4"
+//		"github.com/xcllnt/dhcp/dhcpv4/server4"
 //	)
 //
 //	func handler(conn net.PacketConn, peer net.Addr, m *dhcpv4.DHCPv4) {
@@ -57,7 +57,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 )
 
 // Handler is a type that defines the handler function to be called every time a

--- a/dhcpv4/server4/server_test.go
+++ b/dhcpv4/server4/server_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/insomniacslk/dhcp/dhcpv4/nclient4"
-	"github.com/insomniacslk/dhcp/interfaces"
+	"github.com/xcllnt/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4/nclient4"
+	"github.com/xcllnt/dhcp/interfaces"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv4/types.go
+++ b/dhcpv4/types.go
@@ -3,7 +3,7 @@ package dhcpv4
 import (
 	"fmt"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // values from http://www.networksorcery.com/enp/protocol/dhcp.htm and

--- a/dhcpv4/ztpv4/parse_circuitid.go
+++ b/dhcpv4/ztpv4/parse_circuitid.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 )
 
 // CircuitID represents the structure of network vendor interface formats

--- a/dhcpv4/ztpv4/parse_circuitid_test.go
+++ b/dhcpv4/ztpv4/parse_circuitid_test.go
@@ -3,7 +3,7 @@ package ztpv4
 import (
 	"testing"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv4/ztpv4/ztp.go
+++ b/dhcpv4/ztpv4/ztp.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 )
 
 // VendorData is optional data a particular vendor may or may not include

--- a/dhcpv4/ztpv4/ztp_test.go
+++ b/dhcpv4/ztpv4/ztp_test.go
@@ -3,7 +3,7 @@ package ztpv4
 import (
 	"testing"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/async/client.go
+++ b/dhcpv6/async/client.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	promise "github.com/fanliao/go-promise"
-	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/insomniacslk/dhcp/dhcpv6/client6"
+	"github.com/xcllnt/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6/client6"
 )
 
 // Client implements an asynchronous DHCPv6 client

--- a/dhcpv6/async/client_test.go
+++ b/dhcpv6/async/client_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/insomniacslk/dhcp/dhcpv6/client6"
+	"github.com/xcllnt/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6/client6"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/client6/client.go
+++ b/dhcpv6/client6/client.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6"
 )
 
 // Client constants

--- a/dhcpv6/dhcpv6.go
+++ b/dhcpv6/dhcpv6.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/u-root/u-root/pkg/uio"
 )
 

--- a/dhcpv6/dhcpv6.go
+++ b/dhcpv6/dhcpv6.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/xcllnt/dhcp/iana"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 type DHCPv6 interface {

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -1,6 +1,7 @@
 package dhcpv6
 
 import (
+	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"net"
@@ -10,7 +11,6 @@ import (
 	"github.com/xcllnt/dhcp/iana"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/u-root/u-root/pkg/rand"
 )
 
 func randomReadMock(value []byte, n int, err error) func([]byte) (int, error) {

--- a/dhcpv6/dhcpv6_test.go
+++ b/dhcpv6/dhcpv6_test.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/u-root/u-root/pkg/rand"

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -6,8 +6,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/insomniacslk/dhcp/iana"
-	"github.com/insomniacslk/dhcp/rfc1035label"
+	"github.com/xcllnt/dhcp/iana"
+	"github.com/xcllnt/dhcp/rfc1035label"
 	"github.com/u-root/u-root/pkg/rand"
 	"github.com/u-root/u-root/pkg/uio"
 )

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -1,6 +1,7 @@
 package dhcpv6
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"net"
@@ -8,7 +9,6 @@ import (
 
 	"github.com/xcllnt/dhcp/iana"
 	"github.com/xcllnt/dhcp/rfc1035label"
-	"github.com/u-root/u-root/pkg/rand"
 	"github.com/u-root/u-root/pkg/uio"
 )
 

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/xcllnt/dhcp/iana"
 	"github.com/xcllnt/dhcp/rfc1035label"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 const MessageHeaderSize = 4

--- a/dhcpv6/dhcpv6relay.go
+++ b/dhcpv6/dhcpv6relay.go
@@ -6,7 +6,7 @@ import (
 	"net"
 
 	"github.com/xcllnt/dhcp/iana"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 const RelayHeaderSize = 34

--- a/dhcpv6/dhcpv6relay.go
+++ b/dhcpv6/dhcpv6relay.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/u-root/u-root/pkg/uio"
 )
 

--- a/dhcpv6/duid.go
+++ b/dhcpv6/duid.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 )
 
 // DuidType is the DUID type as defined in rfc3315.

--- a/dhcpv6/duid_test.go
+++ b/dhcpv6/duid_test.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/iputils_test.go
+++ b/dhcpv6/iputils_test.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/dhcpv6/modifiers.go
+++ b/dhcpv6/modifiers.go
@@ -4,8 +4,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/insomniacslk/dhcp/iana"
-	"github.com/insomniacslk/dhcp/rfc1035label"
+	"github.com/xcllnt/dhcp/iana"
+	"github.com/xcllnt/dhcp/rfc1035label"
 )
 
 // WithOption adds the specific option to the DHCPv6 message.

--- a/dhcpv6/modifiers_test.go
+++ b/dhcpv6/modifiers_test.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/nclient6/client.go
+++ b/dhcpv6/nclient6/client.go
@@ -17,7 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6"
 )
 
 // Broadcast destination IP addresses as defined by RFC 3315

--- a/dhcpv6/nclient6/client_test.go
+++ b/dhcpv6/nclient6/client_test.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	"github.com/hugelgupf/socketpair"
-	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/insomniacslk/dhcp/dhcpv6/server6"
+	"github.com/xcllnt/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6/server6"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/option_4rd.go
+++ b/dhcpv6/option_4rd.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // Opt4RD represents a 4RD option. It is only a container for 4RD_*_RULE options

--- a/dhcpv6/option_archtype.go
+++ b/dhcpv6/option_archtype.go
@@ -3,7 +3,7 @@ package dhcpv6
 import (
 	"fmt"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 )
 
 // OptClientArchType represents an option CLIENT_ARCH_TYPE.

--- a/dhcpv6/option_archtype_test.go
+++ b/dhcpv6/option_archtype_test.go
@@ -3,7 +3,7 @@ package dhcpv6
 import (
 	"testing"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/option_bootfileparam.go
+++ b/dhcpv6/option_bootfileparam.go
@@ -3,7 +3,7 @@ package dhcpv6
 import (
 	"fmt"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptBootFileParam returns a BootfileParam option as defined in RFC 5970

--- a/dhcpv6/option_clientid_test.go
+++ b/dhcpv6/option_clientid_test.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/option_clientlinklayeraddress.go
+++ b/dhcpv6/option_clientlinklayeraddress.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/u-root/u-root/pkg/uio"
 )
 

--- a/dhcpv6/option_clientlinklayeraddress.go
+++ b/dhcpv6/option_clientlinklayeraddress.go
@@ -5,7 +5,7 @@ import (
 	"net"
 
 	"github.com/xcllnt/dhcp/iana"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptClientLinkLayerAddress implements OptionClientLinkLayerAddr option.

--- a/dhcpv6/option_clientlinklayeraddress_test.go
+++ b/dhcpv6/option_clientlinklayeraddress_test.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/option_dhcpv4_msg.go
+++ b/dhcpv6/option_dhcpv4_msg.go
@@ -3,7 +3,7 @@ package dhcpv6
 import (
 	"fmt"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4"
 )
 
 // OptDHCPv4Msg represents a OptionDHCPv4Msg option

--- a/dhcpv6/option_dhcpv4_msg_test.go
+++ b/dhcpv6/option_dhcpv4_msg_test.go
@@ -5,8 +5,8 @@ import (
 	"net"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/option_dhcpv4_o_dhcpv6_server.go
+++ b/dhcpv6/option_dhcpv4_o_dhcpv6_server.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptDHCP4oDHCP6Server represents a OptionDHCP4oDHCP6Server option

--- a/dhcpv6/option_dns.go
+++ b/dhcpv6/option_dns.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptDNS returns a DNS Recursive Name Server option as defined by RFC 3646.

--- a/dhcpv6/option_domainsearchlist.go
+++ b/dhcpv6/option_domainsearchlist.go
@@ -3,7 +3,7 @@ package dhcpv6
 import (
 	"fmt"
 
-	"github.com/insomniacslk/dhcp/rfc1035label"
+	"github.com/xcllnt/dhcp/rfc1035label"
 )
 
 // OptDomainSearchList returns a DomainSearchList option as defined by RFC 3646.

--- a/dhcpv6/option_domainsearchlist_test.go
+++ b/dhcpv6/option_domainsearchlist_test.go
@@ -3,7 +3,7 @@ package dhcpv6
 import (
 	"testing"
 
-	"github.com/insomniacslk/dhcp/rfc1035label"
+	"github.com/xcllnt/dhcp/rfc1035label"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/option_elapsedtime.go
+++ b/dhcpv6/option_elapsedtime.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptElapsedTime returns an Elapsed Time option as defined by RFC 3315 Section

--- a/dhcpv6/option_fqdn.go
+++ b/dhcpv6/option_fqdn.go
@@ -3,7 +3,7 @@ package dhcpv6
 import (
 	"fmt"
 
-	"github.com/insomniacslk/dhcp/rfc1035label"
+	"github.com/xcllnt/dhcp/rfc1035label"
 	"github.com/u-root/u-root/pkg/uio"
 )
 

--- a/dhcpv6/option_fqdn.go
+++ b/dhcpv6/option_fqdn.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/xcllnt/dhcp/rfc1035label"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptFQDN implements OptionFQDN option.

--- a/dhcpv6/option_fqdn_test.go
+++ b/dhcpv6/option_fqdn_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/rfc1035label"
+	"github.com/xcllnt/dhcp/rfc1035label"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/option_iaaddress.go
+++ b/dhcpv6/option_iaaddress.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // AddressOptions are options valid for the IAAddress option field.

--- a/dhcpv6/option_iapd.go
+++ b/dhcpv6/option_iapd.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // PDOptions are options used with the IAPD (prefix delegation) option.

--- a/dhcpv6/option_iaprefix.go
+++ b/dhcpv6/option_iaprefix.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // PrefixOptions are the options valid for use with IAPrefix option field.

--- a/dhcpv6/option_informationrefreshtime.go
+++ b/dhcpv6/option_informationrefreshtime.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptInformationRefreshTime implements OptionInformationRefreshTime option.

--- a/dhcpv6/option_nii.go
+++ b/dhcpv6/option_nii.go
@@ -3,7 +3,7 @@ package dhcpv6
 import (
 	"fmt"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // NetworkInterfaceType is the NIC type as defined by RFC 4578 Section 2.2

--- a/dhcpv6/option_nontemporaryaddress.go
+++ b/dhcpv6/option_nontemporaryaddress.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // Duration is a duration as embedded in IA messages (IAPD, IANA, IATA).

--- a/dhcpv6/option_remoteid.go
+++ b/dhcpv6/option_remoteid.go
@@ -3,7 +3,7 @@ package dhcpv6
 import (
 	"fmt"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptRemoteID implemens the Remote ID option as defined by RFC 4649.

--- a/dhcpv6/option_requestedoption.go
+++ b/dhcpv6/option_requestedoption.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptionCodes are a collection of option codes.

--- a/dhcpv6/option_serverid_test.go
+++ b/dhcpv6/option_serverid_test.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/option_statuscode.go
+++ b/dhcpv6/option_statuscode.go
@@ -3,7 +3,7 @@ package dhcpv6
 import (
 	"fmt"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/u-root/u-root/pkg/uio"
 )
 

--- a/dhcpv6/option_statuscode.go
+++ b/dhcpv6/option_statuscode.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/xcllnt/dhcp/iana"
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptStatusCode represents a DHCPv6 Status Code option

--- a/dhcpv6/option_statuscode_test.go
+++ b/dhcpv6/option_statuscode_test.go
@@ -3,7 +3,7 @@ package dhcpv6
 import (
 	"testing"
 
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/iana"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/option_temporaryaddress.go
+++ b/dhcpv6/option_temporaryaddress.go
@@ -3,7 +3,7 @@ package dhcpv6
 import (
 	"fmt"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptIATA implements the identity association for non-temporary addresses

--- a/dhcpv6/option_userclass.go
+++ b/dhcpv6/option_userclass.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptUserClass represent a DHCPv6 User Class option

--- a/dhcpv6/option_vendor_opts.go
+++ b/dhcpv6/option_vendor_opts.go
@@ -3,7 +3,7 @@ package dhcpv6
 import (
 	"fmt"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptVendorOpts represents a DHCPv6 Status Code option

--- a/dhcpv6/option_vendorclass.go
+++ b/dhcpv6/option_vendorclass.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // OptVendorClass represents a DHCPv6 Vendor Class option

--- a/dhcpv6/options.go
+++ b/dhcpv6/options.go
@@ -3,7 +3,7 @@ package dhcpv6
 import (
 	"fmt"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // Option is an interface that all DHCPv6 options adhere to.

--- a/dhcpv6/server6/conn.go
+++ b/dhcpv6/server6/conn.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/insomniacslk/dhcp/interfaces"
+	"github.com/xcllnt/dhcp/interfaces"
 	"golang.org/x/sys/unix"
 )
 

--- a/dhcpv6/server6/logger.go
+++ b/dhcpv6/server6/logger.go
@@ -1,7 +1,7 @@
 package server6
 
 import (
-	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6"
 )
 
 // Logger is a handler which will be used to output logging messages

--- a/dhcpv6/server6/logger_test.go
+++ b/dhcpv6/server6/logger_test.go
@@ -5,7 +5,7 @@ import(
 	"os"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/server6/server.go
+++ b/dhcpv6/server6/server.go
@@ -26,8 +26,8 @@
 //		"log"
 //		"net"
 //
-//		"github.com/insomniacslk/dhcp/dhcpv6"
-//		"github.com/insomniacslk/dhcp/dhcpv6/server6"
+//		"github.com/xcllnt/dhcp/dhcpv6"
+//		"github.com/xcllnt/dhcp/dhcpv6/server6"
 //	)
 //
 //	func handler(conn net.PacketConn, peer net.Addr, m dhcpv6.DHCPv6) {
@@ -57,7 +57,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6"
 	"golang.org/x/net/ipv6"
 )
 

--- a/dhcpv6/server6/server_test.go
+++ b/dhcpv6/server6/server_test.go
@@ -6,9 +6,9 @@ import (
 	"net"
 	"testing"
 
-	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/insomniacslk/dhcp/dhcpv6/nclient6"
-	"github.com/insomniacslk/dhcp/interfaces"
+	"github.com/xcllnt/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6/nclient6"
+	"github.com/xcllnt/dhcp/interfaces"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/ztpv6/parse_remote_id.go
+++ b/dhcpv6/ztpv6/parse_remote_id.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6"
 )
 
 var (

--- a/dhcpv6/ztpv6/parse_remote_id_test.go
+++ b/dhcpv6/ztpv6/parse_remote_id_test.go
@@ -3,7 +3,7 @@ package ztpv6
 import (
 	"testing"
 
-	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6"
 	"github.com/stretchr/testify/require"
 )
 

--- a/dhcpv6/ztpv6/parse_vendor_options.go
+++ b/dhcpv6/ztpv6/parse_vendor_options.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6"
 )
 
 var (

--- a/dhcpv6/ztpv6/parse_vendor_options_test.go
+++ b/dhcpv6/ztpv6/parse_vendor_options_test.go
@@ -3,7 +3,7 @@ package ztpv6
 import (
 	"testing"
 
-	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6"
 	"github.com/stretchr/testify/require"
 )
 

--- a/examples/client6/main.go
+++ b/examples/client6/main.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/insomniacslk/dhcp/dhcpv6/client6"
+	"github.com/xcllnt/dhcp/dhcpv6/client6"
 )
 
 var (

--- a/examples/packetcrafting6/main.go
+++ b/examples/packetcrafting6/main.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"net"
 
-	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/insomniacslk/dhcp/iana"
+	"github.com/xcllnt/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/iana"
 )
 
 func main() {

--- a/examples/server6/main.go
+++ b/examples/server6/main.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"net"
 
-	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/insomniacslk/dhcp/dhcpv6/server6"
+	"github.com/xcllnt/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6/server6"
 )
 
 func handler(conn net.PacketConn, peer net.Addr, m dhcpv6.DHCPv6) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/insomniacslk/dhcp
+module github.com/xcllnt/dhcp
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/u-root/u-root v7.0.0+incompatible
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
 )

--- a/iana/archtype.go
+++ b/iana/archtype.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/xcllnt/dhcp/uio"
 )
 
 // Arch encodes an architecture type per RFC 4578, Section 2.1.

--- a/netboot/netboot.go
+++ b/netboot/netboot.go
@@ -6,10 +6,10 @@ import (
 	"log"
 	"time"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/insomniacslk/dhcp/dhcpv4/client4"
-	"github.com/insomniacslk/dhcp/dhcpv6"
-	"github.com/insomniacslk/dhcp/dhcpv6/client6"
+	"github.com/xcllnt/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv4/client4"
+	"github.com/xcllnt/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv6/client6"
 )
 
 var sleeper = func(d time.Duration) {

--- a/netboot/netconf.go
+++ b/netboot/netconf.go
@@ -10,8 +10,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv6"
 	"github.com/jsimonetti/rtnetlink"
 	"github.com/jsimonetti/rtnetlink/rtnl"
 	"github.com/mdlayher/netlink"

--- a/netboot/netconf_test.go
+++ b/netboot/netconf_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/xcllnt/dhcp/dhcpv4"
+	"github.com/xcllnt/dhcp/dhcpv6"
 	"github.com/stretchr/testify/require"
 )
 

--- a/uio/LICENSE
+++ b/uio/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2012-2019, u-root Authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/uio/alignreader.go
+++ b/uio/alignreader.go
@@ -1,0 +1,41 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uio
+
+import (
+	"io"
+)
+
+// AlignReader keeps track of how many bytes were read so the reader can be
+// aligned at a future time.
+type AlignReader struct {
+	R io.Reader
+	N int
+}
+
+// Read reads from the underlying io.Reader.
+func (r *AlignReader) Read(b []byte) (int, error) {
+	n, err := r.R.Read(b)
+	r.N += n
+	return n, err
+}
+
+// ReadByte reads one byte from the underlying io.Reader.
+func (r *AlignReader) ReadByte() (byte, error) {
+	b := make([]byte, 1)
+	_, err := io.ReadFull(r, b)
+	return b[0], err
+}
+
+// Align aligns the reader to the given number of bytes and returns the
+// bytes read to pad it.
+func (r *AlignReader) Align(n int) ([]byte, error) {
+	if r.N%n == 0 {
+		return []byte{}, nil
+	}
+	pad := make([]byte, n-r.N%n)
+	m, err := io.ReadFull(r, pad)
+	return pad[:m], err
+}

--- a/uio/alignwriter.go
+++ b/uio/alignwriter.go
@@ -1,0 +1,34 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uio
+
+import (
+	"bytes"
+	"io"
+)
+
+// AlignWriter keeps track of how many bytes were written so the writer can be
+// aligned at a future time.
+type AlignWriter struct {
+	W io.Writer
+	N int
+}
+
+// Write writes to the underlying io.Writew.
+func (w *AlignWriter) Write(b []byte) (int, error) {
+	n, err := w.W.Write(b)
+	w.N += n
+	return n, err
+}
+
+// Align aligns the writer to the given number of bytes using the given pad
+// value.
+func (w *AlignWriter) Align(n int, pad byte) error {
+	if w.N%n == 0 {
+		return nil
+	}
+	_, err := w.Write(bytes.Repeat([]byte{pad}, n-w.N%n))
+	return err
+}

--- a/uio/buffer.go
+++ b/uio/buffer.go
@@ -1,0 +1,361 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uio
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Marshaler is the interface implemented by an object that can marshal itself
+// into binary form.
+//
+// Marshal appends data to the buffer b.
+type Marshaler interface {
+	Marshal(l *Lexer)
+}
+
+// Unmarshaler is the interface implemented by an object that can unmarshal a
+// binary representation of itself.
+//
+// Unmarshal Consumes data from the buffer b.
+type Unmarshaler interface {
+	Unmarshal(l *Lexer) error
+}
+
+// ToBytes marshals m in the given byte order.
+func ToBytes(m Marshaler, order binary.ByteOrder) []byte {
+	l := NewLexer(NewBuffer(nil), order)
+	m.Marshal(l)
+	return l.Data()
+}
+
+// FromBytes unmarshals b into obj in the given byte order.
+func FromBytes(obj Unmarshaler, b []byte, order binary.ByteOrder) error {
+	l := NewLexer(NewBuffer(b), order)
+	return obj.Unmarshal(l)
+}
+
+// ToBigEndian marshals m to big endian byte order.
+func ToBigEndian(m Marshaler) []byte {
+	l := NewBigEndianBuffer(nil)
+	m.Marshal(l)
+	return l.Data()
+}
+
+// FromBigEndian unmarshals b into obj in big endian byte order.
+func FromBigEndian(obj Unmarshaler, b []byte) error {
+	l := NewBigEndianBuffer(b)
+	return obj.Unmarshal(l)
+}
+
+// ToLittleEndian marshals m to little endian byte order.
+func ToLittleEndian(m Marshaler) []byte {
+	l := NewLittleEndianBuffer(nil)
+	m.Marshal(l)
+	return l.Data()
+}
+
+// FromLittleEndian unmarshals b into obj in little endian byte order.
+func FromLittleEndian(obj Unmarshaler, b []byte) error {
+	l := NewLittleEndianBuffer(b)
+	return obj.Unmarshal(l)
+}
+
+// Buffer implements functions to manipulate byte slices in a zero-copy way.
+type Buffer struct {
+	// data is the underlying data.
+	data []byte
+
+	// byteCount keeps track of how many bytes have been consumed for
+	// debugging.
+	byteCount int
+}
+
+// NewBuffer Consumes b for marshaling or unmarshaling in the given byte order.
+func NewBuffer(b []byte) *Buffer {
+	return &Buffer{data: b}
+}
+
+// Preallocate increases the capacity of the buffer by n bytes.
+func (b *Buffer) Preallocate(n int) {
+	b.data = append(b.data, make([]byte, 0, n)...)
+}
+
+// WriteN appends n bytes to the Buffer and returns a slice pointing to the
+// newly appended bytes.
+func (b *Buffer) WriteN(n int) []byte {
+	b.data = append(b.data, make([]byte, n)...)
+	return b.data[len(b.data)-n:]
+}
+
+// ReadN consumes n bytes from the Buffer. It returns nil, false if there
+// aren't enough bytes left.
+func (b *Buffer) ReadN(n int) ([]byte, error) {
+	if !b.Has(n) {
+		return nil, fmt.Errorf("buffer too short at position %d: have %d bytes, want %d bytes", b.byteCount, b.Len(), n)
+	}
+	rval := b.data[:n]
+	b.data = b.data[n:]
+	b.byteCount += n
+	return rval, nil
+}
+
+// Data is unConsumed data remaining in the Buffer.
+func (b *Buffer) Data() []byte {
+	return b.data
+}
+
+// Has returns true if n bytes are available.
+func (b *Buffer) Has(n int) bool {
+	return len(b.data) >= n
+}
+
+// Len returns the length of the remaining bytes.
+func (b *Buffer) Len() int {
+	return len(b.data)
+}
+
+// Cap returns the available capacity.
+func (b *Buffer) Cap() int {
+	return cap(b.data)
+}
+
+// Lexer is a convenient encoder/decoder for buffers.
+//
+// Use:
+//
+//   func (s *something) Unmarshal(l *Lexer) {
+//     s.Foo = l.Read8()
+//     s.Bar = l.Read8()
+//     s.Baz = l.Read16()
+//     return l.Error()
+//   }
+type Lexer struct {
+	*Buffer
+
+	// order is the byte order to write in / read in.
+	order binary.ByteOrder
+
+	// err
+	err error
+}
+
+// NewLexer returns a new coder for buffers.
+func NewLexer(b *Buffer, order binary.ByteOrder) *Lexer {
+	return &Lexer{
+		Buffer: b,
+		order:  order,
+	}
+}
+
+// NewLittleEndianBuffer returns a new little endian coder for a new buffer.
+func NewLittleEndianBuffer(b []byte) *Lexer {
+	return &Lexer{
+		Buffer: NewBuffer(b),
+		order:  binary.LittleEndian,
+	}
+}
+
+// NewBigEndianBuffer returns a new big endian coder for a new buffer.
+func NewBigEndianBuffer(b []byte) *Lexer {
+	return &Lexer{
+		Buffer: NewBuffer(b),
+		order:  binary.BigEndian,
+	}
+}
+
+func (l *Lexer) setError(err error) {
+	if l.err == nil {
+		l.err = err
+	}
+}
+
+// Consume returns a slice of the next n bytes from the buffer.
+//
+// Consume gives direct access to the underlying data.
+func (l *Lexer) Consume(n int) []byte {
+	v, err := l.Buffer.ReadN(n)
+	if err != nil {
+		l.setError(err)
+		return nil
+	}
+	return v
+}
+
+func (l *Lexer) append(n int) []byte {
+	return l.Buffer.WriteN(n)
+}
+
+// Error returns an error if an error occurred reading from the buffer.
+func (l *Lexer) Error() error {
+	return l.err
+}
+
+// FinError returns an error if an error occurred or if there is more data left
+// to read in the buffer.
+func (l *Lexer) FinError() error {
+	if l.err != nil {
+		return l.err
+	}
+	if l.Buffer.Len() > 0 {
+		return fmt.Errorf("buffer contains more bytes than it should")
+	}
+	return nil
+}
+
+// Read8 reads a byte from the Buffer.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) Read8() uint8 {
+	v := l.Consume(1)
+	if v == nil {
+		return 0
+	}
+	return uint8(v[0])
+}
+
+// Read16 reads a 16-bit value from the Buffer.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) Read16() uint16 {
+	v := l.Consume(2)
+	if v == nil {
+		return 0
+	}
+	return l.order.Uint16(v)
+}
+
+// Read32 reads a 32-bit value from the Buffer.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) Read32() uint32 {
+	v := l.Consume(4)
+	if v == nil {
+		return 0
+	}
+	return l.order.Uint32(v)
+}
+
+// Read64 reads a 64-bit value from the Buffer.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) Read64() uint64 {
+	v := l.Consume(8)
+	if v == nil {
+		return 0
+	}
+	return l.order.Uint64(v)
+}
+
+// CopyN returns a copy of the next n bytes.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) CopyN(n int) []byte {
+	v := l.Consume(n)
+	if v == nil {
+		return nil
+	}
+
+	p := make([]byte, n)
+	m := copy(p, v)
+	return p[:m]
+}
+
+// ReadAll Consumes and returns a copy of all remaining bytes in the Buffer.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) ReadAll() []byte {
+	return l.CopyN(l.Len())
+}
+
+// ReadBytes reads exactly len(p) values from the Buffer.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) ReadBytes(p []byte) {
+	copy(p, l.Consume(len(p)))
+}
+
+// Read implements io.Reader.Read.
+func (l *Lexer) Read(p []byte) (int, error) {
+	v := l.Consume(len(p))
+	if v == nil {
+		return 0, l.Error()
+	}
+	return copy(p, v), nil
+}
+
+// ReadData reads the binary representation of data from the buffer.
+//
+// See binary.Read.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) ReadData(data interface{}) {
+	l.setError(binary.Read(l, l.order, data))
+}
+
+// WriteData writes a binary representation of data to the buffer.
+//
+// See binary.Write.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) WriteData(data interface{}) {
+	l.setError(binary.Write(l, l.order, data))
+}
+
+// Write8 writes a byte to the Buffer.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) Write8(v uint8) {
+	l.append(1)[0] = byte(v)
+}
+
+// Write16 writes a 16-bit value to the Buffer.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) Write16(v uint16) {
+	l.order.PutUint16(l.append(2), v)
+}
+
+// Write32 writes a 32-bit value to the Buffer.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) Write32(v uint32) {
+	l.order.PutUint32(l.append(4), v)
+}
+
+// Write64 writes a 64-bit value to the Buffer.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) Write64(v uint64) {
+	l.order.PutUint64(l.append(8), v)
+}
+
+// Append returns a newly appended n-size Buffer to write to.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) Append(n int) []byte {
+	return l.append(n)
+}
+
+// WriteBytes writes p to the Buffer.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) WriteBytes(p []byte) {
+	copy(l.append(len(p)), p)
+}
+
+// Write implements io.Writer.Write.
+//
+// If an error occurred, Error() will return a non-nil error.
+func (l *Lexer) Write(p []byte) (int, error) {
+	return copy(l.append(len(p)), p), nil
+}
+
+// Align appends bytes to align the length of the buffer to be divisible by n.
+func (l *Lexer) Align(n int) {
+	pad := ((l.Len() + n - 1) &^ (n - 1)) - l.Len()
+	l.Append(pad)
+}

--- a/uio/cached.go
+++ b/uio/cached.go
@@ -1,0 +1,98 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uio
+
+import (
+	"bytes"
+	"io"
+)
+
+// CachingReader is a lazily caching wrapper of an io.Reader.
+//
+// The wrapped io.Reader is only read from on demand, not upfront.
+type CachingReader struct {
+	buf bytes.Buffer
+	r   io.Reader
+	pos int
+	eof bool
+}
+
+// NewCachingReader buffers reads from r.
+//
+// r is only read from when Read() is called.
+func NewCachingReader(r io.Reader) *CachingReader {
+	return &CachingReader{
+		r: r,
+	}
+}
+
+func (cr *CachingReader) read(p []byte) (int, error) {
+	n, err := cr.r.Read(p)
+	cr.buf.Write(p[:n])
+	if err == io.EOF || (n == 0 && err == nil) {
+		cr.eof = true
+		return n, io.EOF
+	}
+	return n, err
+}
+
+// NewReader returns a new io.Reader that reads cr from offset 0.
+func (cr *CachingReader) NewReader() io.Reader {
+	return Reader(cr)
+}
+
+// Read reads from cr; implementing io.Reader.
+//
+// TODO(chrisko): Decide whether to keep this or only keep NewReader().
+func (cr *CachingReader) Read(p []byte) (int, error) {
+	n, err := cr.ReadAt(p, int64(cr.pos))
+	cr.pos += n
+	return n, err
+}
+
+// ReadAt reads from cr; implementing io.ReaderAt.
+func (cr *CachingReader) ReadAt(p []byte, off int64) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	end := int(off) + len(p)
+
+	// Is the caller asking for some uncached bytes?
+	unread := end - cr.buf.Len()
+	if unread > 0 {
+		// Avoiding allocations: use `p` to read more bytes.
+		for unread > 0 {
+			toRead := unread % len(p)
+			if toRead == 0 {
+				toRead = len(p)
+			}
+
+			m, err := cr.read(p[:toRead])
+			unread -= m
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return 0, err
+			}
+		}
+	}
+
+	// If this is true, the entire file was read just to find out, but the
+	// offset is beyond the end of the file.
+	if off > int64(cr.buf.Len()) {
+		return 0, io.EOF
+	}
+
+	var err error
+	// Did the caller ask for more than was available?
+	//
+	// Note that any io.ReaderAt implementation *must* return an error for
+	// short reads.
+	if cr.eof && unread > 0 {
+		err = io.EOF
+	}
+	return copy(p, cr.buf.Bytes()[off:]), err
+}

--- a/uio/cached_test.go
+++ b/uio/cached_test.go
@@ -1,0 +1,244 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uio
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+)
+
+func TestCachingReaderRead(t *testing.T) {
+	type read struct {
+		// Buffer sizes to call Read with.
+		size int
+
+		// Buffer value corresponding Read(size) we want.
+		want []byte
+
+		// Error corresponding to Read(size) we want.
+		err error
+	}
+
+	for i, tt := range []struct {
+		// Content of the underlying io.Reader.
+		content []byte
+
+		// Read calls to make in order.
+		reads []read
+	}{
+		{
+			content: []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99},
+			reads: []read{
+				{
+					size: 0,
+				},
+				{
+					size: 1,
+					want: []byte{0x11},
+				},
+				{
+					size: 2,
+					want: []byte{0x22, 0x33},
+				},
+				{
+					size: 0,
+				},
+				{
+					size: 3,
+					want: []byte{0x44, 0x55, 0x66},
+				},
+				{
+					size: 4,
+					want: []byte{0x77, 0x88, 0x99},
+					err:  io.EOF,
+				},
+			},
+		},
+		{
+			content: []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99},
+			reads: []read{
+				{
+					size: 11,
+					want: []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99},
+					err:  io.EOF,
+				},
+			},
+		},
+		{
+			content: nil,
+			reads: []read{
+				{
+					size: 2,
+					err:  io.EOF,
+				},
+				{
+					size: 0,
+				},
+			},
+		},
+		{
+			content: []byte{0x33, 0x22, 0x11},
+			reads: []read{
+				{
+					size: 3,
+					want: []byte{0x33, 0x22, 0x11},
+					err:  nil,
+				},
+				{
+					size: 0,
+				},
+				{
+					size: 1,
+					err:  io.EOF,
+				},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("Test [%02d]", i), func(t *testing.T) {
+			buf := NewCachingReader(bytes.NewBuffer(tt.content))
+			for j, r := range tt.reads {
+				p := make([]byte, r.size)
+				m, err := buf.Read(p)
+				if err != r.err {
+					t.Errorf("Read#%d(%d) = %v, want %v", j, r.size, err, r.err)
+				}
+				if m != len(r.want) {
+					t.Errorf("Read#%d(%d) = %d, want %d", j, r.size, m, len(r.want))
+				}
+				if !bytes.Equal(r.want, p[:m]) {
+					t.Errorf("Read#%d(%d) = %v, want %v", j, r.size, p[:m], r.want)
+				}
+			}
+		})
+	}
+}
+
+func TestCachingReaderReadAt(t *testing.T) {
+	type readAt struct {
+		// Buffer sizes to call Read with.
+		size int
+
+		// Offset to read from.
+		off int64
+
+		// Buffer value corresponding Read(size) we want.
+		want []byte
+
+		// Error corresponding to Read(size) we want.
+		err error
+	}
+
+	for i, tt := range []struct {
+		// Content of the underlying io.Reader.
+		content []byte
+
+		// Read calls to make in order.
+		reads []readAt
+	}{
+		{
+			content: []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99},
+			reads: []readAt{
+				{
+					off:  0,
+					size: 0,
+				},
+				{
+					off:  0,
+					size: 1,
+					want: []byte{0x11},
+				},
+				{
+					off:  1,
+					size: 2,
+					want: []byte{0x22, 0x33},
+				},
+				{
+					off:  0,
+					size: 0,
+				},
+				{
+					off:  3,
+					size: 3,
+					want: []byte{0x44, 0x55, 0x66},
+				},
+				{
+					off:  6,
+					size: 4,
+					want: []byte{0x77, 0x88, 0x99},
+					err:  io.EOF,
+				},
+				{
+					off:  0,
+					size: 9,
+					want: []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99},
+				},
+				{
+					off:  0,
+					size: 10,
+					want: []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99},
+					err:  io.EOF,
+				},
+				{
+					off:  0,
+					size: 8,
+					want: []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
+				},
+			},
+		},
+		{
+			content: []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99},
+			reads: []readAt{
+				{
+					off:  10,
+					size: 10,
+					err:  io.EOF,
+				},
+				{
+					off:  5,
+					size: 4,
+					want: []byte{0x66, 0x77, 0x88, 0x99},
+				},
+			},
+		},
+		{
+			content: []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99},
+			reads: []readAt{
+				{
+					size: 9,
+					want: []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99},
+				},
+				{
+					off:  5,
+					size: 4,
+					want: []byte{0x66, 0x77, 0x88, 0x99},
+				},
+				{
+					off:  9,
+					size: 1,
+					err:  io.EOF,
+				},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("Test [%02d]", i), func(t *testing.T) {
+			buf := NewCachingReader(bytes.NewBuffer(tt.content))
+			for j, r := range tt.reads {
+				p := make([]byte, r.size)
+				m, err := buf.ReadAt(p, r.off)
+				if err != r.err {
+					t.Errorf("Read#%d(%d) = %v, want %v", j, r.size, err, r.err)
+				}
+				if m != len(r.want) {
+					t.Errorf("Read#%d(%d) = %d, want %d", j, r.size, m, len(r.want))
+				}
+				if !bytes.Equal(r.want, p[:m]) {
+					t.Errorf("Read#%d(%d) = %v, want %v", j, r.size, p[:m], r.want)
+				}
+			}
+		})
+	}
+}

--- a/uio/lazy.go
+++ b/uio/lazy.go
@@ -1,0 +1,104 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uio
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// LazyOpener is a lazy io.Reader.
+//
+// LazyOpener will use a given open function to derive an io.Reader when Read
+// is first called on the LazyOpener.
+type LazyOpener struct {
+	r    io.Reader
+	err  error
+	open func() (io.Reader, error)
+}
+
+// NewLazyOpener returns a lazy io.Reader based on `open`.
+func NewLazyOpener(open func() (io.Reader, error)) io.ReadCloser {
+	return &LazyOpener{open: open}
+}
+
+// Read implements io.Reader.Read lazily.
+//
+// If called for the first time, the underlying reader will be obtained and
+// then used for the first and subsequent calls to Read.
+func (lr *LazyOpener) Read(p []byte) (int, error) {
+	if lr.r == nil && lr.err == nil {
+		lr.r, lr.err = lr.open()
+	}
+	if lr.err != nil {
+		return 0, lr.err
+	}
+	return lr.r.Read(p)
+}
+
+// Close implements io.Closer.Close.
+func (lr *LazyOpener) Close() error {
+	if c, ok := lr.r.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+// LazyOpenerAt is a lazy io.ReaderAt.
+//
+// LazyOpenerAt will use a given open function to derive an io.ReaderAt when
+// ReadAt is first called.
+type LazyOpenerAt struct {
+	r    io.ReaderAt
+	s    string
+	err  error
+	open func() (io.ReaderAt, error)
+}
+
+// NewLazyFile returns a lazy ReaderAt opened from path.
+func NewLazyFile(path string) *LazyOpenerAt {
+	if len(path) == 0 {
+		return nil
+	}
+	return NewLazyOpenerAt(path, func() (io.ReaderAt, error) {
+		return os.Open(path)
+	})
+}
+
+// NewLazyOpenerAt returns a lazy io.ReaderAt based on `open`.
+func NewLazyOpenerAt(filename string, open func() (io.ReaderAt, error)) *LazyOpenerAt {
+	return &LazyOpenerAt{s: filename, open: open}
+}
+
+// String implements fmt.Stringer.
+func (loa *LazyOpenerAt) String() string {
+	if len(loa.s) > 0 {
+		return loa.s
+	}
+	if loa.r != nil {
+		return fmt.Sprintf("%v", loa.r)
+	}
+	return "unopened mystery file"
+}
+
+// ReadAt implements io.ReaderAt.ReadAt.
+func (loa *LazyOpenerAt) ReadAt(p []byte, off int64) (int, error) {
+	if loa.r == nil && loa.err == nil {
+		loa.r, loa.err = loa.open()
+	}
+	if loa.err != nil {
+		return 0, loa.err
+	}
+	return loa.r.ReadAt(p, off)
+}
+
+// Close implements io.Closer.Close.
+func (loa *LazyOpenerAt) Close() error {
+	if c, ok := loa.r.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}

--- a/uio/lazy_test.go
+++ b/uio/lazy_test.go
@@ -1,0 +1,73 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uio
+
+import (
+	"fmt"
+	"io"
+	"testing"
+)
+
+type mockReader struct {
+	// called is whether Read has been called.
+	called bool
+
+	// err is the error to return on Read.
+	err error
+}
+
+func (m *mockReader) Read([]byte) (int, error) {
+	m.called = true
+	return 0, m.err
+}
+
+func TestLazyOpenerRead(t *testing.T) {
+	for i, tt := range []struct {
+		openErr    error
+		openReader *mockReader
+		wantCalled bool
+	}{
+		{
+			openErr:    nil,
+			openReader: &mockReader{},
+			wantCalled: true,
+		},
+		{
+			openErr:    io.EOF,
+			openReader: nil,
+			wantCalled: false,
+		},
+		{
+			openErr: nil,
+			openReader: &mockReader{
+				err: io.ErrUnexpectedEOF,
+			},
+			wantCalled: true,
+		},
+	} {
+		t.Run(fmt.Sprintf("Test #%02d", i), func(t *testing.T) {
+			var opened bool
+			lr := NewLazyOpener(func() (io.Reader, error) {
+				opened = true
+				return tt.openReader, tt.openErr
+			})
+			_, err := lr.Read([]byte{})
+			if !opened {
+				t.Fatalf("Read(): Reader was not opened")
+			}
+			if tt.openErr != nil && err != tt.openErr {
+				t.Errorf("Read() = %v, want %v", err, tt.openErr)
+			}
+			if tt.openReader != nil {
+				if got, want := tt.openReader.called, tt.wantCalled; got != want {
+					t.Errorf("mockReader.Read() called is %v, want %v", got, want)
+				}
+				if tt.openReader.err != nil && err != tt.openReader.err {
+					t.Errorf("Read() = %v, want %v", err, tt.openReader.err)
+				}
+			}
+		})
+	}
+}

--- a/uio/linewriter.go
+++ b/uio/linewriter.go
@@ -1,0 +1,57 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uio
+
+import (
+	"bytes"
+	"io"
+)
+
+// LineWriter processes one line of log output at a time.
+type LineWriter interface {
+	// OneLine is always called with exactly one line of output.
+	OneLine(b []byte)
+}
+
+// FullLineWriter returns an io.Writer that waits for a full line of prints
+// before calling w.Write on one line each.
+func FullLineWriter(w LineWriter) io.WriteCloser {
+	return &fullLineWriter{w: w}
+}
+
+type fullLineWriter struct {
+	w      LineWriter
+	buffer []byte
+}
+
+func (fsw *fullLineWriter) printBuf() {
+	bufs := bytes.Split(fsw.buffer, []byte{'\n'})
+	for _, buf := range bufs {
+		if len(buf) != 0 {
+			fsw.w.OneLine(buf)
+		}
+	}
+	fsw.buffer = nil
+}
+
+// Write implements io.Writer and buffers p until at least one full line is
+// received.
+func (fsw *fullLineWriter) Write(p []byte) (int, error) {
+	i := bytes.LastIndexByte(p, '\n')
+	if i == -1 {
+		fsw.buffer = append(fsw.buffer, p...)
+	} else {
+		fsw.buffer = append(fsw.buffer, p[:i]...)
+		fsw.printBuf()
+		fsw.buffer = append([]byte{}, p[i:]...)
+	}
+	return len(p), nil
+}
+
+// Close implements io.Closer and flushes the buffer.
+func (fsw *fullLineWriter) Close() error {
+	fsw.printBuf()
+	return nil
+}

--- a/uio/multiwriter.go
+++ b/uio/multiwriter.go
@@ -1,0 +1,37 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uio
+
+import (
+	"io"
+)
+
+type multiCloser struct {
+	io.Writer
+	writers []io.Writer
+}
+
+// Close implements io.Closer and closes any io.Writers that are also
+// io.Closers.
+func (mc *multiCloser) Close() error {
+	var allErr error
+	for _, w := range mc.writers {
+		if c, ok := w.(io.Closer); ok {
+			if err := c.Close(); err != nil {
+				allErr = err
+			}
+		}
+	}
+	return allErr
+}
+
+// MultiWriteCloser is an io.MultiWriter that has an io.Closer and attempts to
+// close those w's that have optional io.Closers.
+func MultiWriteCloser(w ...io.Writer) io.WriteCloser {
+	return &multiCloser{
+		Writer:  io.MultiWriter(w...),
+		writers: w,
+	}
+}

--- a/uio/null.go
+++ b/uio/null.go
@@ -1,0 +1,70 @@
+// Copyright 2012-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Discard implementation copied from the Go project:
+// https://golang.org/src/io/ioutil/ioutil.go.
+// Copyright 2009 The Go Authors. All rights reserved.
+
+package uio
+
+import (
+	"io"
+	"sync"
+)
+
+type devNull int
+
+// devNull implements ReaderFrom as an optimization so io.Copy to
+// ioutil.Discard can avoid doing unnecessary work.
+var _ io.ReaderFrom = devNull(0)
+
+func (devNull) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (devNull) Name() string {
+	return "null"
+}
+
+func (devNull) WriteString(s string) (int, error) {
+	return len(s), nil
+}
+
+var blackHolePool = sync.Pool{
+	New: func() interface{} {
+		b := make([]byte, 8192)
+		return &b
+	},
+}
+
+func (devNull) ReadFrom(r io.Reader) (n int64, err error) {
+	bufp := blackHolePool.Get().(*[]byte)
+	readSize := 0
+	for {
+		readSize, err = r.Read(*bufp)
+		n += int64(readSize)
+		if err != nil {
+			blackHolePool.Put(bufp)
+			if err == io.EOF {
+				return n, nil
+			}
+			return
+		}
+	}
+}
+
+func (devNull) Close() error {
+	return nil
+}
+
+// WriteNameCloser is the interface that groups Write, Close, and Name methods.
+type WriteNameCloser interface {
+	io.Writer
+	io.Closer
+	Name() string
+}
+
+// Discard is a WriteNameCloser on which all Write and Close calls succeed
+// without doing anything, and the Name call returns "null".
+var Discard WriteNameCloser = devNull(0)

--- a/uio/progress.go
+++ b/uio/progress.go
@@ -1,0 +1,33 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uio
+
+import (
+	"io"
+	"strings"
+)
+
+// ProgressReader implements io.Reader and prints Symbol to W after every
+// Interval bytes passes through R.
+type ProgressReader struct {
+	R io.Reader
+
+	Symbol   string
+	Interval int
+	W        io.Writer
+
+	counter int
+}
+
+// Read implements io.Reader for ProgressReader.
+func (r *ProgressReader) Read(p []byte) (n int, err error) {
+	defer func() {
+		//log.Print("r.Counter %d, r.Interval %d, n
+		numSymbols := (r.counter%r.Interval + n) / r.Interval
+		r.W.Write([]byte(strings.Repeat(r.Symbol, numSymbols)))
+		r.counter += n
+	}()
+	return r.R.Read(p)
+}

--- a/uio/progress_test.go
+++ b/uio/progress_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uio
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestProgressReader(t *testing.T) {
+	input := bytes.NewBufferString("01234567890123456789")
+	stdout := &bytes.Buffer{}
+	pr := ProgressReader{
+		R:        input,
+		Symbol:   "#",
+		Interval: 4,
+		W:        stdout,
+	}
+
+	// Read one byte at a time.
+	output := make([]byte, 1)
+	pr.Read(output)
+	pr.Read(output)
+	pr.Read(output)
+	if len(stdout.Bytes()) != 0 {
+		t.Errorf("found %q, but expected no bytes to be written", stdout)
+	}
+	pr.Read(output)
+	if stdout.String() != "#" {
+		t.Errorf("found %q, expected %q to be written", stdout.String(), "#")
+	}
+
+	// Read 9 bytes all at once.
+	output = make([]byte, 9)
+	pr.Read(output)
+	if stdout.String() != "###" {
+		t.Errorf("found %q, expected %q to be written", stdout.String(), "###")
+	}
+	if string(output) != "456789012" {
+		t.Errorf("found %q, expected %q to be written", string(output), "456789012")
+	}
+}

--- a/uio/reader.go
+++ b/uio/reader.go
@@ -1,0 +1,48 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uio
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"math"
+	"reflect"
+)
+
+type inMemReaderAt interface {
+	Bytes() []byte
+}
+
+// ReadAll reads everything that r contains.
+//
+// Callers *must* not modify bytes in the returned byte slice.
+//
+// If r is an in-memory representation, ReadAll will attempt to return a
+// pointer to those bytes directly.
+func ReadAll(r io.ReaderAt) ([]byte, error) {
+	if imra, ok := r.(inMemReaderAt); ok {
+		return imra.Bytes(), nil
+	}
+	return ioutil.ReadAll(Reader(r))
+}
+
+// Reader generates a Reader from a ReaderAt.
+func Reader(r io.ReaderAt) io.Reader {
+	return io.NewSectionReader(r, 0, math.MaxInt64)
+}
+
+// ReaderAtEqual compares the contents of r1 and r2.
+func ReaderAtEqual(r1, r2 io.ReaderAt) bool {
+	var c, d []byte
+	var r1err, r2err error
+	if r1 != nil {
+		c, r1err = ReadAll(r1)
+	}
+	if r2 != nil {
+		d, r2err = ReadAll(r2)
+	}
+	return bytes.Equal(c, d) && reflect.DeepEqual(r1err, r2err)
+}

--- a/uio/uio.go
+++ b/uio/uio.go
@@ -1,0 +1,9 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package uio unifies commonly used io utilities for u-root.
+//
+// uio's most used feature is the Buffer/Lexer combination to parse binary data
+// of arbitrary endianness into data structures.
+package uio


### PR DESCRIPTION
RFC 2131 gives two examples of padding in section 4.1. For both the
examples, the 'end' option preceeds the padding with the 'pad' option.
These examples relate to overloading pre-defined fields for options,
not padding the packet for a minimal size.

Older versions of the U-Boot firmware support DHCP, but do not expect
the 'pad' option. The firmware logs the following warning for each
occurence:
    *** Unhandled DHCP Option in OFFER/ACK: 0
This warning disappears when the 'end' option preceeds the 'pad'
option.