### PR TITLE
misuse of 'err' to check nil

### DIFF
--- a/netboot/netconf.go
+++ b/netboot/netconf.go
@@ -192,7 +192,7 @@ func ConfigureInterface(ifname string, netconf *NetConf) (err error) {
 		return err
 	}
 	defer func() {
-		if cerr := rt.Close(); err != nil {
+		if cerr := rt.Close(); cerr != nil {
 			err = cerr
 		}
 	}()

--- a/netboot/netconf_integ_test.go
+++ b/netboot/netconf_integ_test.go
@@ -55,7 +55,7 @@ func TestConfigureInterface(t *testing.T) {
 			Name: "IP addr, DNS, and routers",
 			NetConf: &NetConf{
 				Addresses: []AddrConf{
-					AddrConf{IPNet: net.IPNet{IP: net.ParseIP("10.20.30.40")}},
+					AddrConf{IPNet: net.IPNet{IP: net.ParseIP("10.20.30.41")}},
 				},
 				DNSServers:    []net.IP{net.ParseIP("8.8.8.8")},
 				DNSSearchList: []string{"slackware.it"},


### PR DESCRIPTION
In ConfigureInterface(),the defer closure misuse outter 'err' to check nil ,not 'cerr' inside the closure.