### PR TITLE
Improve compatibility with some devices

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -604,7 +604,8 @@ func (d *DHCPv4) DomainName() string {
 //
 // The Host Name option is described by RFC 2132, Section 3.14.
 func (d *DHCPv4) HostName() string {
-	return GetString(OptionHostName, d.Options)
+	name := GetString(OptionHostName, d.Options)
+	return strings.TrimRight(name, "\x00")
 }
 
 // RootPath parses the DHCPv4 Root Path option if present.

--- a/dhcpv4/option_string_test.go
+++ b/dhcpv4/option_string_test.go
@@ -34,6 +34,9 @@ func TestParseOptHostName(t *testing.T) {
 
 	m, _ = New()
 	require.Equal(t, "", m.HostName())
+
+	m, _ = New(WithGeneric(OptionHostName, []byte{'t', 'e', 's', 't', 0}))
+	require.Equal(t, "test", m.HostName())
 }
 
 func TestOptRootPath(t *testing.T) {


### PR DESCRIPTION
We, the _AdGuard_ team, have received an [issue](https://github.com/AdguardTeam/AdGuardHome/issues/2582) some time ago.  After researching a little we've found that some devices may include trailing zero-byte in [DHCP option 12](https://tools.ietf.org/html/rfc2132#section-3.14) length calculation.  We've also found that similar issues with some other options were already solved in fcbde74dab23754aa33fbcd409327c0a1409f2a7.

For now, we've come up with a [little workaround](https://github.com/AdguardTeam/AdGuardHome/commit/5aa0ca9319919f35eb2e1dc4c9e6d8f0385c394e) in _AdGuard Home_, but it's a temporary solution.  Please review our little fix, we hope to get rid of our crutch as soon as possible :)