### PR TITLE
client6: support point to point interface

### DIFF
--- a/dhcpv6/client6/client.go
+++ b/dhcpv6/client6/client.go
@@ -210,6 +210,9 @@ func (c *Client) Solicit(ifname string, modifiers ...dhcpv6.Modifier) (dhcpv6.DH
 	if err != nil {
 		return nil, nil, err
 	}
+	if (iface.Flags | net.FlagPointToPoint) != 0 {
+		iface.HardwareAddr = []byte{0,0,0,0,0,0}
+	}
 	solicit, err := dhcpv6.NewSolicit(iface.HardwareAddr)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Some ISPs use dhcpv6 to delegate prefix over ppp interface. Set dummy HardwareAddr to on point to point interface to avoid address too short error.