### PR TITLE
dhcpv4: remove server IP from REQUEST messages

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -232,22 +232,13 @@ func NewInform(hwaddr net.HardwareAddr, localIP net.IP, modifiers ...Modifier) (
 
 // NewRequestFromOffer builds a DHCPv4 request from an offer.
 func NewRequestFromOffer(offer *DHCPv4, modifiers ...Modifier) (*DHCPv4, error) {
-	// find server IP address
-	serverIP := offer.ServerIdentifier()
-	if serverIP == nil {
-		if offer.ServerIPAddr == nil || offer.ServerIPAddr.IsUnspecified() {
-			return nil, fmt.Errorf("missing Server IP Address in DHCP Offer")
-		}
-		serverIP = offer.ServerIPAddr
-	}
-
 	return New(PrependModifiers(modifiers,
 		WithReply(offer),
 		WithMessageType(MessageTypeRequest),
-		WithServerIP(serverIP),
 		WithClientIP(offer.ClientIPAddr),
 		WithOption(OptRequestedIPAddress(offer.YourIPAddr)),
-		WithOption(OptServerIdentifier(serverIP)),
+		// This is usually the server IP.
+		WithOptionCopied(offer, OptionServerIdentifier),
 		WithRequestedOptions(
 			OptionSubnetMask,
 			OptionRouter,

--- a/dhcpv4/dhcpv4_test.go
+++ b/dhcpv4/dhcpv4_test.go
@@ -231,10 +231,6 @@ func TestDHCPv4NewRequestFromOffer(t *testing.T) {
 	require.NoError(t, err)
 	offer.SetBroadcast()
 	offer.UpdateOption(OptMessageType(MessageTypeOffer))
-	_, err = NewRequestFromOffer(offer)
-	require.Error(t, err)
-
-	// Now add the option so it doesn't error out.
 	offer.UpdateOption(OptServerIdentifier(net.IPv4(192, 168, 0, 1)))
 
 	// Broadcast request


### PR DESCRIPTION
RFC 2131 Section 4.4.1 specifies that REQUEST messages should set
'siaddr' to 0.

cc @rjoleary