### PR TITLE
Add ZTPv6 NVOS Support

### DIFF
--- a/dhcpv6/ztpv6/parse_vendor_options.go
+++ b/dhcpv6/ztpv6/parse_vendor_options.go
@@ -77,6 +77,18 @@ func ParseVendorData(packet dhcpv6.DHCPv6) (*VendorData, error) {
 			vd.Model = p[1]
 			vd.Serial = p[2]
 			return &vd, nil
+		
+		// NVOS##MMM1234##MM1234X56ABC
+		case strings.HasPrefix(d, "NVOS##"):
+			p := strings.Split(d, "##")
+			if len(p) < 3 {
+				return nil, errVendorOptionMalformed
+			}
+
+			vd.VendorName = p[0]
+			vd.Model = p[1]
+			vd.Serial = p[2]
+			return &vd, nil
 
 		// For Ciena the class identifier (opt 60) is written in the following format:
 		//    {vendor iana code}-{product}-{type}

--- a/dhcpv6/ztpv6/parse_vendor_options_test.go
+++ b/dhcpv6/ztpv6/parse_vendor_options_test.go
@@ -72,6 +72,7 @@ func TestParseVendorDataWithVendorClass(t *testing.T) {
 		{name: "unknownVendor", vc: "VendorX;BFR10K;XX12345", fail: true, want: nil},
 		{name: "truncatedArista", vc: "Arista;1234", fail: true, want: nil},
 		{name: "truncatedZPE", vc: "ZPESystems:1234", fail: true, want: nil},
+		{name: "truncatedNVOS", vc: "NVOS##MMM1234", fail: true, want: nil},
 		{
 			name: "arista",
 			vc:   "Arista;DCS-7050S-64;01.23;JPE12345678",
@@ -80,8 +81,11 @@ func TestParseVendorDataWithVendorClass(t *testing.T) {
 			name: "zpe",
 			vc:   "ZPESystems:NSC:001234567",
 			want: &VendorData{VendorName: "ZPESystems", Model: "NSC", Serial: "001234567"},
-		},
-		{
+		}, {
+			name: "nvos",
+			vc:   "NVOS##MMM1234##MM1234X123456",
+			want: &VendorData{VendorName: "NVOS", Model: "MMM1234", Serial: "MM1234X123456"},
+		}, {
 			name: "Ciena",
 			vc:   "1271-23422Z11-123",
 			clientId: &dhcpv6.DUIDEN{


### PR DESCRIPTION
Adding support for NVOS ZTPv6 via Option 16 (Vendor Class Option) because it will be needed for bootstrapping.