### PR TITLE
Add strict padding setting to the nclient4

### DIFF
--- a/dhcpv4/dhcpv4.go
+++ b/dhcpv4/dhcpv4.go
@@ -300,6 +300,13 @@ func NewReleaseFromACK(ack *DHCPv4, modifiers ...Modifier) (*DHCPv4, error) {
 // FromBytes decodes a DHCPv4 packet from a sequence of bytes, and returns an
 // error if the packet is not valid.
 func FromBytes(q []byte) (*DHCPv4, error) {
+	return FromBytesWithStrictPadding(q, false)
+}
+
+// FromBytesWithStrictPadding decodes a DHCPv4 packet from a sequence of bytes, and returns an
+// error if the packet is not valid.
+// Octets after the End option are checked or not according to pad option.
+func FromBytesWithStrictPadding(q []byte, strictPadding bool) (*DHCPv4, error) {
 	var p DHCPv4
 	buf := uio.NewBigEndianBuffer(q)
 
@@ -353,7 +360,7 @@ func FromBytes(q []byte) (*DHCPv4, error) {
 	}
 
 	p.Options = make(Options)
-	if err := p.Options.fromBytesCheckEnd(buf.Data(), true); err != nil {
+	if err := p.Options.fromBytesWithStrictPadding(buf.Data(), true, strictPadding); err != nil {
 		return nil, err
 	}
 	return &p, nil

--- a/dhcpv4/nclient4/client_test.go
+++ b/dhcpv4/nclient4/client_test.go
@@ -72,6 +72,40 @@ func serveAndClient(ctx context.Context, responses [][]*dhcpv4.DHCPv4, opts ...C
 	return mc, serverConn
 }
 
+func serveAndClientWithBytesResp(response []byte, opts ...ClientOpt) *Client {
+	// Fake PacketConn connection.
+	clientRawConn, serverRawConn, err := socketpair.PacketSocketPair()
+	if err != nil {
+		panic(err)
+	}
+
+	clientConn := NewBroadcastUDPConn(clientRawConn, &net.UDPAddr{Port: ClientPort})
+	serverConn := NewBroadcastUDPConn(serverRawConn, &net.UDPAddr{Port: ServerPort})
+
+	o := []ClientOpt{WithRetry(1), WithTimeout(2 * time.Second)}
+	o = append(o, opts...)
+	mc, err := NewWithConn(clientConn, net.HardwareAddr{0xa, 0xb, 0xc, 0xd, 0xe, 0xf}, o...)
+	if err != nil {
+		panic(err)
+	}
+
+	// Fake server.
+	go func() {
+		b := make([]byte, 4096)
+		_, peer, err := serverConn.ReadFrom(b)
+		if err != nil {
+			panic(err)
+		}
+
+		_, err = serverConn.WriteTo(response, peer)
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	return mc
+}
+
 func ComparePacket(got *dhcpv4.DHCPv4, want *dhcpv4.DHCPv4) error {
 	if got == nil && got == want {
 		return nil
@@ -278,6 +312,62 @@ func TestSimpleSendAndReadDiscardGarbage(t *testing.T) {
 
 	if err := ComparePacket(rcvd, responses); err != nil {
 		t.Errorf("got unexpected packets: %v", err)
+	}
+}
+
+func TestSendAndReadWithDefaultPadding(t *testing.T) {
+	pkt := newPacket(dhcpv4.OpcodeBootRequest, [4]byte{0x33, 0x33, 0x33, 0x33})
+
+	// Both the server and client only get 2 seconds.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	response, err := dhcpv4.NewReplyFromRequest(pkt)
+	if err != nil {
+		t.Errorf("NewReplyFromRequest(%v) = %v, want nil", pkt, err)
+	}
+
+	bytes := response.ToBytes()
+
+	// Add garbage to the end.
+	bytes[len(bytes)-1] = 0x01
+
+	mc := serveAndClientWithBytesResp(bytes)
+	defer mc.Close()
+
+	rcvd, err := mc.SendAndRead(ctx, DefaultServers, pkt, nil)
+	if err != nil {
+		t.Errorf("SendAndRead(%v) = %v, want nil", pkt, err)
+	}
+
+	if err := ComparePacket(rcvd, response); err != nil {
+		t.Errorf("got unexpected packets: %v", err)
+	}
+}
+
+func TestSendAndReadWithStrictPadding(t *testing.T) {
+	pkt := newPacket(dhcpv4.OpcodeBootRequest, [4]byte{0x33, 0x33, 0x33, 0x33})
+
+	// Both the server and client only get 2 seconds.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	response, err := dhcpv4.NewReplyFromRequest(pkt)
+	if err != nil {
+		t.Errorf("NewReplyFromRequest(%v) = %v, want nil", pkt, err)
+	}
+
+	bytes := response.ToBytes()
+
+	// Add garbage to the end.
+	bytes[len(bytes)-1] = 0x01
+
+	mc := serveAndClientWithBytesResp(bytes, WithStrictPadding())
+	defer mc.Close()
+
+	_, err = mc.SendAndRead(ctx, DefaultServers, pkt, nil)
+	if err == nil {
+		t.Errorf("SendAndRead(%v) error is nil, want error", pkt)
 	}
 }
 

--- a/dhcpv4/options.go
+++ b/dhcpv4/options.go
@@ -106,7 +106,7 @@ func (o Options) ToBytes() []byte {
 //
 // Returns an error if any invalid option or length is found.
 func (o Options) FromBytes(data []byte) error {
-	return o.fromBytesCheckEnd(data, false)
+	return o.fromBytesWithStrictPadding(data, false, false)
 }
 
 const (
@@ -115,9 +115,9 @@ const (
 	optEnd       = 255
 )
 
-// FromBytesCheckEnd parses Options from byte sequences using the
+// fromBytesWithStrictPadding parses Options from byte sequences using the
 // parsing function that is passed in as a paremeter
-func (o Options) fromBytesCheckEnd(data []byte, checkEndOption bool) error {
+func (o Options) fromBytesWithStrictPadding(data []byte, checkEndOption bool, strictPadding bool) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -159,6 +159,10 @@ func (o Options) fromBytesCheckEnd(data []byte, checkEndOption bool) error {
 	// up.
 	if !end && checkEndOption {
 		return io.ErrUnexpectedEOF
+	}
+
+	if !strictPadding {
+		return nil
 	}
 
 	// Any bytes left must be padding.

--- a/dhcpv4/options_test.go
+++ b/dhcpv4/options_test.go
@@ -227,9 +227,10 @@ func TestOptionsMarshal(t *testing.T) {
 
 func TestOptionsUnmarshal(t *testing.T) {
 	for i, tt := range []struct {
-		input     []byte
-		want      Options
-		wantError bool
+		input         []byte
+		strictPadding bool
+		want          Options
+		wantError     bool
 	}{
 		{
 			// Buffer missing data.
@@ -255,9 +256,15 @@ func TestOptionsUnmarshal(t *testing.T) {
 			wantError: true,
 		},
 		{
-			// Option present after the End is a nono.
-			input:     []byte{byte(OptionEnd), 3},
-			wantError: true,
+			// Option present after the End if not strictPadding.
+			input: []byte{byte(OptionEnd), 3},
+			want:  Options{},
+		},
+		{
+			// Option present after the End if strictPadding.
+			input:         []byte{byte(OptionEnd), 3},
+			strictPadding: true,
+			wantError:     true,
 		},
 		{
 			input: []byte{byte(OptionEnd)},
@@ -306,7 +313,7 @@ func TestOptionsUnmarshal(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("Test %02d", i), func(t *testing.T) {
 			opt := make(Options)
-			err := opt.fromBytesCheckEnd(tt.input, true)
+			err := opt.fromBytesWithStrictPadding(tt.input, true, tt.strictPadding)
 			if tt.wantError {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
RFC 2132 says:
`The end option marks the end of valid information in the vendor field.  Subsequent octets should be filled with pad options.`

But it seems that this does not mean that the client should consider packages with non-pad options after the End option invalid, because RFC 2119 explains:
`3. SHOULD   This word, or the adjective "RECOMMENDED", mean that there may exist valid reasons in particular circumstances to ignore a particular item, but the full implications must be understood and carefully weighed before choosing a different course.`

This PR is an alternative to https://github.com/insomniacslk/dhcp/pull/543, with zero padding checking disabled by default. 