### PR TITLE
Make Option 82 come last

### DIFF
--- a/dhcpv4/options.go
+++ b/dhcpv4/options.go
@@ -110,8 +110,9 @@ func (o Options) FromBytes(data []byte) error {
 }
 
 const (
-	optPad = 0
-	optEnd = 255
+	optPad       = 0
+	optAgentInfo = 82
+	optEnd       = 255
 )
 
 // FromBytesCheckEnd parses Options from byte sequences using the
@@ -176,11 +177,28 @@ func (o Options) fromBytesCheckEnd(data []byte, checkEndOption bool) error {
 func (o Options) sortedKeys() []int {
 	// Send all values for a given key
 	var codes []int
+	var hasOptAgentInfo, hasOptEnd bool
 	for k := range o {
+		// RFC 3046 section 2.1 states that option 82 SHALL come last (ignoring End).
+		if k == optAgentInfo {
+			hasOptAgentInfo = true
+			continue
+		}
+		if k == optEnd {
+			hasOptEnd = true
+			continue
+		}
 		codes = append(codes, int(k))
 	}
 
 	sort.Ints(codes)
+
+	if hasOptAgentInfo {
+		codes = append(codes, optAgentInfo)
+	}
+	if hasOptEnd {
+		codes = append(codes, optEnd)
+	}
 	return codes
 }
 

--- a/dhcpv4/options_test.go
+++ b/dhcpv4/options_test.go
@@ -179,14 +179,17 @@ func TestOptionsMarshal(t *testing.T) {
 		},
 		{
 			// Test sorted key order.
+			// RFC 3046 section 2.1 states that option 82 SHALL come last.
 			opts: Options{
 				5:   []byte{1, 2, 3},
+				82:  []byte{201, 202, 203},
 				100: []byte{101, 102, 103},
 				255: []byte{},
 			},
 			want: []byte{
 				5, 3, 1, 2, 3,
 				100, 3, 101, 102, 103,
+				82, 3, 201, 202, 203,
 			},
 		},
 		{


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc3046#section-2.1 states:

```
A DHCP relay agent adding a Relay Agent Information field SHALL add
it as the last option (but before 'End Option' 255, if present) in
the DHCP options field of any recognized BOOTP or DHCP packet
forwarded from a client to a server.
```