### PR TITLE
Updates to DHCP options and message types

### DIFF
--- a/dhcpv4/options.go
+++ b/dhcpv4/options.go
@@ -307,7 +307,7 @@ func getOption(code OptionCode, data []byte, vendorDecoder OptionDecoder) fmt.St
 	var d OptionDecoder
 	switch code {
 	case OptionRouter, OptionDomainNameServer, OptionNTPServers, OptionServerIdentifier,
-		OptionOPTIONv4DOTSADDRESS, OptionV4PCPSERVER:
+		OptionOPTIONv4DOTSAddress, OptionV4PCPSERVER:
 		d = &IPs{}
 
 	case OptionBroadcastAddress, OptionRequestedIPAddress:

--- a/dhcpv4/options.go
+++ b/dhcpv4/options.go
@@ -306,7 +306,8 @@ type OptionDecoder interface {
 func getOption(code OptionCode, data []byte, vendorDecoder OptionDecoder) fmt.Stringer {
 	var d OptionDecoder
 	switch code {
-	case OptionRouter, OptionDomainNameServer, OptionNTPServers, OptionServerIdentifier:
+	case OptionRouter, OptionDomainNameServer, OptionNTPServers, OptionServerIdentifier,
+		OptionOPTIONv4DOTSADDRESS, OptionV4PCPSERVER:
 		d = &IPs{}
 
 	case OptionBroadcastAddress, OptionRequestedIPAddress:
@@ -326,7 +327,8 @@ func getOption(code OptionCode, data []byte, vendorDecoder OptionDecoder) fmt.St
 		d = &OptionCodeList{}
 
 	case OptionHostName, OptionDomainName, OptionRootPath,
-		OptionClassIdentifier, OptionTFTPServerName, OptionBootfileName:
+		OptionClassIdentifier, OptionTFTPServerName, OptionBootfileName,
+		OptionOPTIONV4DOTSRI, OptionMUDURLV4:
 		var s String
 		d = &s
 
@@ -336,7 +338,7 @@ func getOption(code OptionCode, data []byte, vendorDecoder OptionDecoder) fmt.St
 	case OptionDNSDomainSearchList:
 		d = &rfc1035label.Labels{}
 
-	case OptionIPAddressLeaseTime:
+	case OptionIPAddressLeaseTime, OptionIPv6OnlyPreferred:
 		var dur Duration
 		d = &dur
 

--- a/dhcpv4/types.go
+++ b/dhcpv4/types.go
@@ -27,15 +27,25 @@ type MessageType byte
 const (
 	// MessageTypeNone is not a real message type, it is used by certain
 	// functions to signal that no explicit message type is requested
-	MessageTypeNone     MessageType = 0
-	MessageTypeDiscover MessageType = 1
-	MessageTypeOffer    MessageType = 2
-	MessageTypeRequest  MessageType = 3
-	MessageTypeDecline  MessageType = 4
-	MessageTypeAck      MessageType = 5
-	MessageTypeNak      MessageType = 6
-	MessageTypeRelease  MessageType = 7
-	MessageTypeInform   MessageType = 8
+	MessageTypeNone             MessageType = 0
+	MessageTypeDiscover         MessageType = 1
+	MessageTypeOffer            MessageType = 2
+	MessageTypeRequest          MessageType = 3
+	MessageTypeDecline          MessageType = 4
+	MessageTypeAck              MessageType = 5
+	MessageTypeNak              MessageType = 6
+	MessageTypeRelease          MessageType = 7
+	MessageTypeInform           MessageType = 8
+	MessageTypeForceRenew       MessageType = 9
+	MessageTypeLeaseQuery       MessageType = 10
+	MessageTypeLeaseUnassigned  MessageType = 11
+	MessageTypeLeaseUnknown     MessageType = 12
+	MessageTypeLeaseActive      MessageType = 13
+	MessageTypeBulkLeaseQuery   MessageType = 14
+	MessageTypeLeaseQueryDone   MessageType = 15
+	MessageTyepActiveLeaseQuery MessageType = 16
+	MessageTypeLeaseQueryStatus MessageType = 17
+	MessageTypeTLS              MessageType = 18
 )
 
 // ToBytes returns the serialized version of this option described by RFC 2132,
@@ -61,14 +71,24 @@ func (m *MessageType) FromBytes(data []byte) error {
 }
 
 var messageTypeToString = map[MessageType]string{
-	MessageTypeDiscover: "DISCOVER",
-	MessageTypeOffer:    "OFFER",
-	MessageTypeRequest:  "REQUEST",
-	MessageTypeDecline:  "DECLINE",
-	MessageTypeAck:      "ACK",
-	MessageTypeNak:      "NAK",
-	MessageTypeRelease:  "RELEASE",
-	MessageTypeInform:   "INFORM",
+	MessageTypeDiscover:         "DISCOVER",
+	MessageTypeOffer:            "OFFER",
+	MessageTypeRequest:          "REQUEST",
+	MessageTypeDecline:          "DECLINE",
+	MessageTypeAck:              "ACK",
+	MessageTypeNak:              "NAK",
+	MessageTypeRelease:          "RELEASE",
+	MessageTypeInform:           "INFORM",
+	MessageTypeForceRenew:       "FORCERENEW",
+	MessageTypeLeaseQuery:       "LEASEQUERY",
+	MessageTypeLeaseUnassigned:  "LEASEUNASSIGNED",
+	MessageTypeLeaseUnknown:     "LEASEUNKNOWN",
+	MessageTypeLeaseActive:      "LEASEACTIVE",
+	MessageTypeBulkLeaseQuery:   "BULKLEASEQUEARY",
+	MessageTypeLeaseQueryDone:   "LEASEQUERYDONE",
+	MessageTyepActiveLeaseQuery: "ACTIVELEASEQUERY",
+	MessageTypeLeaseQueryStatus: "LEASEQUERYSTATUS",
+	MessageTypeTLS:              "TLS",
 }
 
 // OpcodeType represents a DHCPv4 opcode.
@@ -238,7 +258,10 @@ const (
 	OptionGeoConfCivic                optionCode = 99
 	OptionIEEE10031TZString           optionCode = 100
 	OptionReferenceToTZDatabase       optionCode = 101
-	// Options 102-111 returned in RFC 3679
+	// Options 102-107 returned in RFC 3679
+	OptionIPv6OnlyPreferred     optionCode = 108
+	OptionDHCP4O6S46SADDR       optionCode = 109
+	// Options 110-111 returned in RFC 3679
 	OptionNetInfoParentServerAddress optionCode = 112
 	OptionNetInfoParentServerTag     optionCode = 113
 	OptionURL                        optionCode = 114
@@ -270,7 +293,12 @@ const (
 	OptionSIPUAConfigurationServiceDomains      optionCode = 141
 	OptionOPTIONIPv4AddressANDSF                optionCode = 142
 	OptionOPTIONIPv6AddressANDSF                optionCode = 143
-	// Options 144-149 returned in RFC 3679
+	OptionGeoLoc                                optionCode = 144
+	OptionFORCERENEWNONCECAPABLE                optionCode = 145
+	OptionRDNSSSelection                        optionCode = 146
+	OptionOPTIONV4DOTSRI                        optionCode = 147
+	OptionOPTIONv4DOTSADDRESS                   optionCode = 148
+	// Option 149 returned in RFC 3679
 	OptionTFTPServerAddress optionCode = 150
 	OptionStatusCode        optionCode = 151
 	OptionBaseTime          optionCode = 152
@@ -279,7 +307,12 @@ const (
 	OptionQueryEndTime      optionCode = 155
 	OptionDHCPState         optionCode = 156
 	OptionDataSource        optionCode = 157
-	// Options 158-174 returned in RFC 3679
+	OptionV4PCPSERVER       optionCode = 158
+	OptionOPTIONV4PORTPARAMS optionCode = 159
+	// Option 160 returned in RFC 3679
+	OptionMUDURLV4 optionCode = 161
+	OptionV4DNR    optionCode = 162
+	// Options 163-174 returned in RFC 3679
 	OptionEtherboot                        optionCode = 175
 	OptionIPTelephone                      optionCode = 176
 	OptionEtherbootPacketCableAndCableHome optionCode = 177
@@ -401,7 +434,10 @@ var optionCodeToString = map[OptionCode]string{
 	OptionGeoConfCivic:                "GEOCONF_CIVIC",
 	OptionIEEE10031TZString:           "IEEE 1003.1 TZ String",
 	OptionReferenceToTZDatabase:       "Reference to the TZ Database",
-	// Options 102-111 returned in RFC 3679
+	// Options 102-107 returned in RFC 3679
+	OptionIPv6OnlyPreferred: "Number of seconds that DHCPv4 should be disabled",
+	OptionDHCP4O6S46SADDR:   "DHCPv4 over DHCPv6 Softwire Source Address Option",
+	// Options 110-111 returned in RFC 3679
 	OptionNetInfoParentServerAddress: "NetInfo Parent Server Address",
 	OptionNetInfoParentServerTag:     "NetInfo Parent Server Tag",
 	OptionURL:                        "URL",
@@ -433,16 +469,26 @@ var optionCodeToString = map[OptionCode]string{
 	OptionSIPUAConfigurationServiceDomains:      "SIP UA Configuration Service Domains",
 	OptionOPTIONIPv4AddressANDSF:                "OPTION-IPv4_Address-ANDSF",
 	OptionOPTIONIPv6AddressANDSF:                "OPTION-IPv6_Address-ANDSF",
-	// Options 144-149 returned in RFC 3679
-	OptionTFTPServerAddress: "TFTP Server Address",
-	OptionStatusCode:        "Status Code",
-	OptionBaseTime:          "Base Time",
-	OptionStartTimeOfState:  "Start Time of State",
-	OptionQueryStartTime:    "Query Start Time",
-	OptionQueryEndTime:      "Query End Time",
-	OptionDHCPState:         "DHCP Staet",
-	OptionDataSource:        "Data Source",
-	// Options 158-174 returned in RFC 3679
+	OptionGeoLoc:                                "Geospatial Location with Uncertainty",
+	OptionFORCERENEWNONCECAPABLE:                "Forcerenew Nonce Capable",
+	OptionRDNSSSelection:                        "Information for selecting RDNSS",
+	OptionOPTIONV4DOTSRI:                        "The name of the peer DOTS agent",
+	OptionOPTIONv4DOTSADDRESS:                   "IPv4 addresses of peer DOTS agent(s)",
+	// Option 149 returned in RFC 3679
+	OptionTFTPServerAddress:  "TFTP Server Address",
+	OptionStatusCode:         "Status Code",
+	OptionBaseTime:           "Base Time",
+	OptionStartTimeOfState:   "Start Time of State",
+	OptionQueryStartTime:     "Query Start Time",
+	OptionQueryEndTime:       "Query End Time",
+	OptionDHCPState:          "DHCP Staet",
+	OptionDataSource:         "Data Source",
+	OptionV4PCPSERVER:        "PCP server IP addresses",
+	OptionOPTIONV4PORTPARAMS: "DHCPv4 Port Parameters",
+	// Options 160 returned in RFC 3679
+	OptionMUDURLV4: "Manufacturer Usage Description URL",
+	OptionV4DNR:    "Encrypted DNS Server",
+	// Options 163-174 returned in RFC 3679
 	OptionEtherboot:                        "Etherboot",
 	OptionIPTelephone:                      "IP Telephone",
 	OptionEtherbootPacketCableAndCableHome: "Etherboot / PacketCable and CableHome",

--- a/dhcpv4/types.go
+++ b/dhcpv4/types.go
@@ -297,7 +297,7 @@ const (
 	OptionFORCERENEWNONCECAPABLE                optionCode = 145
 	OptionRDNSSSelection                        optionCode = 146
 	OptionOPTIONV4DOTSRI                        optionCode = 147
-	OptionOPTIONv4DOTSADDRESS                   optionCode = 148
+	OptionOPTIONv4DOTSAddress                   optionCode = 148
 	// Option 149 returned in RFC 3679
 	OptionTFTPServerAddress optionCode = 150
 	OptionStatusCode        optionCode = 151
@@ -473,7 +473,7 @@ var optionCodeToString = map[OptionCode]string{
 	OptionFORCERENEWNONCECAPABLE:                "Forcerenew Nonce Capable",
 	OptionRDNSSSelection:                        "Information for selecting RDNSS",
 	OptionOPTIONV4DOTSRI:                        "The name of the peer DOTS agent",
-	OptionOPTIONv4DOTSADDRESS:                   "IPv4 addresses of peer DOTS agent(s)",
+	OptionOPTIONv4DOTSAddress:                   "IPv4 addresses of peer DOTS agent(s)",
 	// Option 149 returned in RFC 3679
 	OptionTFTPServerAddress:  "TFTP Server Address",
 	OptionStatusCode:         "Status Code",

--- a/dhcpv6/types.go
+++ b/dhcpv6/types.go
@@ -36,10 +36,24 @@ const (
 	MessageTypeLeaseQueryReply    MessageType = 15
 	MessageTypeLeaseQueryDone     MessageType = 16
 	MessageTypeLeaseQueryData     MessageType = 17
-	_                             MessageType = 18
-	_                             MessageType = 19
+	MessageTypeReconfigureRequest MessageType = 18
+	MessageTypeReconfigureReply   MessageType = 19
 	MessageTypeDHCPv4Query        MessageType = 20
 	MessageTypeDHCPv4Response     MessageType = 21
+	MessageTypeActiveLeaseQuery   MessageType = 22
+	MessapeTypeSTARTTLS           MessageType = 23
+	MessageTypeBndUpd             MessageType = 24
+	MessageTypeBndReply           MessageType = 25
+	MessageTypePoolReq            MessageType = 26
+	MessageTypePoolResp           MessageType = 27
+	MessageTypeUpdReq             MessageType = 28
+	MessageTypeUpdReqAll          MessageType = 29
+	MessageTypeUpdDone            MessageType = 30
+	MessageTypeConnect            MessageType = 31
+	MessageTypeConnectReply       MessageType = 32
+	MessageTypeDisconnect         MessageType = 33
+	MessageTypeState              MessageType = 34
+	MessageTypeContact            MessageType = 35
 )
 
 // String prints the message type name.
@@ -70,8 +84,24 @@ var messageTypeToStringMap = map[MessageType]string{
 	MessageTypeLeaseQueryReply:    "LEASEQUERY-REPLY",
 	MessageTypeLeaseQueryDone:     "LEASEQUERY-DONE",
 	MessageTypeLeaseQueryData:     "LEASEQUERY-DATA",
+        MessageTypeReconfigureRequest: "RECONFIGURE-REQUEST",
+        MessageTypeReconfigureReply:   "RECONFIGURE-REPLY",
 	MessageTypeDHCPv4Query:        "DHCPv4-QUERY",
 	MessageTypeDHCPv4Response:     "DHCPv4-RESPONSE",
+        MessageTypeActiveLeaseQuery:   "ACTIVELEASEQUERY",
+        MessapeTypeSTARTTLS:           "STARTTLS",
+        MessageTypeBndUpd:             "BNDUPD",
+        MessageTypeBndReply:           "BNDREPLY",
+        MessageTypePoolReq:            "POOLREQ",
+        MessageTypePoolResp:           "POOLRESP",
+        MessageTypeUpdReq:             "UPDREQ",
+        MessageTypeUpdReqAll:          "UPDREQALL",
+        MessageTypeUpdDone:            "UPDDONE",
+        MessageTypeConnect:            "CONNECT",
+        MessageTypeConnectReply:       "CONNECTREPLY",
+        MessageTypeDisconnect:         "DISCONNECT",
+        MessageTypeState:              "STATE",
+        MessageTypeContact:            "CONTACT",
 }
 
 // OptionCode is a single byte representing the code for a given Option.
@@ -224,12 +254,16 @@ const (
 	OptionRelayPort                               OptionCode = 135
 	OptionV6SZTPRedirect                          OptionCode = 136
 	OptionS46BindIPv6Prefix                       OptionCode = 137
-	_                                             OptionCode = 138
-	_                                             OptionCode = 139
-	_                                             OptionCode = 140
-	_                                             OptionCode = 141
-	_                                             OptionCode = 142
+	OptionIaLL                                    OptionCode = 138
+	OptionLLAddr                                  OptionCode = 139
+	OptionSlapQuad                                OptionCode = 140
+	OptionV6DotsRi                                OptionCode = 141
+	OptionV6DotsAddress                           OptionCode = 142
 	OptionIPv6AddressANDSF                        OptionCode = 143
+	OptionV6DNR                                   OptionCode = 144
+	OptionRegisteredDomain                        OptionCode = 145
+	OptionForwardDistManager                      OptionCode = 146
+	OptionReverseDistManager                      OptionCode = 147
 )
 
 // optionCodeToString maps DHCPv6 OptionCodes to human-readable strings.
@@ -369,5 +403,14 @@ var optionCodeToString = map[OptionCode]string{
 	OptionRelayPort:                               "Relay Source Port",
 	OptionV6SZTPRedirect:                          "IPv6 Secure Zerotouch Provisioning Redirect",
 	OptionS46BindIPv6Prefix:                       "Softwire46 Source Binding Prefix Hint",
+	OptionIaLL:                                    "Identity Association for Link-Layer Addresses",
+	OptionLLAddr:                                  "Link-Layer Addresses",
+	OptionSlapQuad:                                "Structured Local Address Plan (SLAP) Quadrant Selection",
+	OptionV6DotsRi:                                "DDoS Open Threat Signaling (DOTS) Reference Identifier Option",
+	OptionV6DotsAddress:                           "DDoS Open Threat Signaling (DOTS) Address",
 	OptionIPv6AddressANDSF:                        "IPv6 Access Network Discovery and Selection Function Address",
+	OptionV6DNR:                                   "Encrypted DNS",
+	OptionRegisteredDomain:                        "Registered Homenet Domain",
+	OptionForwardDistManager:                      "Forward Distribution Manager",
+	OptionReverseDistManager:                      "Reverse Distribution Manager",
 }


### PR DESCRIPTION
New DHCP4 Message Types from RFC3203, RFC4388, RFC6926, RFC7724.

New DHCP4 Options from RFC8925, RFC8539, RFC6225, RFC6704, RFC6737,
        RFC8973, RFC7618, RFC8250, RFC-ietf-add-dnr-16.
(as per https://www.iana.org/assignments/bootp-dhcp-parameters/bootp-dhcp-parameters.xhtml
 2023-04-28).

New DHCP6 Message Types from RFC6977, RFC7653, RFC7653, RFC8156

New DHCP6 Options from RFC8947, RFC8948, RFC8973, RFC-ietf-add-dnr-16,
        RFC-ietf-homenet-naming-architecture-dhc-options-24
(as per https://www.iana.org/assignments/dhcpv6-parameters/dhcpv6-parameters.xhtml
 2023-04-28).
