### PR TITLE
dhcpv4: make NewInform() formatting consistent with neighbors

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -222,8 +222,7 @@ func PrependModifiers(m []Modifier, other ...Modifier) []Modifier {
 // NewInform builds a new DHCPv4 Informational message with the specified
 // hardware address.
 func NewInform(hwaddr net.HardwareAddr, localIP net.IP, modifiers ...Modifier) (*DHCPv4, error) {
-	return New(PrependModifiers(
-		modifiers,
+	return New(PrependModifiers(modifiers,
 		WithHwAddr(hwaddr),
 		WithMessageType(MessageTypeInform),
 		WithClientIP(localIP),


### PR DESCRIPTION
This is just a minor readability improvement that makes `NewInform()` consistent with the neighboring functions like `NewRequest()`, `NewReply()`, `NewRelease()` etc. Having the prepended modifiers on the same line helps with separating the modifiers that provided by the function from the modifiers passed in by the consumer of the function.