### PR TITLE
dhcpv4: return a new lease from Renew()

### DIFF
--- a/dhcpv4/nclient4/lease_test.go
+++ b/dhcpv4/nclient4/lease_test.go
@@ -238,7 +238,7 @@ func (sll *testServerLeaseList) runTest(t *testing.T) {
 		sll.lastTestSvrErrLock.RUnlock()
 
 		if keepgoing {
-			err = clnt.Renew(context.Background(), lease)
+			lease, err = clnt.Renew(context.Background(), lease)
 			sll.lastTestSvrErrLock.RLock()
 			keepgoing = chkerr(err, sll.lastTestSvrErr, l.ShouldFail, t)
 			sll.lastTestSvrErrLock.RUnlock()

--- a/dhcpv4/server4/server_test.go
+++ b/dhcpv4/server4/server_test.go
@@ -116,7 +116,7 @@ func TestServer(t *testing.T) {
 		require.Equal(t, ifaces[0].HardwareAddr, p.ClientHWAddr)
 	}
 
-	err = c.Renew(context.Background(), lease, modifiers...)
+	lease, err = c.Renew(context.Background(), lease, modifiers...)
 	require.NoError(t, err)
 	require.NotNil(t, lease.Offer, lease.ACK)
 	for _, p := range []*dhcpv4.DHCPv4{lease.Offer, lease.ACK} {


### PR DESCRIPTION
Follow-up of https://github.com/insomniacslk/dhcp/pull/469#discussion_r967858102, `Renew()` should return a new lease upon successful renewal instead of modifying the one passed in by reference.