### PR TITLE
Add Cisco ZTPv6 Support

### DIFF
--- a/dhcpv6/ztpv6/parse_vendor_options.go
+++ b/dhcpv6/ztpv6/parse_vendor_options.go
@@ -46,7 +46,8 @@ func ParseVendorData(packet dhcpv6.DHCPv6) (*VendorData, error) {
 	for _, d := range vData {
 		switch {
 		// Arista;DCS-0000;00.00;ZZZ00000000
-		case strings.HasPrefix(d, "Arista;"):
+		// Cisco;8800;12.34;FOC00000000
+		case strings.HasPrefix(d, "Arista;"), strings.HasPrefix(d, "Cisco;"):
 			p := strings.Split(d, ";")
 			if len(p) < 4 {
 				return nil, errVendorOptionMalformed

--- a/dhcpv6/ztpv6/parse_vendor_options_test.go
+++ b/dhcpv6/ztpv6/parse_vendor_options_test.go
@@ -18,11 +18,16 @@ func TestParseVendorDataWithVendorOpts(t *testing.T) {
 		{name: "empty", fail: true},
 		{name: "unknownVendor", vc: "VendorX;BFR10K;XX12345", fail: true, want: nil},
 		{name: "truncatedArista", vc: "Arista;1234", fail: true, want: nil},
+		{name: "truncatedCisco", vc: "Cisco;1234", fail: true, want: nil},
 		{name: "truncatedZPE", vc: "ZPESystems:1234", fail: true, want: nil},
 		{
 			name: "arista",
 			vc:   "Arista;DCS-7050S-64;01.23;JPE12345678",
 			want: &VendorData{VendorName: "Arista", Model: "DCS-7050S-64", Serial: "JPE12345678"},
+		}, {
+			name: "cisco",
+			vc:   "Cisco;SYS-8801;01.23;FOC12345678",
+			want: &VendorData{VendorName: "Cisco", Model: "SYS-8801", Serial: "FOC12345678"},
 		}, {
 			name: "zpe",
 			vc:   "ZPESystems:NSC:001234567",


### PR DESCRIPTION
Adding ZTPv6 Cisco support based on Option 17 Suboption 1 (Vendor Specific Information Option).