### PR TITLE
Adding support to parse vendor data for cisco firepower

### DIFF
--- a/dhcpv4/ztpv4/ztp.go
+++ b/dhcpv4/ztpv4/ztp.go
@@ -68,7 +68,7 @@ func parseClassIdentifier(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 
 	// Cisco Firepower FPR4100/9300 models use Opt 60 for model info
 	// and Opt 61 contains the serial number
-	case vc == "FPR9300" || vc == "FPR4100":
+	case vc == "FPR4100" || vc == "FPR9300":
 		vd.VendorName = iana.EntIDCiscoSystems.String()
 		vd.Model = vc
 		vd.Serial = dhcpv4.GetString(dhcpv4.OptionClientIdentifier, packet.Options)

--- a/dhcpv4/ztpv4/ztp_test.go
+++ b/dhcpv4/ztpv4/ztp_test.go
@@ -12,19 +12,13 @@ func TestParseClassIdentifier(t *testing.T) {
 	tt := []struct {
 		name         string
 		vc, hostname string
-		ci           []byte //Client Identifier
+		ci           []byte // Client Identifier
 		want         *VendorData
 		fail         bool
 	}{
 		{name: "empty", fail: true},
 		{name: "unknownVendor", vc: "VendorX;BFR10K;XX12345", fail: true},
 		{name: "truncatedVendor", vc: "Arista;1234", fail: true},
-		{
-			name: "cisco",
-			vc:   "FPR4100",
-			ci:   []byte("JMX2525X0BW"),
-			want: &VendorData{VendorName: iana.EntIDCiscoSystems.String(), Model: "FPR4100", Serial: "JMX2525X0BW"},
-		},
 		{
 			name: "arista",
 			vc:   "Arista;DCS-7050S-64;01.23;JPE12345678",
@@ -51,6 +45,12 @@ func TestParseClassIdentifier(t *testing.T) {
 			name: "zpe",
 			vc:   "ZPESystems:NSC:001234567",
 			want: &VendorData{VendorName: "ZPESystems", Model: "NSC", Serial: "001234567"},
+		},
+		{
+			name: "cisco",
+			vc:   "FPR4100",
+			ci:   []byte("JMX2525X0BW"),
+			want: &VendorData{VendorName: "Cisco Systems", Model: "FPR4100", Serial: "JMX2525X0BW"},
 		},
 	}
 


### PR DESCRIPTION
Support for Cisco Firepower FPR4100/9300 models. Apart from the model numbers there is no indication that they are Cisco devices, so hard to filter based on the models.

Opt 60 contains the model information
Opt 61 contains serial number