### PR TITLE
Improving test coverage before lazy parsing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17', '1.18', '1.19', '1.20']
+        go: ['1.18', '1.19', '1.20']
     env:
       GO111MODULE: on
     steps:
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17', '1.18', '1.19', '1.20']
+        go: ['1.18', '1.19', '1.20']
     env:
       GO111MODULE: on
     steps:

--- a/dhcpv6/dhcpv6.go
+++ b/dhcpv6/dhcpv6.go
@@ -47,7 +47,7 @@ func MessageFromBytes(data []byte) (*Message, error) {
 	}
 	buf.ReadBytes(d.TransactionID[:])
 	if buf.Error() != nil {
-		return nil, fmt.Errorf("Error parsing DHCPv6 header: %v", buf.Error())
+		return nil, fmt.Errorf("failed to parse DHCPv6 header: %w", buf.Error())
 	}
 	if err := d.Options.FromBytes(buf.Data()); err != nil {
 		return nil, err

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -211,6 +211,33 @@ func (mo MessageOptions) UserClasses() [][]byte {
 	return nil
 }
 
+// VendorClasses returns the all vendor class options.
+func (mo MessageOptions) VendorClasses() []*OptVendorClass {
+	opt := mo.Options.Get(OptionVendorClass)
+	if opt == nil {
+		return nil
+	}
+	var vo []*OptVendorClass
+	for _, o := range opt {
+		if t, ok := o.(*OptVendorClass); ok {
+			vo = append(vo, t)
+		}
+	}
+	return vo
+}
+
+// VendorClass returns the vendor class options matching the given enterprise
+// number.
+func (mo MessageOptions) VendorClass(enterpriseNumber uint32) [][]byte {
+	vo := mo.VendorClasses()
+	for _, v := range vo {
+		if v.EnterpriseNumber == enterpriseNumber {
+			return v.Data
+		}
+	}
+	return nil
+}
+
 // VendorOpts returns the all vendor-specific options.
 //
 // RFC 8415 Section 21.17:

--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -106,6 +106,18 @@ func (mo MessageOptions) OneIAPD() *OptIAPD {
 	return iapds[0]
 }
 
+// FourRD returns all 4RD options.
+func (mo MessageOptions) FourRD() []*Opt4RD {
+	opts := mo.Get(Option4RD)
+	var frds []*Opt4RD
+	for _, o := range opts {
+		if m, ok := o.(*Opt4RD); ok {
+			frds = append(frds, m)
+		}
+	}
+	return frds
+}
+
 // Status returns the status code associated with this option.
 func (mo MessageOptions) Status() *OptStatusCode {
 	opt := mo.Options.GetOne(OptionStatusCode)

--- a/dhcpv6/duid.go
+++ b/dhcpv6/duid.go
@@ -61,6 +61,9 @@ func (d *DUIDLLT) Equal(e DUID) bool {
 	if !ok {
 		return false
 	}
+	if d == nil {
+		return d == ellt
+	}
 	return d.HWType == ellt.HWType && d.Time == ellt.Time && bytes.Equal(d.LinkLayerAddr, ellt.LinkLayerAddr)
 }
 
@@ -102,6 +105,9 @@ func (d *DUIDLL) Equal(e DUID) bool {
 	ell, ok := e.(*DUIDLL)
 	if !ok {
 		return false
+	}
+	if d == nil {
+		return d == ell
 	}
 	return d.HWType == ell.HWType && bytes.Equal(d.LinkLayerAddr, ell.LinkLayerAddr)
 }
@@ -145,6 +151,9 @@ func (d *DUIDEN) Equal(e DUID) bool {
 	if !ok {
 		return false
 	}
+	if d == nil {
+		return d == en
+	}
 	return d.EnterpriseNumber == en.EnterpriseNumber && bytes.Equal(d.EnterpriseIdentifier, en.EnterpriseIdentifier)
 }
 
@@ -187,6 +196,9 @@ func (d *DUIDUUID) Equal(e DUID) bool {
 	if !ok {
 		return false
 	}
+	if d == nil {
+		return d == euuid
+	}
 	return d.UUID == euuid.UUID
 }
 
@@ -226,6 +238,9 @@ func (d *DUIDOpaque) Equal(e DUID) bool {
 	if !ok {
 		return false
 	}
+	if d == nil {
+		return d == eopaque
+	}
 	return d.Type == eopaque.Type && bytes.Equal(d.Data, eopaque.Data)
 }
 
@@ -259,7 +274,7 @@ func (d DUIDType) String() string {
 func DUIDFromBytes(data []byte) (DUID, error) {
 	buf := uio.NewBigEndianBuffer(data)
 	if !buf.Has(2) {
-		return nil, fmt.Errorf("buffer too short: have %d bytes, want 2 bytes", buf.Len())
+		return nil, fmt.Errorf("%w: have %d bytes, want 2 bytes", uio.ErrBufferTooShort, buf.Len())
 	}
 
 	typ := DUIDType(buf.Read16())

--- a/dhcpv6/option_clientid_test.go
+++ b/dhcpv6/option_clientid_test.go
@@ -1,78 +1,108 @@
 package dhcpv6
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/insomniacslk/dhcp/iana"
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/uio/uio"
 )
 
-func TestParseMessageOptionsWithClientID(t *testing.T) {
-	buf := []byte{
-		0, 1, // Client ID option
-		0, 10, // length
-		0, 3, // DUID_LL
-		0, 1, // hwtype ethernet
-		0, 1, 2, 3, 4, 5, // HW addr
-	}
-
-	want := &DUIDLL{HWType: iana.HWTypeEthernet, LinkLayerAddr: net.HardwareAddr{0, 1, 2, 3, 4, 5}}
-	var mo MessageOptions
-	if err := mo.FromBytes(buf); err != nil {
-		t.Errorf("FromBytes = %v", err)
-	} else if got := mo.ClientID(); !reflect.DeepEqual(got, want) {
-		t.Errorf("ClientID = %v, want %v", got, want)
-	}
-}
-
-func TestParseOptClientID(t *testing.T) {
-	data := []byte{
-		0, 3, // DUID_LL
-		0, 1, // hwtype ethernet
-		0, 1, 2, 3, 4, 5, // hw addr
-	}
-	var opt optClientID
-	err := opt.FromBytes(data)
-	require.NoError(t, err)
-	want := OptClientID(
-		&DUIDLL{
-			HWType:        iana.HWTypeEthernet,
-			LinkLayerAddr: net.HardwareAddr([]byte{0, 1, 2, 3, 4, 5}),
+func TestClientIDParseAndGetter(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		err  error
+		want DUID
+	}{
+		{
+			buf: []byte{
+				0, 1, // Client ID option
+				0, 10, // length
+				0, 3, // DUID_LL
+				0, 1, // hwtype ethernet
+				0, 1, 2, 3, 4, 5, // HW addr
+			},
+			want: &DUIDLL{HWType: iana.HWTypeEthernet, LinkLayerAddr: net.HardwareAddr{0, 1, 2, 3, 4, 5}},
 		},
-	)
-	require.Equal(t, want, &opt)
-}
-
-func TestOptClientIdToBytes(t *testing.T) {
-	opt := OptClientID(
-		&DUIDLL{
-			HWType:        iana.HWTypeEthernet,
-			LinkLayerAddr: net.HardwareAddr([]byte{5, 4, 3, 2, 1, 0}),
+		{
+			buf:  nil,
+			want: nil,
 		},
-	)
-	expected := []byte{
-		0, 3, // DUID_LL
-		0, 1, // hwtype ethernet
-		5, 4, 3, 2, 1, 0, // hw addr
+		{
+			buf:  []byte{0, 1, 0, 1, 0},
+			want: nil,
+			err:  uio.ErrBufferTooShort,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var mo MessageOptions
+			if err := mo.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			if got := mo.ClientID(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ClientID = %v, want %v", got, tt.want)
+			}
+		})
 	}
-	require.Equal(t, expected, opt.ToBytes())
 }
 
-func TestOptClientIdDecodeEncode(t *testing.T) {
-	data := []byte{
-		0, 3, // DUID_LL
-		0, 1, // hwtype ethernet
-		5, 4, 3, 2, 1, 0, // hw addr
+func TestClientID(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		want optClientID
+		err  error
+	}{
+		{
+			buf: []byte{
+				0, 3, // DUID_LL
+				0, 1, // hwtype ethernet
+				0, 1, 2, 3, 4, 5, // hw addr
+			},
+			want: optClientID{
+				&DUIDLL{
+					HWType:        iana.HWTypeEthernet,
+					LinkLayerAddr: net.HardwareAddr([]byte{0, 1, 2, 3, 4, 5}),
+				},
+			},
+		},
+		{
+			buf: []byte{0},
+			err: uio.ErrBufferTooShort,
+		},
+		{
+			buf: []byte{0, 3, 0},
+			err: uio.ErrBufferTooShort,
+		},
+		{
+			buf: nil,
+			err: uio.ErrBufferTooShort,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var opt optClientID
+			if err := opt.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			if tt.err == nil {
+				if !reflect.DeepEqual(tt.want, opt) {
+					t.Errorf("FromBytes = %v, want %v", opt, tt.want)
+				}
+
+				out := tt.want.ToBytes()
+				if diff := cmp.Diff(tt.buf, out); diff != "" {
+					t.Errorf("ToBytes mismatch: (-want, +got):\n%s", diff)
+				}
+			}
+		})
 	}
-	var opt optClientID
-	err := opt.FromBytes(data)
-	require.NoError(t, err)
-	require.Equal(t, data, opt.ToBytes())
 }
 
-func TestOptionClientId(t *testing.T) {
+func TestOptionClientIDString(t *testing.T) {
 	opt := OptClientID(
 		&DUIDLL{
 			HWType:        iana.HWTypeEthernet,
@@ -86,24 +116,4 @@ func TestOptionClientId(t *testing.T) {
 		"Client ID: DUID-LL{HWType=Ethernet HWAddr=de:ad:00:00:be:ef}",
 		"String() should contain the correct cid output",
 	)
-}
-
-func TestOptClientIdparseOptClientIDBogusDUID(t *testing.T) {
-	data := []byte{
-		0, 4, // DUID_UUID
-		1, 2, 3, 4, 5, 6, 7, 8, 9, // a UUID should be 18 bytes not 17
-		10, 11, 12, 13, 14, 15, 16, 17,
-	}
-	var opt optClientID
-	err := opt.FromBytes(data)
-	require.Error(t, err, "A truncated OptClientId DUID should return an error")
-}
-
-func TestOptClientIdparseOptClientIDInvalidTooShort(t *testing.T) {
-	data := []byte{
-		0, // truncated: DUIDs are at least 2 bytes
-	}
-	var opt optClientID
-	err := opt.FromBytes(data)
-	require.Error(t, err, "A truncated OptClientId should return an error")
 }

--- a/dhcpv6/option_clientlinklayeraddress_test.go
+++ b/dhcpv6/option_clientlinklayeraddress_test.go
@@ -2,40 +2,65 @@ package dhcpv6
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"net"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/insomniacslk/dhcp/iana"
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/uio/uio"
 )
 
-func TestParseOptClientLinkLayerAddress(t *testing.T) {
-	data := []byte{
-		0, 1, // LinkLayerType
-		164, 131, 231, 227, 223, 136,
-	}
-	var opt optClientLinkLayerAddress
-	err := opt.FromBytes(data)
+func TestClientLinkLayerAddressParseAndGetter(t *testing.T) {
+	for i, tt := range []struct {
+		buf        []byte
+		err        error
+		wantHWType iana.HWType
+		wantHWAddr net.HardwareAddr
+	}{
+		{
+			buf: []byte{
+				0, 79, // Client Link Layer Address option
+				0, 8, // length
+				0, 1, // Ethernet
+				1, 2, 3, 4, 5, 6,
+			},
+			wantHWType: iana.HWTypeEthernet,
+			wantHWAddr: net.HardwareAddr{1, 2, 3, 4, 5, 6},
+		},
+		{
+			buf: []byte{0, 79, 0, 1, 0},
+			err: uio.ErrBufferTooShort,
+		},
+		{
+			buf: []byte{0, 79, 0},
+			err: uio.ErrUnreadBytes,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var ro RelayOptions
+			if err := ro.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			if gotHWType, gotHWAddr := ro.ClientLinkLayerAddress(); gotHWType != tt.wantHWType || !bytes.Equal(gotHWAddr, tt.wantHWAddr) {
+				t.Errorf("ClientLinkLayerAddress = (%s, %v), want (%s, %v)", gotHWType, tt.wantHWType, gotHWAddr, tt.wantHWAddr)
+			}
 
-	require.NoError(t, err)
-	require.Equal(t, OptionClientLinkLayerAddr, opt.Code())
-	require.Equal(t, iana.HWTypeEthernet, opt.LinkLayerType)
-	require.Equal(t, net.HardwareAddr(data[2:]), opt.LinkLayerAddress)
-	require.Equal(t, "Client Link-Layer Address: Type=Ethernet LinkLayerAddress=a4:83:e7:e3:df:88", opt.String())
+			if tt.err == nil {
+				var m MessageOptions
+				m.Add(OptClientLinkLayerAddress(tt.wantHWType, tt.wantHWAddr))
+				got := m.ToBytes()
+				if diff := cmp.Diff(tt.buf, got); diff != "" {
+					t.Errorf("ToBytes mismatch (-want, +got): %s", diff)
+				}
+			}
+		})
+	}
 }
 
-func TestOptClientLinkLayerAddressToBytes(t *testing.T) {
-	mac, _ := net.ParseMAC("a4:83:e7:e3:df:88")
-	opt := optClientLinkLayerAddress{
-		LinkLayerType:    iana.HWTypeEthernet,
-		LinkLayerAddress: mac,
-	}
-	want := []byte{
-		0, 1, // LinkLayerType
-		164, 131, 231, 227, 223, 136,
-	}
-	b := opt.ToBytes()
-	if !bytes.Equal(b, want) {
-		t.Fatalf("opt.ToBytes()=%v, want %v", b, want)
-	}
+func TestOptClientLinkLayerAddressString(t *testing.T) {
+	opt := OptClientLinkLayerAddress(iana.HWTypeEthernet, net.HardwareAddr{0xa4, 0x83, 0xe7, 0xe3, 0xdf, 0x88})
+	require.Equal(t, "Client Link-Layer Address: Type=Ethernet LinkLayerAddress=a4:83:e7:e3:df:88", opt.String())
 }

--- a/dhcpv6/option_domainsearchlist_test.go
+++ b/dhcpv6/option_domainsearchlist_test.go
@@ -1,49 +1,84 @@
 package dhcpv6
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/insomniacslk/dhcp/rfc1035label"
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/uio/uio"
 )
 
-func TestParseOptDomainSearchList(t *testing.T) {
-	data := []byte{
-		7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
-		6, 's', 'u', 'b', 'n', 'e', 't', 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'o', 'r', 'g', 0,
-	}
-	var opt optDomainSearchList
-	err := opt.FromBytes(data)
-	require.NoError(t, err)
-	require.Equal(t, OptionDomainSearchList, opt.Code())
-	require.Equal(t, 2, len(opt.DomainSearchList.Labels))
-	require.Equal(t, "example.com", opt.DomainSearchList.Labels[0])
-	require.Equal(t, "subnet.example.org", opt.DomainSearchList.Labels[1])
-	require.Contains(t, opt.String(), "example.com subnet.example.org", "String() should contain the correct domain search output")
-}
-
-func TestOptDomainSearchListToBytes(t *testing.T) {
-	expected := []byte{
-		7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
-		6, 's', 'u', 'b', 'n', 'e', 't', 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'o', 'r', 'g', 0,
-	}
-	opt := OptDomainSearchList(
-		&rfc1035label.Labels{
-			Labels: []string{
-				"example.com",
-				"subnet.example.org",
+func TestDomainSearchListParseAndGetter(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		err  error
+		want *rfc1035label.Labels
+	}{
+		{
+			buf: []byte{
+				0, 24, // Domain Search List option
+				0, 33, // length
+				7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
+				6, 's', 'u', 'b', 'n', 'e', 't', 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'o', 'r', 'g', 0,
+			},
+			want: &rfc1035label.Labels{
+				Labels: []string{
+					"example.com",
+					"subnet.example.org",
+				},
 			},
 		},
-	)
-	require.Equal(t, expected, opt.ToBytes())
+		{
+			buf: []byte{
+				0, 24, // Domain Search List option
+				0, 22, // length
+				7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
+				6, 's', 'u', 'b', 'n', 'e', 't', 7, 'e', // truncated
+			},
+			err: rfc1035label.ErrBufferTooShort,
+		},
+		{
+			buf:  nil,
+			want: nil,
+		},
+		{
+			buf:  []byte{0, 24, 0},
+			want: nil,
+			err:  uio.ErrUnreadBytes,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var mo MessageOptions
+			if err := mo.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			got := mo.DomainSearchList()
+			if !cmp.Equal(got, tt.want, cmpopts.IgnoreUnexported(rfc1035label.Labels{})) {
+				t.Errorf("DomainSearchList = %v, want %v", got, tt.want)
+			}
+
+			if tt.want != nil {
+				var m MessageOptions
+				m.Add(OptDomainSearchList(tt.want))
+				got := m.ToBytes()
+				if diff := cmp.Diff(tt.buf, got); diff != "" {
+					t.Errorf("ToBytes mismatch (-want, +got): %s", diff)
+				}
+			}
+		})
+	}
 }
 
-func TestParseOptDomainSearchListInvalidLength(t *testing.T) {
-	data := []byte{
-		7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
-		6, 's', 'u', 'b', 'n', 'e', 't', 7, 'e', // truncated
-	}
-	var opt optDomainSearchList
-	err := opt.FromBytes(data)
-	require.Error(t, err, "A truncated OptDomainSearchList should return an error")
+func TestOptDomainSearchListString(t *testing.T) {
+	opt := OptDomainSearchList(&rfc1035label.Labels{
+		Labels: []string{
+			"example.com",
+			"subnet.example.org",
+		},
+	})
+	require.Contains(t, opt.String(), "example.com subnet.example.org", "String() should contain the correct domain search output")
 }

--- a/dhcpv6/option_elapsedtime_test.go
+++ b/dhcpv6/option_elapsedtime_test.go
@@ -1,29 +1,69 @@
 package dhcpv6
 
 import (
-	"bytes"
+	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/google/go-cmp/cmp"
+	"github.com/u-root/uio/uio"
 )
 
-func TestOptElapsedTime(t *testing.T) {
-	var opt optElapsedTime
-	err := opt.FromBytes([]byte{0xaa, 0xbb})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if elapsedTime := opt.ElapsedTime; elapsedTime != 0xaabb*10*time.Millisecond {
-		t.Fatalf("Invalid elapsed time. Expected 0xaabb, got %v", elapsedTime)
-	}
-}
+func TestElapsedTimeParseAndGetter(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		err  error
+		want time.Duration
+	}{
+		{
+			buf: []byte{
+				0, 8, // Elapsed Time option
+				0, 2, // length
+				0, 2,
+			},
+			want: 20 * time.Millisecond,
+		},
+		{
+			buf: []byte{
+				0, 8, // Elapsed Time option
+				0, 1, // length
+				0,
+			},
+			err: uio.ErrBufferTooShort,
+		},
+		{
+			buf: []byte{
+				0, 8, // Elapsed Time option
+				0, 3, // length
+				0, 2, 2,
+			},
+			err: uio.ErrUnreadBytes,
+		},
+		{
+			buf: []byte{0, 8, 0},
+			err: uio.ErrUnreadBytes,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var mo MessageOptions
+			if err := mo.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			if got := mo.ElapsedTime(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ElapsedTime = %v, want %v", got, tt.want)
+			}
 
-func TestOptElapsedTimeToBytes(t *testing.T) {
-	opt := OptElapsedTime(0)
-	expected := []byte{0, 0}
-	if toBytes := opt.ToBytes(); !bytes.Equal(expected, toBytes) {
-		t.Fatalf("Invalid ToBytes output. Expected %v, got %v", expected, toBytes)
+			if tt.err == nil {
+				var m MessageOptions
+				m.Add(OptElapsedTime(tt.want))
+				got := m.ToBytes()
+				if diff := cmp.Diff(tt.buf, got); diff != "" {
+					t.Errorf("ToBytes mismatch (-want, +got): %s", diff)
+				}
+			}
+		})
 	}
 }
 
@@ -33,13 +73,4 @@ func TestOptElapsedTimeString(t *testing.T) {
 	if optString := opt.String(); optString != expected {
 		t.Fatalf("Invalid elapsed time string. Expected %v, got %v", expected, optString)
 	}
-}
-
-func TestOptElapsedTimeParseInvalidOption(t *testing.T) {
-	var opt optElapsedTime
-	err := opt.FromBytes([]byte{0xaa})
-	require.Error(t, err, "A short option should return an error")
-
-	err = opt.FromBytes([]byte{0xaa, 0xbb, 0xcc})
-	require.Error(t, err, "An option with too many bytes should return an error")
 }

--- a/dhcpv6/option_fqdn_test.go
+++ b/dhcpv6/option_fqdn_test.go
@@ -1,43 +1,88 @@
 package dhcpv6
 
 import (
-	"bytes"
+	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/insomniacslk/dhcp/rfc1035label"
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/uio/uio"
 )
 
-func TestParseOptFQDN(t *testing.T) {
-	data := []byte{
-		0, // Flags
-		4, 'c', 'n', 'o', 's', 9, 'l', 'o', 'c', 'a', 'l',
-		'h', 'o', 's', 't', 0,
-	}
-	var opt OptFQDN
-	err := opt.FromBytes(data)
+func TestFQDNParseAndGetter(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		err  error
+		want *OptFQDN
+	}{
+		{
+			buf: []byte{
+				0, 39, // FQDN option
+				0, 34, // length
+				0, // flags
+				7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
+				6, 's', 'u', 'b', 'n', 'e', 't', 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'o', 'r', 'g', 0,
+			},
+			want: &OptFQDN{
+				Flags: 0,
+				DomainName: &rfc1035label.Labels{
+					Labels: []string{
+						"example.com",
+						"subnet.example.org",
+					},
+				},
+			},
+		},
+		{
+			buf: []byte{
+				0, 39, // FQDN
+				0, 23, // length
+				0, // flags
+				7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
+				6, 's', 'u', 'b', 'n', 'e', 't', 7, 'e', // truncated
+			},
+			err: rfc1035label.ErrBufferTooShort,
+		},
+		{
+			buf:  nil,
+			want: nil,
+		},
+		{
+			buf:  []byte{0, 39, 0},
+			want: nil,
+			err:  uio.ErrUnreadBytes,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var mo MessageOptions
+			if err := mo.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			got := mo.FQDN()
+			if !cmp.Equal(got, tt.want, cmpopts.IgnoreUnexported(rfc1035label.Labels{})) {
+				t.Errorf("FQDN = %v, want %v", got, tt.want)
+			}
 
-	require.NoError(t, err)
-	require.Equal(t, OptionFQDN, opt.Code())
-	require.Equal(t, uint8(0), opt.Flags)
-	require.Equal(t, "cnos.localhost", opt.DomainName.Labels[0])
-	require.Equal(t, "FQDN: {Flags=0 DomainName=[cnos.localhost]}", opt.String())
+			if tt.want != nil {
+				var m MessageOptions
+				m.Add(tt.want)
+				got := m.ToBytes()
+				if diff := cmp.Diff(tt.buf, got); diff != "" {
+					t.Errorf("ToBytes mismatch (-want, +got): %s", diff)
+				}
+			}
+		})
+	}
 }
 
-func TestOptFQDNToBytes(t *testing.T) {
-	opt := OptFQDN{
-		Flags: 0,
+func TestOptFQDNString(t *testing.T) {
+	opt := &OptFQDN{
 		DomainName: &rfc1035label.Labels{
 			Labels: []string{"cnos.localhost"},
 		},
 	}
-	want := []byte{
-		0, // Flags
-		4, 'c', 'n', 'o', 's', 9, 'l', 'o', 'c', 'a', 'l',
-		'h', 'o', 's', 't', 0,
-	}
-	b := opt.ToBytes()
-	if !bytes.Equal(b, want) {
-		t.Fatalf("opt.ToBytes()=%v, want %v", b, want)
-	}
+	require.Equal(t, "FQDN: {Flags=0 DomainName=[cnos.localhost]}", opt.String())
 }

--- a/dhcpv6/option_iaaddress_test.go
+++ b/dhcpv6/option_iaaddress_test.go
@@ -1,77 +1,151 @@
 package dhcpv6
 
 import (
+	"errors"
+	"fmt"
 	"net"
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/insomniacslk/dhcp/iana"
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/uio/uio"
 )
 
-func TestOptIAAddressParse(t *testing.T) {
-	ipaddr := []byte{0x24, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
-	data := append(ipaddr, []byte{
-		0xa, 0xb, 0xc, 0xd, // preferred lifetime
-		0xe, 0xf, 0x1, 0x2, // valid lifetime
-		0, 8, 0, 2, 0xaa, 0xbb, // options
-	}...)
-	var opt OptIAAddress
-	err := opt.FromBytes(data)
-	require.NoError(t, err)
-	require.Equal(t, net.IP(ipaddr), opt.IPv6Addr)
-	require.Equal(t, 0x0a0b0c0d*time.Second, opt.PreferredLifetime)
-	require.Equal(t, 0x0e0f0102*time.Second, opt.ValidLifetime)
-}
+func TestIAAddressParseAndGetter(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		err  error
+		want []*OptIAAddress
+	}{
+		{
+			buf: []byte{
+				0, 5, // IAAddr option
+				0, 0x18, // length
+				0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0, // IPv6
+				0, 0, 0, 2, // PreferredLifetime
+				0, 0, 0, 4, // ValidLifetime
+			},
+			want: []*OptIAAddress{
+				&OptIAAddress{
+					IPv6Addr:          net.IP{0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0},
+					PreferredLifetime: 2 * time.Second,
+					ValidLifetime:     4 * time.Second,
+					Options:           AddressOptions{Options: Options{}},
+				},
+			},
+		},
+		{
+			buf: []byte{
+				0, 5, // IAAddr option
+				0, 32, // length
+				0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0, // IPv6
+				0, 0, 0, 2, // PreferredLifetime
+				0, 0, 0, 4, // ValidLifetime
+				0, 13, // option status code
+				0, 4, // length
+				0, 0, // StatusSuccess,
+				'O', 'K', // OK
+			},
+			want: []*OptIAAddress{
+				&OptIAAddress{
+					IPv6Addr:          net.IP{0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0},
+					PreferredLifetime: 2 * time.Second,
+					ValidLifetime:     4 * time.Second,
+					Options: AddressOptions{Options: Options{
+						&OptStatusCode{StatusCode: iana.StatusSuccess, StatusMessage: "OK"},
+					}},
+				},
+			},
+		},
+		{
+			buf: []byte{
+				0, 5, // IAAddr option
+				0, 0x18, // length
+				0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0, // IPv6
+				0, 0, 0, 2, // PreferredLifetime
+				0, 0, 0, 4, // ValidLifetime
 
-func TestOptIAAddressParseInvalidTooShort(t *testing.T) {
-	data := []byte{
-		0x24, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-		0xa, 0xb, 0xc, 0xd, // preferred lifetime
-		// truncated here
-	}
-	var opt OptIAAddress
-	err := opt.FromBytes(data)
-	require.Error(t, err)
-}
+				0, 5, // IAAddr option
+				0, 0x18, // length
+				0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0, // IPv6
+				0, 0, 0, 2, // PreferredLifetime
+				0, 0, 0, 4, // ValidLifetime
+			},
+			want: []*OptIAAddress{
+				&OptIAAddress{
+					IPv6Addr:          net.IP{0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0},
+					PreferredLifetime: 2 * time.Second,
+					ValidLifetime:     4 * time.Second,
+					Options:           AddressOptions{Options: Options{}},
+				},
+				&OptIAAddress{
+					IPv6Addr:          net.IP{0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0},
+					PreferredLifetime: 2 * time.Second,
+					ValidLifetime:     4 * time.Second,
+					Options:           AddressOptions{Options: Options{}},
+				},
+			},
+		},
+		{
+			buf:  []byte{0, 3, 0, 1, 0},
+			want: nil,
+			err:  uio.ErrUnreadBytes,
+		},
+		{
+			buf: []byte{
+				0, 5, // IAAddr option code
+				0, 4, // length
+				0, 0, 0, 1, // truncated IP
+			},
+			want: nil,
+			err:  uio.ErrBufferTooShort,
+		},
+		{
+			buf: []byte{
+				0, 5, // IAAddr option
+				0, 28, // length
+				0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0, // IPv6
+				0, 0, 0, 2, // PreferredLifetime
+				0, 0, 0, 4, // ValidLifetime
+				0, 13, // option status code
+				0, 1, // length
+				// option too short
+			},
+			err: uio.ErrBufferTooShort,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var io IdentityOptions
+			if err := io.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			if got := io.Addresses(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Addresses = %v, want %v", got, tt.want)
+			}
 
-func TestOptIAAddressParseInvalidBrokenOptions(t *testing.T) {
-	data := []byte{
-		0x24, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-		0xa, 0xb, 0xc, 0xd, // preferred lifetime
-		0xe, 0xf, 0x1, 0x2, // valid lifetime
-		0, 8, 0, 2, 0xaa, // broken options
-	}
-	var opt OptIAAddress
-	err := opt.FromBytes(data)
-	require.Error(t, err)
-}
+			var wantOneAddr *OptIAAddress
+			if len(tt.want) >= 1 {
+				wantOneAddr = tt.want[0]
+			}
+			if got := io.OneAddress(); !reflect.DeepEqual(got, wantOneAddr) {
+				t.Errorf("OneAddress = %v, want %v", got, wantOneAddr)
+			}
 
-func TestOptIAAddressToBytesDefault(t *testing.T) {
-	want := []byte{
-		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // IP
-		0, 0, 0, 0, // preferred lifetime
-		0, 0, 0, 0, // valid lifetime
+			if len(tt.want) >= 1 {
+				var b IdentityOptions
+				for _, iana := range tt.want {
+					b.Add(iana)
+				}
+				got := b.ToBytes()
+				if diff := cmp.Diff(tt.buf, got); diff != "" {
+					t.Errorf("ToBytes mismatch (-want, +got): %s", diff)
+				}
+			}
+		})
 	}
-	opt := OptIAAddress{}
-	require.Equal(t, opt.ToBytes(), want)
-}
-
-func TestOptIAAddressToBytes(t *testing.T) {
-	ipBytes := []byte{0x24, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
-	expected := append(ipBytes, []byte{
-		0xa, 0xb, 0xc, 0xd, // preferred lifetime
-		0xe, 0xf, 0x1, 0x2, // valid lifetime
-		0, 8, 0, 2, 0x00, 0x01, // options
-	}...)
-	opt := OptIAAddress{
-		IPv6Addr:          net.IP(ipBytes),
-		PreferredLifetime: 0x0a0b0c0d * time.Second,
-		ValidLifetime:     0x0e0f0102 * time.Second,
-		Options: AddressOptions{[]Option{
-			OptElapsedTime(10 * time.Millisecond),
-		}},
-	}
-	require.Equal(t, expected, opt.ToBytes())
 }
 
 func TestOptIAAddressString(t *testing.T) {

--- a/dhcpv6/option_iapd.go
+++ b/dhcpv6/option_iapd.go
@@ -18,6 +18,9 @@ type PDOptions struct {
 // Prefixes are the prefixes associated with this delegation.
 func (po PDOptions) Prefixes() []*OptIAPrefix {
 	opts := po.Options.Get(OptionIAPrefix)
+	if len(opts) == 0 {
+		return nil
+	}
 	pre := make([]*OptIAPrefix, 0, len(opts))
 	for _, o := range opts {
 		if iap, ok := o.(*OptIAPrefix); ok {

--- a/dhcpv6/option_iapd_test.go
+++ b/dhcpv6/option_iapd_test.go
@@ -1,125 +1,172 @@
 package dhcpv6
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/uio/uio"
 )
 
-func TestParseMessageWithIAPD(t *testing.T) {
-	data := []byte{
-		0, 25, // IAPD option code
-		0, 41, // length
-		1, 0, 0, 0, // IAID
-		0, 0, 0, 1, // T1
-		0, 0, 0, 2, // T2
-		0, 26, 0, 25, // 26 = IAPrefix Option, 25 = length
-		0, 0, 0, 2, // IAPrefix preferredLifetime
-		0, 0, 0, 4, // IAPrefix validLifetime
-		36,                                             // IAPrefix prefixLength
-		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // IAPrefix ipv6Prefix
-	}
-	var got MessageOptions
-	if err := got.FromBytes(data); err != nil {
-		t.Errorf("FromBytes = %v", err)
-	}
-
-	want := &OptIAPD{
-		IaId: [4]byte{1, 0, 0, 0},
-		T1:   1 * time.Second,
-		T2:   2 * time.Second,
-		Options: PDOptions{Options: Options{&OptIAPrefix{
-			PreferredLifetime: 2 * time.Second,
-			ValidLifetime:     4 * time.Second,
-			Prefix: &net.IPNet{
-				Mask: net.CIDRMask(36, 128),
-				IP:   net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+func TestIAPDParseAndGetter(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		err  error
+		want []*OptIAPD
+	}{
+		{
+			buf: []byte{
+				0, 25, // IAPD option code
+				0, 41, // length
+				1, 0, 0, 0, // IAID
+				0, 0, 0, 1, // T1
+				0, 0, 0, 2, // T2
+				0, 26, 0, 25, // 26 = IAPrefix Option, 25 = length
+				0, 0, 0, 2, // IAPrefix preferredLifetime
+				0, 0, 0, 4, // IAPrefix validLifetime
+				36,                                             // IAPrefix prefixLength
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // IAPrefix ipv6Prefix
 			},
-			Options: PrefixOptions{Options: Options{}},
-		}}},
-	}
-	if gotIAPD := got.OneIAPD(); !reflect.DeepEqual(gotIAPD, want) {
-		t.Errorf("OneIAPD = %v, want %v", gotIAPD, want)
-	}
-}
-
-func TestOptIAPDParseOptIAPD(t *testing.T) {
-	data := []byte{
-		1, 0, 0, 0, // IAID
-		0, 0, 0, 1, // T1
-		0, 0, 0, 2, // T2
-		0, 26, 0, 25, // 26 = IAPrefix Option, 25 = length
-		0xaa, 0xbb, 0xcc, 0xdd, // IAPrefix preferredLifetime
-		0xee, 0xff, 0x00, 0x11, // IAPrefix validLifetime
-		36,                                             // IAPrefix prefixLength
-		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // IAPrefix ipv6Prefix
-	}
-	var opt OptIAPD
-	err := opt.FromBytes(data)
-	require.NoError(t, err)
-	require.Equal(t, OptionIAPD, opt.Code())
-	require.Equal(t, [4]byte{1, 0, 0, 0}, opt.IaId)
-	require.Equal(t, time.Second, opt.T1)
-	require.Equal(t, 2*time.Second, opt.T2)
-}
-
-func TestOptIAPDParseOptIAPDInvalidLength(t *testing.T) {
-	data := []byte{
-		1, 0, 0, 0, // IAID
-		0, 0, 0, 1, // T1
-		// truncated from here
-	}
-	var opt OptIAPD
-	err := opt.FromBytes(data)
-	require.Error(t, err)
-}
-
-func TestOptIAPDParseOptIAPDInvalidOptions(t *testing.T) {
-	data := []byte{
-		1, 0, 0, 0, // IAID
-		0, 0, 0, 1, // T1
-		0, 0, 0, 2, // T2
-		0, 26, 0, 25, // 26 = IAPrefix Option, 25 = length
-		0xaa, 0xbb, 0xcc, 0xdd, // IAPrefix preferredLifetime
-		0xee, 0xff, 0x00, 0x11, // IAPrefix validLifetime
-		36,                                          // IAPrefix prefixLength
-		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // IAPrefix ipv6Prefix missing last byte
-	}
-	var opt OptIAPD
-	err := opt.FromBytes(data)
-	require.Error(t, err)
-}
-
-func TestOptIAPDToBytes(t *testing.T) {
-	oaddr := OptIAPrefix{
-		PreferredLifetime: 0xaabbccdd * time.Second,
-		ValidLifetime:     0xeeff0011 * time.Second,
-		Prefix: &net.IPNet{
-			Mask: net.CIDRMask(36, 128),
-			IP:   net.IPv6loopback,
+			want: []*OptIAPD{
+				&OptIAPD{
+					IaId: [4]byte{1, 0, 0, 0},
+					T1:   1 * time.Second,
+					T2:   2 * time.Second,
+					Options: PDOptions{Options: Options{&OptIAPrefix{
+						PreferredLifetime: 2 * time.Second,
+						ValidLifetime:     4 * time.Second,
+						Prefix: &net.IPNet{
+							Mask: net.CIDRMask(36, 128),
+							IP:   net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+						},
+						Options: PrefixOptions{Options: Options{}},
+					}}},
+				},
+			},
 		},
-	}
-	opt := OptIAPD{
-		IaId:    [4]byte{1, 2, 3, 4},
-		T1:      12345 * time.Second,
-		T2:      54321 * time.Second,
-		Options: PDOptions{[]Option{&oaddr}},
-	}
+		{
+			buf: []byte{
+				0, 25, // IAPD option code
+				0, 41, // length
+				1, 0, 0, 0, // IAID
+				0, 0, 0, 1, // T1
+				0, 0, 0, 2, // T2
+				0, 26, 0, 25, // 26 = IAPrefix Option, 25 = length
+				0, 0, 0, 2, // IAPrefix preferredLifetime
+				0, 0, 0, 4, // IAPrefix validLifetime
+				36,                                             // IAPrefix prefixLength
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // IAPrefix ipv6Prefix
 
-	expected := []byte{
-		1, 2, 3, 4, // IA ID
-		0, 0, 0x30, 0x39, // T1 = 12345
-		0, 0, 0xd4, 0x31, // T2 = 54321
-		0, 26, 0, 25, // 26 = IAPrefix Option, 25 = length
-		0xaa, 0xbb, 0xcc, 0xdd, // IAPrefix preferredLifetime
-		0xee, 0xff, 0x00, 0x11, // IAPrefix validLifetime
-		36,                                             // IAPrefix prefixLength
-		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // IAPrefix ipv6Prefix
+				0, 25, // IAPD option code
+				0, 41, // length
+				1, 2, 3, 4, // IAID
+				0, 0, 0, 5, // T1
+				0, 0, 0, 6, // T2
+				0, 26, 0, 25, // 26 = IAPrefix Option, 25 = length
+				0, 0, 0, 2, // IAPrefix preferredLifetime
+				0, 0, 0, 4, // IAPrefix validLifetime
+				36,                                             // IAPrefix prefixLength
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // IAPrefix ipv6Prefix
+			},
+			want: []*OptIAPD{
+				&OptIAPD{
+					IaId: [4]byte{1, 0, 0, 0},
+					T1:   1 * time.Second,
+					T2:   2 * time.Second,
+					Options: PDOptions{Options: Options{&OptIAPrefix{
+						PreferredLifetime: 2 * time.Second,
+						ValidLifetime:     4 * time.Second,
+						Prefix: &net.IPNet{
+							Mask: net.CIDRMask(36, 128),
+							IP:   net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+						},
+						Options: PrefixOptions{Options: Options{}},
+					}}},
+				},
+				&OptIAPD{
+					IaId: [4]byte{1, 2, 3, 4},
+					T1:   5 * time.Second,
+					T2:   6 * time.Second,
+					Options: PDOptions{Options: Options{&OptIAPrefix{
+						PreferredLifetime: 2 * time.Second,
+						ValidLifetime:     4 * time.Second,
+						Prefix: &net.IPNet{
+							Mask: net.CIDRMask(36, 128),
+							IP:   net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+						},
+						Options: PrefixOptions{Options: Options{}},
+					}}},
+				},
+			},
+		},
+		{
+			buf:  nil,
+			want: nil,
+		},
+		{
+			buf:  []byte{0, 25, 0, 1, 0},
+			want: nil,
+			err:  uio.ErrBufferTooShort,
+		},
+		{
+			buf: []byte{
+				0, 25, // IAPD option code
+				0, 8, // length
+				1, 0, 0, 0, // IAID
+				0, 0, 0, 1, // T1
+				// truncated from here
+			},
+			want: nil,
+			err:  uio.ErrBufferTooShort,
+		},
+		{
+			buf: []byte{
+				0, 25, // IAPD option code
+				0, 36, // length
+				1, 0, 0, 0, // IAID
+				0, 0, 0, 1, // T1
+				0, 0, 0, 2, // T2
+				0, 26, 0, 4, // 26 = IAPrefix Option, 4 = length
+				0, 0, 0, 2, // IAPrefix preferredLifetime
+				// Missing stuff
+			},
+			want: nil,
+			err:  uio.ErrBufferTooShort,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var mo MessageOptions
+			if err := mo.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			if got := mo.IAPD(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IAPD = %v, want %v", got, tt.want)
+			}
+			var wantOne *OptIAPD
+			if len(tt.want) >= 1 {
+				wantOne = tt.want[0]
+			}
+			if got := mo.OneIAPD(); !reflect.DeepEqual(got, wantOne) {
+				t.Errorf("OneIAPD = %v, want %v", got, wantOne)
+			}
+
+			if len(tt.want) >= 1 {
+				var b MessageOptions
+				for _, iana := range tt.want {
+					b.Add(iana)
+				}
+				got := b.ToBytes()
+				if diff := cmp.Diff(tt.buf, got); diff != "" {
+					t.Errorf("ToBytes mismatch (-want, +got): %s", diff)
+				}
+			}
+		})
 	}
-	require.Equal(t, expected, opt.ToBytes())
 }
 
 func TestOptIAPDString(t *testing.T) {

--- a/dhcpv6/option_iapd_test.go
+++ b/dhcpv6/option_iapd_test.go
@@ -111,7 +111,7 @@ func TestIAPDParseAndGetter(t *testing.T) {
 		{
 			buf:  []byte{0, 25, 0, 1, 0},
 			want: nil,
-			err:  uio.ErrBufferTooShort,
+			err:  uio.ErrUnreadBytes,
 		},
 		{
 			buf: []byte{

--- a/dhcpv6/option_informationrefreshtime_test.go
+++ b/dhcpv6/option_informationrefreshtime_test.go
@@ -2,9 +2,67 @@ package dhcpv6
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/u-root/uio/uio"
 )
+
+func TestInformationRefreshTimeParseAndGetter(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		err  error
+		want time.Duration
+	}{
+		{
+			buf: []byte{
+				0, 32, // IRT option
+				0, 4, // length
+				0, 0, 0, 3,
+			},
+			want: 3 * time.Second,
+		},
+		{
+			buf: []byte{
+				0, 32, // IRT option
+				0, 6, // length
+				0, 0, 0, 3, 0, 0,
+			},
+			err: uio.ErrUnreadBytes,
+		},
+		{
+			buf: []byte{0, 32, 0, 1, 0},
+			err: uio.ErrBufferTooShort,
+		},
+		{
+			buf: []byte{0, 32, 0},
+			err: uio.ErrUnreadBytes,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var mo MessageOptions
+			if err := mo.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			if got := mo.InformationRefreshTime(0); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("InformationRefreshTime = %v, want %v", got, tt.want)
+			}
+
+			if tt.err == nil {
+				var m MessageOptions
+				m.Add(OptInformationRefreshTime(tt.want))
+				got := m.ToBytes()
+				if diff := cmp.Diff(tt.buf, got); diff != "" {
+					t.Errorf("ToBytes mismatch (-want, +got): %s", diff)
+				}
+			}
+		})
+	}
+}
 
 func TestOptInformationRefreshTime(t *testing.T) {
 	var opt optInformationRefreshTime

--- a/dhcpv6/option_nontemporaryaddress_test.go
+++ b/dhcpv6/option_nontemporaryaddress_test.go
@@ -1,78 +1,158 @@
 package dhcpv6
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/uio/uio"
 )
 
-func TestParseMessageWithIANA(t *testing.T) {
-	data := []byte{
-		0, 3, // IANA option code
-		0, 40, // length
-		1, 0, 0, 0, // IAID
-		0, 0, 0, 1, // T1
-		0, 0, 0, 2, // T2
-		0, 5, 0, 0x18, 0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0, 0, 0, 0, 2, 0, 0, 0, 4, // options
-	}
-	var got MessageOptions
-	if err := got.FromBytes(data); err != nil {
-		t.Errorf("FromBytes = %v", err)
-	}
+func TestIANAParseAndGetter(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		err  error
+		want []*OptIANA
+	}{
+		{
+			buf: []byte{
+				0, 3, // IANA option code
+				0, 40, // length
+				1, 0, 0, 0, // IAID
+				0, 0, 0, 1, // T1
+				0, 0, 0, 2, // T2
+				0, 5, 0, 0x18, 0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0, // IPv6
+				0, 0, 0, 2, // PreferredLifetime
+				0, 0, 0, 4, // ValidLifetime
+			},
+			want: []*OptIANA{
+				&OptIANA{
+					IaId: [4]byte{1, 0, 0, 0},
+					T1:   1 * time.Second,
+					T2:   2 * time.Second,
+					Options: IdentityOptions{Options: Options{&OptIAAddress{
+						IPv6Addr:          net.IP{0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0},
+						PreferredLifetime: 2 * time.Second,
+						ValidLifetime:     4 * time.Second,
+						Options:           AddressOptions{Options: Options{}},
+					}}},
+				},
+			},
+		},
+		{
+			buf: []byte{
+				0, 3, // IANA option code
+				0, 40, // length
+				1, 0, 0, 0, // IAID
+				0, 0, 0, 1, // T1
+				0, 0, 0, 2, // T2
+				0, 5, 0, 0x18, 0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0, // IPv6
+				0, 0, 0, 2, // PreferredLifetime
+				0, 0, 0, 4, // ValidLifetime
 
-	want := &OptIANA{
-		IaId: [4]byte{1, 0, 0, 0},
-		T1:   1 * time.Second,
-		T2:   2 * time.Second,
-		Options: IdentityOptions{Options: Options{&OptIAAddress{
-			IPv6Addr:          net.IP{0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0},
-			PreferredLifetime: 2 * time.Second,
-			ValidLifetime:     4 * time.Second,
-			Options:           AddressOptions{Options: Options{}},
-		}}},
-	}
-	if gotIANA := got.OneIANA(); !reflect.DeepEqual(gotIANA, want) {
-		t.Errorf("OneIANA = %v, want %v", gotIANA, want)
-	}
-}
+				0, 3, // IANA option code
+				0, 40, // length
+				1, 2, 3, 4, // IAID
+				0, 0, 0, 9, // T1
+				0, 0, 0, 8, // T2
+				0, 5, 0, 0x18, 0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0, // IPv6
+				0, 0, 0, 2, // PreferredLifetime
+				0, 0, 0, 4, // ValidLifetime
+			},
+			want: []*OptIANA{
+				&OptIANA{
+					IaId: [4]byte{1, 0, 0, 0},
+					T1:   1 * time.Second,
+					T2:   2 * time.Second,
+					Options: IdentityOptions{Options: Options{&OptIAAddress{
+						IPv6Addr:          net.IP{0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0},
+						PreferredLifetime: 2 * time.Second,
+						ValidLifetime:     4 * time.Second,
+						Options:           AddressOptions{Options: Options{}},
+					}}},
+				},
+				&OptIANA{
+					IaId: [4]byte{1, 2, 3, 4},
+					T1:   9 * time.Second,
+					T2:   8 * time.Second,
+					Options: IdentityOptions{Options: Options{&OptIAAddress{
+						IPv6Addr:          net.IP{0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0},
+						PreferredLifetime: 2 * time.Second,
+						ValidLifetime:     4 * time.Second,
+						Options:           AddressOptions{Options: Options{}},
+					}}},
+				},
+			},
+		},
 
-func TestOptIANAParseOptIANA(t *testing.T) {
-	data := []byte{
-		1, 0, 0, 0, // IAID
-		0, 0, 0, 1, // T1
-		0, 0, 0, 2, // T2
-		0, 5, 0, 0x18, 0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0, 0, 0, 0xb2, 0x7a, 0, 0, 0xc0, 0x8a, // options
-	}
-	var opt OptIANA
-	err := opt.FromBytes(data)
-	require.NoError(t, err)
-	require.Equal(t, OptionIANA, opt.Code())
-}
+		{
+			buf:  nil,
+			want: nil,
+		},
+		{
+			buf:  []byte{0, 3, 0, 1, 0},
+			want: nil,
+			err:  uio.ErrBufferTooShort,
+		},
+		{
+			buf: []byte{
+				0, 3, // IANA option code
+				0, 8, // length
+				1, 0, 0, 0, // IAID
+				0, 0, 0, 1, // T1
+				// truncated from here
+			},
+			want: nil,
+			err:  uio.ErrBufferTooShort,
+		},
+		{
+			buf: []byte{
+				0, 3, // IANA option code
+				0, 36, // length
+				1, 0, 0, 0, // IAID
+				0, 0, 0, 1, // T1
+				0, 0, 0, 2, // T2
+				0, 5, 0, 0x18, 0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0, // IPv6
+				0, 0, 0xb2, 0x7a, // PreferredLifetime
+				// Missing ValidLifetime
+			},
+			want: nil,
+			err:  uio.ErrBufferTooShort,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var mo MessageOptions
+			if err := mo.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			if got := mo.IANA(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IANA = %v, want %v", got, tt.want)
+			}
+			var wantOne *OptIANA
+			if len(tt.want) >= 1 {
+				wantOne = tt.want[0]
+			}
+			if got := mo.OneIANA(); !reflect.DeepEqual(got, wantOne) {
+				t.Errorf("OneIANA = %v, want %v", got, wantOne)
+			}
 
-func TestOptIANAParseOptIANAInvalidLength(t *testing.T) {
-	data := []byte{
-		1, 0, 0, 0, // IAID
-		0, 0, 0, 1, // T1
-		// truncated from here
+			if len(tt.want) >= 1 {
+				var b MessageOptions
+				for _, iana := range tt.want {
+					b.Add(iana)
+				}
+				got := b.ToBytes()
+				if diff := cmp.Diff(tt.buf, got); diff != "" {
+					t.Errorf("ToBytes mismatch (-want, +got): %s", diff)
+				}
+			}
+		})
 	}
-	var opt OptIANA
-	err := opt.FromBytes(data)
-	require.Error(t, err)
-}
-
-func TestOptIANAParseOptIANAInvalidOptions(t *testing.T) {
-	data := []byte{
-		1, 0, 0, 0, // IAID
-		0, 0, 0, 1, // T1
-		0, 0, 0, 2, // T2
-		0, 5, 0, 0x18, 0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0, 0, 0, 0xb2, 0x7a, // truncated options
-	}
-	var opt OptIANA
-	err := opt.FromBytes(data)
-	require.Error(t, err)
 }
 
 func TestOptIANAGetOneOption(t *testing.T) {
@@ -127,30 +207,14 @@ func TestOptIANADelOption(t *testing.T) {
 	require.Equal(t, iana2.Options.Options, Options{&optsc})
 }
 
-func TestOptIANAToBytes(t *testing.T) {
-	opt := OptIANA{
-		IaId: [4]byte{1, 2, 3, 4},
-		T1:   12345 * time.Second,
-		T2:   54321 * time.Second,
-		Options: IdentityOptions{[]Option{
-			OptElapsedTime(10 * time.Millisecond),
-		}},
-	}
-	expected := []byte{
-		1, 2, 3, 4, // IA ID
-		0, 0, 0x30, 0x39, // T1 = 12345
-		0, 0, 0xd4, 0x31, // T2 = 54321
-		0, 8, 0, 2, 0x00, 0x01,
-	}
-	require.Equal(t, expected, opt.ToBytes())
-}
-
 func TestOptIANAString(t *testing.T) {
 	data := []byte{
 		1, 0, 0, 0, // IAID
 		0, 0, 0, 1, // T1
 		0, 0, 0, 2, // T2
-		0, 5, 0, 0x18, 0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0, 0, 0, 0xb2, 0x7a, 0, 0, 0xc0, 0x8a, // options
+		0, 5, 0, 0x18, 0x24, 1, 0xdb, 0, 0x30, 0x10, 0xc0, 0x8f, 0xfa, 0xce, 0, 0, 0, 0x44, 0, 0, // IPv6
+		0, 0, 0xb2, 0x7a, // PreferredLifetime
+		0, 0, 0xc0, 0x8a, // ValidLifetime
 	}
 	var opt OptIANA
 	err := opt.FromBytes(data)

--- a/dhcpv6/option_nontemporaryaddress_test.go
+++ b/dhcpv6/option_nontemporaryaddress_test.go
@@ -97,7 +97,7 @@ func TestIANAParseAndGetter(t *testing.T) {
 		{
 			buf:  []byte{0, 3, 0, 1, 0},
 			want: nil,
-			err:  uio.ErrBufferTooShort,
+			err:  uio.ErrUnreadBytes,
 		},
 		{
 			buf: []byte{

--- a/dhcpv6/option_remoteid.go
+++ b/dhcpv6/option_remoteid.go
@@ -31,7 +31,7 @@ func (op *OptRemoteID) String() string {
 	)
 }
 
-// FromBytes builds an OptRemoteId structure from a sequence of bytes. The
+// FromBytes builds an OptRemoteID structure from a sequence of bytes. The
 // input data does not include option code and length bytes.
 func (op *OptRemoteID) FromBytes(data []byte) error {
 	buf := uio.NewBigEndianBuffer(data)

--- a/dhcpv6/option_serverid_test.go
+++ b/dhcpv6/option_serverid_test.go
@@ -1,82 +1,112 @@
 package dhcpv6
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/insomniacslk/dhcp/iana"
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/uio/uio"
 )
 
-func TestParseMessageOptionsWithServerID(t *testing.T) {
-	buf := []byte{
-		0, 2, // Server ID option
-		0, 10, // length
-		0, 3, // DUID_LL
-		0, 1, // hwtype ethernet
-		0, 1, 2, 3, 4, 5, // HW addr
-	}
-
-	want := &DUIDLL{HWType: iana.HWTypeEthernet, LinkLayerAddr: net.HardwareAddr{0, 1, 2, 3, 4, 5}}
-	var mo MessageOptions
-	if err := mo.FromBytes(buf); err != nil {
-		t.Errorf("FromBytes = %v", err)
-	} else if got := mo.ServerID(); !reflect.DeepEqual(got, want) {
-		t.Errorf("ServerID = %v, want %v", got, want)
-	}
-}
-
-func TestParseOptServerID(t *testing.T) {
-	data := []byte{
-		0, 3, // DUID_LL
-		0, 1, // hwtype ethernet
-		0, 1, 2, 3, 4, 5, // hw addr
-	}
-	var opt optServerID
-	err := opt.FromBytes(data)
-	require.NoError(t, err)
-	want := OptServerID(
-		&DUIDLL{
-			HWType:        iana.HWTypeEthernet,
-			LinkLayerAddr: net.HardwareAddr{0, 1, 2, 3, 4, 5},
+func TestServerIDParseAndGetter(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		err  error
+		want DUID
+	}{
+		{
+			buf: []byte{
+				0, 2, // Server ID option
+				0, 10, // length
+				0, 3, // DUID_LL
+				0, 1, // hwtype ethernet
+				0, 1, 2, 3, 4, 5, // HW addr
+			},
+			want: &DUIDLL{HWType: iana.HWTypeEthernet, LinkLayerAddr: net.HardwareAddr{0, 1, 2, 3, 4, 5}},
 		},
-	)
-	require.Equal(t, &opt, want)
+		{
+			buf:  nil,
+			want: nil,
+		},
+		{
+			buf:  []byte{0, 1, 0, 1, 0},
+			want: nil,
+			err:  uio.ErrBufferTooShort,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var mo MessageOptions
+			if err := mo.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			if got := mo.ServerID(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ServerID = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
-func TestOptServerIdToBytes(t *testing.T) {
+func TestServerID(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		want optServerID
+		err  error
+	}{
+		{
+			buf: []byte{
+				0, 3, // DUID_LL
+				0, 1, // hwtype ethernet
+				0, 1, 2, 3, 4, 5, // hw addr
+			},
+			want: optServerID{
+				&DUIDLL{
+					HWType:        iana.HWTypeEthernet,
+					LinkLayerAddr: net.HardwareAddr([]byte{0, 1, 2, 3, 4, 5}),
+				},
+			},
+		},
+		{
+			buf: []byte{0},
+			err: uio.ErrBufferTooShort,
+		},
+		{
+			buf: []byte{0, 3, 0},
+			err: uio.ErrBufferTooShort,
+		},
+		{
+			buf: nil,
+			err: uio.ErrBufferTooShort,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var opt optServerID
+			if err := opt.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			if tt.err == nil {
+				if !reflect.DeepEqual(tt.want, opt) {
+					t.Errorf("FromBytes = %v, want %v", opt, tt.want)
+				}
+
+				out := tt.want.ToBytes()
+				if diff := cmp.Diff(tt.buf, out); diff != "" {
+					t.Errorf("ToBytes mismatch: (-want, +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestOptionServerIDString(t *testing.T) {
 	opt := OptServerID(
 		&DUIDLL{
 			HWType:        iana.HWTypeEthernet,
-			LinkLayerAddr: net.HardwareAddr{5, 4, 3, 2, 1, 0},
-		},
-	)
-	expected := []byte{
-		0, 3, // DUID_LL
-		0, 1, // hwtype ethernet
-		5, 4, 3, 2, 1, 0, // hw addr
-	}
-	require.Equal(t, expected, opt.ToBytes())
-}
-
-func TestOptServerIdDecodeEncode(t *testing.T) {
-	data := []byte{
-		0, 3, // DUID_LL
-		0, 1, // hwtype ethernet
-		5, 4, 3, 2, 1, 0, // hw addr
-	}
-	var opt optServerID
-	err := opt.FromBytes(data)
-	require.NoError(t, err)
-	require.Equal(t, data, opt.ToBytes())
-}
-
-func TestOptionServerId(t *testing.T) {
-	opt := OptServerID(
-		&DUIDLL{
-			HWType:        iana.HWTypeEthernet,
-			LinkLayerAddr: net.HardwareAddr{0xde, 0xad, 0, 0, 0xbe, 0xef},
+			LinkLayerAddr: net.HardwareAddr([]byte{0xde, 0xad, 0, 0, 0xbe, 0xef}),
 		},
 	)
 	require.Equal(t, OptionServerID, opt.Code())
@@ -84,26 +114,6 @@ func TestOptionServerId(t *testing.T) {
 		t,
 		opt.String(),
 		"Server ID: DUID-LL{HWType=Ethernet HWAddr=de:ad:00:00:be:ef}",
-		"String() should contain the correct sid output",
+		"String() should contain the correct cid output",
 	)
-}
-
-func TestOptServerIdparseOptServerIDBogusDUID(t *testing.T) {
-	data := []byte{
-		0, 4, // DUID_UUID
-		1, 2, 3, 4, 5, 6, 7, 8, 9, // a UUID should be 18 bytes not 17
-		10, 11, 12, 13, 14, 15, 16, 17,
-	}
-	var opt optServerID
-	err := opt.FromBytes(data)
-	require.Error(t, err, "A truncated OptServerId DUID should return an error")
-}
-
-func TestOptServerIdparseOptServerIDInvalidTooShort(t *testing.T) {
-	data := []byte{
-		0, // truncated: DUIDs are at least 2 bytes
-	}
-	var opt optServerID
-	err := opt.FromBytes(data)
-	require.Error(t, err, "A truncated OptServerId should return an error")
 }

--- a/dhcpv6/option_statuscode_test.go
+++ b/dhcpv6/option_statuscode_test.go
@@ -1,41 +1,69 @@
 package dhcpv6
 
 import (
+	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/insomniacslk/dhcp/iana"
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/uio/uio"
 )
 
-func TestParseOptStatusCode(t *testing.T) {
-	data := []byte{
-		0, 5, // StatusUseMulticast
-		'u', 's', 'e', ' ', 'm', 'u', 'l', 't', 'i', 'c', 'a', 's', 't',
-	}
-	var opt OptStatusCode
-	err := opt.FromBytes(data)
-	require.NoError(t, err)
-	require.Equal(t, iana.StatusUseMulticast, opt.StatusCode)
-	require.Equal(t, "use multicast", opt.StatusMessage)
-}
+func TestStatusCodeParseAndGetter(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		err  error
+		want *OptStatusCode
+	}{
+		{
+			buf: []byte{
+				0, 13, // StatusCode option
+				0, 15, // length
+				0, 5, // StatusUseMulticast
+				'u', 's', 'e', ' ', 'm', 'u', 'l', 't', 'i', 'c', 'a', 's', 't',
+			},
+			want: &OptStatusCode{
+				StatusCode:    iana.StatusUseMulticast,
+				StatusMessage: "use multicast",
+			},
+		},
+		{
+			buf:  nil,
+			want: nil,
+		},
+		{
+			buf:  []byte{0, 13, 0, 1, 0},
+			want: nil,
+			err:  uio.ErrBufferTooShort,
+		},
+		{
+			buf:  []byte{0, 13, 0},
+			want: nil,
+			err:  uio.ErrUnreadBytes,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var mo MessageOptions
+			if err := mo.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			if got := mo.Status(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Status = %v, want %v", got, tt.want)
+			}
 
-func TestOptStatusCodeToBytes(t *testing.T) {
-	expected := []byte{
-		0, 0, // StatusSuccess
-		's', 'u', 'c', 'c', 'e', 's', 's',
+			if tt.want != nil {
+				var m MessageOptions
+				m.Add(tt.want)
+				got := m.ToBytes()
+				if diff := cmp.Diff(tt.buf, got); diff != "" {
+					t.Errorf("ToBytes mismatch (-want, +got): %s", diff)
+				}
+			}
+		})
 	}
-	opt := OptStatusCode{
-		StatusCode:    iana.StatusSuccess,
-		StatusMessage: "success",
-	}
-	actual := opt.ToBytes()
-	require.Equal(t, expected, actual)
-}
-
-func TestOptStatusCodeParseOptStatusCodeTooShort(t *testing.T) {
-	var opt OptStatusCode
-	err := opt.FromBytes([]byte{0})
-	require.Error(t, err, "ParseOptStatusCode: Expected error on truncated option")
 }
 
 func TestOptStatusCodeString(t *testing.T) {

--- a/dhcpv6/option_temporaryaddress.go
+++ b/dhcpv6/option_temporaryaddress.go
@@ -9,8 +9,8 @@ import (
 // OptIATA implements the identity association for non-temporary addresses
 // option.
 //
-// This module defines the OptIATA structure.
-// https://www.ietf.org/rfc/rfc8415.txt
+// This module defines the OptIATA structure, as defined by RFC 8415 Section
+// 21.5.
 type OptIATA struct {
 	IaId    [4]byte
 	Options IdentityOptions

--- a/dhcpv6/option_temporaryaddress_test.go
+++ b/dhcpv6/option_temporaryaddress_test.go
@@ -85,7 +85,7 @@ func TestIATAParseAndGetter(t *testing.T) {
 		{
 			buf:  []byte{0, 4, 0, 1, 0},
 			want: nil,
-			err:  uio.ErrBufferTooShort,
+			err:  uio.ErrUnreadBytes,
 		},
 		{
 			buf: []byte{
@@ -94,7 +94,7 @@ func TestIATAParseAndGetter(t *testing.T) {
 				1, 0, 0, // IAID too short
 			},
 			want: nil,
-			err:  uio.ErrBufferTooShort,
+			err:  uio.ErrUnreadBytes,
 		},
 		{
 			buf: []byte{

--- a/dhcpv6/option_userclass.go
+++ b/dhcpv6/option_userclass.go
@@ -42,7 +42,7 @@ func (op *OptUserClass) String() string {
 // input data does not include option code and length bytes.
 func (op *OptUserClass) FromBytes(data []byte) error {
 	if len(data) == 0 {
-		return fmt.Errorf("user class option must not be empty")
+		return fmt.Errorf("%w: user class option must not be empty", uio.ErrBufferTooShort)
 	}
 	buf := uio.NewBigEndianBuffer(data)
 	for buf.Has(2) {

--- a/dhcpv6/option_vendorclass.go
+++ b/dhcpv6/option_vendorclass.go
@@ -1,7 +1,6 @@
 package dhcpv6
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -49,8 +48,8 @@ func (op *OptVendorClass) FromBytes(data []byte) error {
 		len := buf.Read16()
 		op.Data = append(op.Data, buf.CopyN(int(len)))
 	}
-	if len(op.Data) < 1 {
-		return errors.New("ParseOptVendorClass: at least one vendor class data is required")
+	if len(op.Data) == 0 {
+		return fmt.Errorf("%w: vendor class data should not be empty", uio.ErrBufferTooShort)
 	}
 	return buf.FinError()
 }

--- a/dhcpv6/option_vendorclass_test.go
+++ b/dhcpv6/option_vendorclass_test.go
@@ -1,73 +1,88 @@
 package dhcpv6
 
 import (
+	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/uio/uio"
 )
 
-func TestParseOptVendorClass(t *testing.T) {
-	data := []byte{
-		0xaa, 0xbb, 0xcc, 0xdd, // EnterpriseNumber
-		0, 10, 'H', 'T', 'T', 'P', 'C', 'l', 'i', 'e', 'n', 't',
-		0, 4, 't', 'e', 's', 't',
-	}
-	var opt OptVendorClass
-	err := opt.FromBytes(data)
-	require.NoError(t, err)
-	require.Equal(t, OptionVendorClass, opt.Code())
-	require.Equal(t, 2, len(opt.Data))
-	require.Equal(t, uint32(0xaabbccdd), opt.EnterpriseNumber)
-	require.Equal(t, []byte("HTTPClient"), opt.Data[0])
-	require.Equal(t, []byte("test"), opt.Data[1])
-}
-
-func TestOptVendorClassToBytes(t *testing.T) {
-	opt := OptVendorClass{
-		EnterpriseNumber: uint32(0xaabbccdd),
-		Data: [][]byte{
-			[]byte("HTTPClient"),
-			[]byte("test"),
+func TestVendorClassParseAndGetter(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		err  error
+		want []*OptVendorClass
+	}{
+		{
+			buf: []byte{
+				0, 16, // Vendor Class
+				0, 14, // length
+				0, 0, 0, 16,
+				0, 4,
+				'S', 'L', 'A', 'M',
+				0, 2,
+				'h', 'h',
+			},
+			want: []*OptVendorClass{
+				&OptVendorClass{
+					EnterpriseNumber: 16,
+					Data:             [][]byte{[]byte("SLAM"), []byte("hh")},
+				},
+			},
 		},
-	}
-	data := opt.ToBytes()
-	expected := []byte{
-		0xaa, 0xbb, 0xcc, 0xdd, // EnterpriseNumber
-		0, 10, 'H', 'T', 'T', 'P', 'C', 'l', 'i', 'e', 'n', 't',
-		0, 4, 't', 'e', 's', 't',
-	}
-	require.Equal(t, expected, data)
-}
+		{
+			buf: []byte{
+				0, 16,
+				0, 0,
+			},
+			err: uio.ErrBufferTooShort,
+		},
+		{
+			buf: []byte{
+				0, 16,
+				0, 4,
+				0, 0, 0, 6,
+			},
+			err: uio.ErrBufferTooShort,
+		},
+		{
+			buf: []byte{0, 16, 0},
+			err: uio.ErrUnreadBytes,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var mo MessageOptions
+			if err := mo.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			if got := mo.VendorClasses(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("VendorClass = %v, want %v", got, tt.want)
+			}
+			for _, v := range tt.want {
+				if got := mo.VendorClass(v.EnterpriseNumber); !reflect.DeepEqual(got, v.Data) {
+					t.Errorf("VendorClass(%d) = %v, want %v", v.EnterpriseNumber, got, v.Data)
+				}
+			}
+			if got := mo.VendorClass(100); got != nil {
+				t.Errorf("VendorClass(100) = %v, want nil", got)
+			}
 
-func TestOptVendorClassParseOptVendorClassMalformed(t *testing.T) {
-	buf := []byte{
-		0xaa, 0xbb, // truncated EnterpriseNumber
+			if tt.want != nil {
+				var m MessageOptions
+				for _, o := range tt.want {
+					m.Add(o)
+				}
+				got := m.ToBytes()
+				if diff := cmp.Diff(tt.buf, got); diff != "" {
+					t.Errorf("ToBytes mismatch (-want, +got): %s", diff)
+				}
+			}
+		})
 	}
-	var opt OptVendorClass
-	err := opt.FromBytes(buf)
-	require.Error(t, err, "ParseOptVendorClass() should error if given truncated EnterpriseNumber")
-
-	buf = []byte{
-		0xaa, 0xbb, 0xcc, 0xdd, // EnterpriseNumber
-	}
-	err = opt.FromBytes(buf)
-	require.Error(t, err, "ParseOptVendorClass() should error if given no vendor classes")
-
-	buf = []byte{
-		0xaa, 0xbb, 0xcc, 0xdd, // EnterpriseNumber
-		0, 9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
-		0, 4, 't', 'e',
-	}
-	err = opt.FromBytes(buf)
-	require.Error(t, err, "ParseOptVendorClass() should error if given truncated vendor classes")
-
-	buf = []byte{
-		0xaa, 0xbb, 0xcc, 0xdd, // EnterpriseNumber
-		0, 9, 'l', 'i', 'n', 'u', 'x', 'b', 'o', 'o', 't',
-		0,
-	}
-	err = opt.FromBytes(buf)
-	require.Error(t, err, "ParseOptVendorClass() should error if given a truncated length")
 }
 
 func TestOptVendorClassString(t *testing.T) {

--- a/dhcpv6/options.go
+++ b/dhcpv6/options.go
@@ -224,7 +224,9 @@ type OptionParser func(code OptionCode, data []byte) (Option, error)
 // FromBytesWithParser parses Options from byte sequences using the parsing
 // function that is passed in as a paremeter
 func (o *Options) FromBytesWithParser(data []byte, parser OptionParser) error {
-	*o = make(Options, 0, 10)
+	if *o == nil {
+		*o = make(Options, 0, 10)
+	}
 	if len(data) == 0 {
 		// no options, no party
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -1,19 +1,26 @@
 module github.com/insomniacslk/dhcp
 
-go 1.13
+go 1.18
 
 require (
 	github.com/fanliao/go-promise v0.0.0-20141029170127-1890db352a72
 	github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714
-	github.com/josharian/native v1.1.0 // indirect
 	github.com/jsimonetti/rtnetlink v0.0.0-20201110080708-d2c240429e6c
 	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7
 	github.com/mdlayher/netlink v1.1.1
 	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065
-	github.com/pierrec/lz4/v4 v4.1.14 // indirect
-	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/u-root/uio v0.0.0-20230215032506-9aa6f7e2d72c
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	golang.org/x/sys v0.5.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/josharian/native v1.1.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.14 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/smartystreets/goconvey v1.6.4 // indirect
+	github.com/stretchr/objx v0.1.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,14 @@ go 1.18
 
 require (
 	github.com/fanliao/go-promise v0.0.0-20141029170127-1890db352a72
+	github.com/google/go-cmp v0.5.9
 	github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714
 	github.com/jsimonetti/rtnetlink v0.0.0-20201110080708-d2c240429e6c
 	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7
 	github.com/mdlayher/netlink v1.1.1
 	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065
 	github.com/stretchr/testify v1.6.1
-	github.com/u-root/uio v0.0.0-20230215032506-9aa6f7e2d72c
+	github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	golang.org/x/sys v0.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714 h1:/jC7qQFrv8CrSJVmaolDVOxTfS9kc36uB6H40kdbQq8=
@@ -46,6 +48,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/u-root/uio v0.0.0-20230215032506-9aa6f7e2d72c h1:PHoGTnweZP+KIg/8Zc6+iOesrIF5yHkpb4GBDxHm7yE=
 github.com/u-root/uio v0.0.0-20230215032506-9aa6f7e2d72c/go.mod h1:eLL9Nub3yfAho7qB0MzZizFhTU2QkLeoVsWdHtDW264=
+github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 h1:tHNk7XK9GkmKUR6Gh8gVBKXc2MVSZ4G/NnWLtzw4gNA=
+github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923/go.mod h1:eLL9Nub3yfAho7qB0MzZizFhTU2QkLeoVsWdHtDW264=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -77,6 +81,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065 h1:aFkJ6lx4FPip+S+Uw4
 github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065/go.mod h1:7EpbotpCmVZcu+KCX4g9WaRNuu11uyhiW7+Le1dKawg=
 github.com/pierrec/lz4/v4 v4.1.14 h1:+fL8AQEZtz/ijeNnpduH0bROTu0O3NZAlPjQxGn8LwE=
 github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/pierrec/lz4/v4 v4.1.17 h1:kV4Ip+/hUBC+8T6+2EgburRtkE9ef4nbY3f4dFhGjMc=
-github.com/pierrec/lz4/v4 v4.1.17/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
@@ -79,7 +77,6 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/rfc1035label/label.go
+++ b/rfc1035label/label.go
@@ -89,6 +89,10 @@ func FromBytes(data []byte) (*Labels, error) {
 	return &l, nil
 }
 
+// ErrBufferTooShort is returned when the label cannot be parsed due to a wrong
+// length or missing bytes.
+var ErrBufferTooShort = errors.New("rfc1035label: buffer too short")
+
 // fromBytes decodes a serialized stream and returns a list of labels
 func labelsFromBytes(buf []byte) ([]string, error) {
 	var (
@@ -132,7 +136,7 @@ func labelsFromBytes(buf []byte) ([]string, error) {
 			pos = off
 		} else {
 			if pos+length > len(buf) {
-				return nil, errors.New("rfc1035label: buffer too short")
+				return nil, ErrBufferTooShort
 			}
 			chunk = string(buf[pos : pos+length])
 			if label != "" {


### PR DESCRIPTION
Cover every part of message encoding and decoding.

Requires generics. Go 1.18.

New getters for 4RD & vendor class options