### PR TITLE
Make server4 package compile on Windows

### DIFF
--- a/dhcpv4/server4/conn_unix.go
+++ b/dhcpv4/server4/conn_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package server4
 
 import (

--- a/dhcpv4/server4/conn_windows.go
+++ b/dhcpv4/server4/conn_windows.go
@@ -1,0 +1,11 @@
+package server4
+
+import (
+	"errors"
+	"net"
+)
+
+// NewIPv4UDPConn fails on Windows. Use WithConn() to pass the connection.
+func NewIPv4UDPConn(iface string, addr *net.UDPAddr) (*net.UDPConn, error) {
+	return nil, errors.New("not implemented on Windows")
+}

--- a/interfaces/bindtodevice_windows.go
+++ b/interfaces/bindtodevice_windows.go
@@ -1,0 +1,8 @@
+package interfaces
+
+import "errors"
+
+// BindToInterface fails on Windows.
+func BindToInterface(fd int, ifname string) error {
+	return errors.New("not implemented on Windows")
+}


### PR DESCRIPTION
I am working on an userland network stack based on gvisor (https://github.com/containers/gvisor-tap-vsock).
I use this library as the dhcp server. It works really great but doesn't compile on Windows.

This PR allows to start the server on Windows with a net.PacketConn directly `server4.WithConn()`. 

It also requires this PR in u-root: https://github.com/u-root/u-root/pull/2019