### PR TITLE
Make server6 package compile on Windows

### DIFF
--- a/dhcpv6/server6/conn_unix.go
+++ b/dhcpv6/server6/conn_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package server6
 
 import (

--- a/dhcpv6/server6/conn_windows.go
+++ b/dhcpv6/server6/conn_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package server6
+
+import (
+	"errors"
+	"net"
+)
+
+// NewIPv6UDPConn fails on Windows. Use WithConn() to pass the connection.
+func NewIPv6UDPConn(iface string, addr *net.UDPAddr) (*net.UDPConn, error) {
+	return nil, errors.New("not implemented on Windows")
+}


### PR DESCRIPTION
This PR mirrors the change in https://github.com/insomniacslk/dhcp/pull/428 in order to make `server6` compile on Windows by adding a dummy `NewIPv6UDPConn` function.