### PR TITLE
Escape agent options containing binary when stringifying

### DIFF
--- a/dhcpv4/option_relay_agent_information.go
+++ b/dhcpv4/option_relay_agent_information.go
@@ -50,7 +50,7 @@ type raiSubOptionValue struct {
 }
 
 func (rv raiSubOptionValue) String() string {
-	return fmt.Sprintf("%s (%v)", string(rv.val), rv.val)
+	return fmt.Sprintf("%q (%v)", string(rv.val), rv.val)
 }
 
 type raiSubOptionCode uint8

--- a/dhcpv4/option_relay_agent_information_test.go
+++ b/dhcpv4/option_relay_agent_information_test.go
@@ -36,14 +36,16 @@ func TestOptRelayAgentInfo(t *testing.T) {
 	opt := OptRelayAgentInfo(
 		OptGeneric(GenericOptionCode(1), []byte("linux")),
 		OptGeneric(GenericOptionCode(2), []byte("boot")),
+		OptGeneric(GenericOptionCode(3), []byte{2, 30, 99}),
 		OptGeneric(GenericOptionCode(LinkSelectionSubOption), []byte{192, 0, 2, 1}),
 	)
 	wantBytes := []byte{
 		1, 5, 'l', 'i', 'n', 'u', 'x',
 		2, 4, 'b', 'o', 'o', 't',
+		3, 3, 2, 30, 99,
 		5, 4, 192, 0, 2, 1,
 	}
-	wantString := "Relay Agent Information:\n\n    Agent Circuit ID Sub-option: linux ([108 105 110 117 120])\n    Agent Remote ID Sub-option: boot ([98 111 111 116])\n    Link Selection Sub-option: 192.0.2.1\n"
+	wantString := "Relay Agent Information:\n\n    Agent Circuit ID Sub-option: \"linux\" ([108 105 110 117 120])\n    Agent Remote ID Sub-option: \"boot\" ([98 111 111 116])\n    unknown (3): \"\\x02\\x1ec\" ([2 30 99])\n    Link Selection Sub-option: 192.0.2.1\n"
 	require.Equal(t, wantBytes, opt.Value.ToBytes())
 	require.Equal(t, OptionRelayAgentInformation, opt.Code)
 	require.Equal(t, wantString, opt.String())

--- a/dhcpv4/options_test.go
+++ b/dhcpv4/options_test.go
@@ -119,7 +119,7 @@ func TestParseOption(t *testing.T) {
 		{
 			code:  OptionRelayAgentInformation,
 			value: []byte{1, 12, 99, 105, 114, 99, 117, 105, 116, 45, 105, 100, 45, 49},
-			want:  "\n    Agent Circuit ID Sub-option: circuit-id-1 ([99 105 114 99 117 105 116 45 105 100 45 49])\n",
+			want:  "\n    Agent Circuit ID Sub-option: \"circuit-id-1\" ([99 105 114 99 117 105 116 45 105 100 45 49])\n",
 		},
 		{
 			code:  OptionClientSystemArchitectureType,


### PR DESCRIPTION
Printing strings that contain binary messes up my terminal. Using %q instead of %s will result in the binary being escaped.