### PR TITLE
Porting work for DragonFly BSD

### DIFF
--- a/dhcpv4/nclient4/conn_unix.go
+++ b/dhcpv4/nclient4/conn_unix.go
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build go1.12 && (darwin || freebsd || linux || netbsd || openbsd)
+//go:build go1.12 && (darwin || freebsd || linux || netbsd || openbsd || dragonfly)
 // +build go1.12
-// +build darwin freebsd linux netbsd openbsd
+// +build darwin freebsd linux netbsd openbsd dragonfly
 
 package nclient4
 

--- a/interfaces/bindtodevice_bsd.go
+++ b/interfaces/bindtodevice_bsd.go
@@ -1,4 +1,4 @@
-// +build aix freebsd openbsd netbsd
+// +build aix freebsd openbsd netbsd dragonfly
 
 package interfaces
 


### PR DESCRIPTION
This adds DragonFly BSD to the list of BSDs so that lima-vm can be built (https://github.com/lima-vm/lima/issues/892)