### PR TITLE
Fix nil check to prevent a panic by trying to dereference a nil pointer

### DIFF
--- a/dhcpv4/client4/client.go
+++ b/dhcpv4/client4/client.go
@@ -314,7 +314,7 @@ func (c *Client) SendReceive(sendFd, recvFd int, packet *dhcpv4.DHCPv4, messageT
 			}
 			dstPort := int(binary.BigEndian.Uint16(udph[2:4]))
 			expectedDstPort := dhcpv4.ClientPort
-			if c.RemoteAddr != nil {
+			if c.LocalAddr != nil {
 				expectedDstPort = c.LocalAddr.(*net.UDPAddr).Port
 			}
 			if dstPort != expectedDstPort {


### PR DESCRIPTION
There was a copy/paste error where we were not checking the correct pointer before trying to convert it.  If I set the `RemoteAddr` to something without setting the `LocalAddr` and I was hitting this panic: `panic: interface conversion: net.Addr is nil, not *net.UDPAddr`  This PR fixes the issue to check the `LocalAddr` pointer before trying to convert it.