### PR TITLE
Pad packets after the 'end' option to be more conformant

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -520,20 +520,18 @@ func (d *DHCPv4) ToBytes() []byte {
 	// Write all options.
 	d.Options.Marshal(buf)
 
+	// Finish the options.
+	buf.Write8(OptionEnd.Code())
+
 	// DHCP is based on BOOTP, and BOOTP messages have a minimum length of
 	// 300 bytes per RFC 951. This not stated explicitly, but if you sum up
 	// all the bytes in the message layout, you'll get 300 bytes.
 	//
 	// Some DHCP servers and relay agents care about this BOOTP legacy B.S.
 	// and "conveniently" drop messages that are less than 300 bytes long.
-	//
-	// We subtract one byte for the OptionEnd option.
-	if buf.Len()+1 < bootpMinLen {
-		buf.WriteBytes(bytes.Repeat([]byte{OptionPad.Code()}, bootpMinLen-1-buf.Len()))
+	if buf.Len() < bootpMinLen {
+		buf.WriteBytes(bytes.Repeat([]byte{OptionPad.Code()}, bootpMinLen-buf.Len()))
 	}
-
-	// Finish the packet.
-	buf.Write8(OptionEnd.Code())
 
 	return buf.Data()
 }

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -165,13 +165,13 @@ func TestNewToBytes(t *testing.T) {
 	// Magic Cookie
 	expected = append(expected, magicCookie[:]...)
 
-	// Minimum message length padding.
-	//
-	// 236 + 4 byte cookie + 59 bytes padding + 1 byte end.
-	expected = append(expected, bytes.Repeat([]byte{0}, 59)...)
-
 	// End
 	expected = append(expected, 0xff)
+
+	// Minimum message length padding.
+	//
+	// 236 + 4 byte cookie + 1 byte end + 59 bytes padding.
+	expected = append(expected, bytes.Repeat([]byte{0}, 59)...)
 
 	d, err := New()
 	require.NoError(t, err)

--- a/dhcpv6/option_dhcpv4_msg_test.go
+++ b/dhcpv6/option_dhcpv4_msg_test.go
@@ -87,13 +87,13 @@ func TestOptDHCPv4MsgToBytes(t *testing.T) {
 	// Magic Cookie
 	expected = append(expected, magicCookie[:]...)
 
-	// Minimum message length padding.
-	//
-	// 236 + 4 byte cookie + 59 bytes padding + 1 byte end.
-	expected = append(expected, bytes.Repeat([]byte{0}, 59)...)
-
 	// End
 	expected = append(expected, 0xff)
+
+	// Minimum message length padding.
+	//
+	// 236 + 4 byte cookie + 1 byte end + 59 bytes padding.
+	expected = append(expected, bytes.Repeat([]byte{0}, 59)...)
 
 	d, err := dhcpv4.New()
 	require.NoError(t, err)


### PR DESCRIPTION
RFC 2131 gives two examples of padding in section 4.1. For both the
examples, the 'end' option preceeds the padding with the 'pad' option.
These examples relate to overloading pre-defined fields for options,
not padding the packet for a minimal size.

Older versions of the U-Boot firmware support DHCP, but do not expect
the 'pad' option. The firmware logs the following warning for each
occurence:
    *** Unhandled DHCP Option in OFFER/ACK: 0
This warning disappears when the 'end' option preceeds the 'pad'
option.

Signed-off-by: Marcel Moolenaar <mmoolena@amazon.com>