### PR TITLE
Add Support for Labels Containing Partial Domain Names (RFC 4704 Section 4.2)

### DIFF
--- a/rfc1035label/label.go
+++ b/rfc1035label/label.go
@@ -104,8 +104,6 @@ func labelsFromBytes(buf []byte) ([]string, error) {
 			// domain name field as per RFC 4704 Section 4.2
 			if label != "" {
 				labels = append(labels, label)
-
-				return labels, nil
 			}
 
 			break

--- a/rfc1035label/label.go
+++ b/rfc1035label/label.go
@@ -100,6 +100,14 @@ func labelsFromBytes(buf []byte) ([]string, error) {
 
 	for {
 		if pos >= len(buf) {
+			// interpret label without trailing zero-length byte as a partial
+			// domain name field as per RFC 4704 Section 4.2
+			if label != "" {
+				labels = append(labels, label)
+
+				return labels, nil
+			}
+
 			break
 		}
 		length := int(buf[pos])

--- a/rfc1035label/label_test.go
+++ b/rfc1035label/label_test.go
@@ -28,6 +28,18 @@ func TestLabelsFromBytesZeroLength(t *testing.T) {
 	require.Equal(t, []byte{}, labels.ToBytes())
 }
 
+func TestLabelsFromBytesWithoutZeroLength(t *testing.T) {
+	expected := []byte{
+		0x8, 'h', 'o', 's', 't', 'n', 'a', 'm', 'e',
+	}
+	labels, err := FromBytes(expected)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(labels.Labels))
+	require.Equal(t, len(expected), labels.Length())
+	require.Equal(t, expected, labels.ToBytes())
+	require.Equal(t, "hostname", labels.Labels[0])
+}
+
 func TestLabelsFromBytesInvalidLength(t *testing.T) {
 	_, err := FromBytes([]byte{0x5, 0xaa, 0xbb}) // short length
 	require.Error(t, err)

--- a/rfc1035label/label_test.go
+++ b/rfc1035label/label_test.go
@@ -28,7 +28,9 @@ func TestLabelsFromBytesZeroLength(t *testing.T) {
 	require.Equal(t, []byte{}, labels.ToBytes())
 }
 
-func TestLabelsFromBytesWithoutZeroLength(t *testing.T) {
+func TestLabelsFromBytesPartialDomainName(t *testing.T) {
+	// Partial domain name without trailing zero-length byte as per RFC 4704
+	// Section 4.2
 	expected := []byte{
 		0x8, 'h', 'o', 's', 't', 'n', 'a', 'm', 'e',
 	}


### PR DESCRIPTION
This PR only contains a failing test case for #466. I don't know enough about RFC 1035 (especially compressed ones) to be comfortable implementing a solution that does not break anything.