### PR TITLE
Revert "[dhcpv6] don't copy the RemoteID"

### DIFF
--- a/dhcpv6/dhcpv6relay.go
+++ b/dhcpv6/dhcpv6relay.go
@@ -178,13 +178,14 @@ func (r *RelayMessage) GetInnerMessage() (*Message, error) {
 
 // NewRelayReplFromRelayForw creates a MessageTypeRelayReply based on a
 // MessageTypeRelayForward and replaces the inner message with the passed
-// DHCPv6 message. It copies the OptionInterfaceID if the option is
-// present in the Relay packet.
+// DHCPv6 message. It copies the OptionInterfaceID and OptionRemoteID if the
+// options are present in the Relay packet.
 func NewRelayReplFromRelayForw(relay *RelayMessage, msg *Message) (DHCPv6, error) {
 	var (
 		err                error
 		linkAddr, peerAddr []net.IP
 		optiid             []Option
+		optrid             []Option
 	)
 	if relay == nil {
 		return nil, errors.New("Relay message cannot be nil")
@@ -199,6 +200,7 @@ func NewRelayReplFromRelayForw(relay *RelayMessage, msg *Message) (DHCPv6, error
 		linkAddr = append(linkAddr, relay.LinkAddr)
 		peerAddr = append(peerAddr, relay.PeerAddr)
 		optiid = append(optiid, relay.GetOneOption(OptionInterfaceID))
+		optrid = append(optrid, relay.GetOneOption(OptionRemoteID))
 		decap, err := DecapsulateRelay(relay)
 		if err != nil {
 			return nil, err
@@ -216,6 +218,9 @@ func NewRelayReplFromRelayForw(relay *RelayMessage, msg *Message) (DHCPv6, error
 			return nil, err
 		}
 		if opt := optiid[i]; opt != nil {
+			m.AddOption(opt)
+		}
+		if opt := optrid[i]; opt != nil {
 			m.AddOption(opt)
 		}
 	}

--- a/dhcpv6/dhcpv6relay_test.go
+++ b/dhcpv6/dhcpv6relay_test.go
@@ -91,6 +91,7 @@ func TestNewRelayRepFromRelayForw(t *testing.T) {
 	rf.PeerAddr = net.IPv6linklocalallrouters
 	rf.LinkAddr = net.IPv6interfacelocalallnodes
 	rf.AddOption(OptInterfaceID(nil))
+	rf.AddOption(&OptRemoteID{})
 
 	// create the inner message
 	s, err := NewMessage()
@@ -108,6 +109,7 @@ func TestNewRelayRepFromRelayForw(t *testing.T) {
 	require.Equal(t, relay.PeerAddr, rf.PeerAddr)
 	require.Equal(t, relay.LinkAddr, rf.LinkAddr)
 	require.NotNil(t, rr.GetOneOption(OptionInterfaceID))
+	require.NotNil(t, rr.GetOneOption(OptionRemoteID))
 	m, err := relay.GetInnerMessage()
 	require.NoError(t, err)
 	require.Equal(t, m, a)


### PR DESCRIPTION
This reverts commit 4cc310c391f640ff2ac15f6c56ccbba2d362a8aa.

Although my change in https://github.com/insomniacslk/dhcp/pull/445 was RFC compliant, I checked the history of why we were copying the remote id in the first place and found https://github.com/insomniacslk/dhcp/pull/135

Add it back to avoid potential breakage.