### PR TITLE
Return error from RequestNetbootv4

### DIFF
--- a/netboot/netboot.go
+++ b/netboot/netboot.go
@@ -48,7 +48,6 @@ func RequestNetbootv6(ifname string, timeout time.Duration, retries int, modifie
 		if err != nil {
 			log.Printf("Client.Exchange failed: %v", err)
 			if i >= retries {
-				// don't wait at the end of the last attempt
 				return nil, fmt.Errorf("netboot failed after %d attempts: %v", retries+1, err)
 			}
 			log.Printf("sleeping %v before retrying", delay)
@@ -80,8 +79,7 @@ func RequestNetbootv4(ifname string, timeout time.Duration, retries int, modifie
 			log.Printf("Client.Exchange failed: %v", err)
 			log.Printf("sleeping %v before retrying", delay)
 			if i >= retries {
-				// don't wait at the end of the last attempt
-				break
+				return nil, fmt.Errorf("netboot failed after %d attempts: %v", retries+1, err)
 			}
 			sleeper(delay)
 			// TODO add random splay


### PR DESCRIPTION
The current behavior of `RequestNetbootv4` is potentially dangerous because when it reaches the max number of retries, it returns `conversation, nil` (line 91) back to the caller, even if `client.Exchange()` (line 77) returned an `err`. This leads to a situation where the caller will see `err == nil` but incorrect data returned via the other parameter.

This changes the behavior to match the behavior of `RequestNetbootv6`.  If this change isn't allowed because it's not backwards compatible then we should at least consider returning `nil, nil` instead of `conversation, nil` on the final retry.

I found this while investigating potential nil pointers at https://github.com/u-root/u-root/issues/2517

Signed-off-by: Avi Brender <avibrender@gmail.com>