### PR TITLE
Remove zero padding check

### DIFF
--- a/dhcpv4/options.go
+++ b/dhcpv4/options.go
@@ -21,11 +21,6 @@ var (
 	// ErrZeroLengthByteStream is an error that is thrown any time a zero-length
 	// byte stream is encountered.
 	ErrZeroLengthByteStream = errors.New("zero-length byte stream")
-
-	// ErrInvalidOptions is returned when invalid options data is
-	// encountered during parsing. The data could report an incorrect
-	// length or have trailing bytes which are not part of the option.
-	ErrInvalidOptions = errors.New("invalid options data")
 )
 
 // OptionValue is an interface that all DHCP v4 options adhere to.
@@ -161,14 +156,6 @@ func (o Options) fromBytesCheckEnd(data []byte, checkEndOption bool) error {
 		return io.ErrUnexpectedEOF
 	}
 
-	// Any bytes left must be padding.
-	var pad uint8
-	for buf.Len() >= 1 {
-		pad = buf.Read8()
-		if pad != optPad && pad != optEnd {
-			return ErrInvalidOptions
-		}
-	}
 	return nil
 }
 

--- a/dhcpv4/options_test.go
+++ b/dhcpv4/options_test.go
@@ -255,9 +255,9 @@ func TestOptionsUnmarshal(t *testing.T) {
 			wantError: true,
 		},
 		{
-			// Option present after the End is a nono.
-			input:     []byte{byte(OptionEnd), 3},
-			wantError: true,
+			// Option present after the End.
+			input: []byte{byte(OptionEnd), 3},
+			want:  Options{},
 		},
 		{
 			input: []byte{byte(OptionEnd)},


### PR DESCRIPTION
RFC 2132 says:
`The end option marks the end of valid information in the vendor field.  Subsequent octets should be filled with pad options.`

But it seems that this does not mean that the client should consider packages with non-pad options after the End option invalid, because RFC 2119 explains:
`3. SHOULD   This word, or the adjective "RECOMMENDED", mean that there may exist valid reasons in particular circumstances to ignore a particular item, but the full implications must be understood and carefully weighed before choosing a different course.`

This PR is an alternative to https://github.com/insomniacslk/dhcp/pull/543 and https://github.com/insomniacslk/dhcp/pull/545.