### PR TITLE
[ztpv4][cisco firepower] Check to ensure serial number in Opt 61 is not empty

### DIFF
--- a/dhcpv4/ztpv4/ztp.go
+++ b/dhcpv4/ztpv4/ztp.go
@@ -73,7 +73,7 @@ func parseClassIdentifier(packet *dhcpv4.DHCPv4) (*VendorData, error) {
 		vd.Model = vc
 		vd.Serial = dhcpv4.GetString(dhcpv4.OptionClientIdentifier, packet.Options)
 		if len(vd.Serial) == 0 {
-			return nil, errors.New("could not get serial from Client Identifier Opt 61")
+			return nil, errors.New("client identifier option is missing")
 		}
 		return vd, nil
 

--- a/dhcpv4/ztpv4/ztp_test.go
+++ b/dhcpv4/ztpv4/ztp_test.go
@@ -52,12 +52,7 @@ func TestParseClassIdentifier(t *testing.T) {
 			ci:   []byte("JMX2525X0BW"),
 			want: &VendorData{VendorName: "Cisco Systems", Model: "FPR4100", Serial: "JMX2525X0BW"},
 		},
-		{
-			name: "ciscoNoSerial",
-			vc:   "FPR4100",
-			ci:   []byte(""),
-			fail: true,
-		},
+		{name: "ciscoNoSerial", vc: "FPR4100", fail: true},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
Raise error if serial number is "" in Opt 61 of DHCP request