### PR TITLE
Rename module to reflect new github path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
-module github.com/insomniacslk/dhcp
+module github.com/vitrifi/dhcp
 
 go 1.20
 
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714
+	github.com/insomniacslk/dhcp v0.0.0-00010101000000-000000000000
 	github.com/jsimonetti/rtnetlink v1.3.5
 	github.com/mdlayher/netlink v1.7.2
 	github.com/mdlayher/packet v1.1.2
@@ -24,3 +25,5 @@ require (
 	golang.org/x/sync v0.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )
+
+replace github.com/insomniacslk/dhcp => github.com/vitrifi/dhcp v0.0.0-20240829085014-a3a4c1f04475

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 h1:tHNk7XK9GkmKUR6Gh8gVBKXc2MVSZ4G/NnWLtzw4gNA=
 github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923/go.mod h1:eLL9Nub3yfAho7qB0MzZizFhTU2QkLeoVsWdHtDW264=
+github.com/vitrifi/dhcp v0.0.0-20240829085014-a3a4c1f04475 h1:h68wcphmgg+7U7pHV2WfHYcHCJbO57aSj4ocDYdEsc8=
+github.com/vitrifi/dhcp v0.0.0-20240829085014-a3a4c1f04475/go.mod h1:KclMyHxX06VrVr0DJmeFSUb1ankt7xTfoOA35pCkoic=
 golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=


### PR DESCRIPTION
This PR renames `github.com/insomniacslk/dhcp` module into `github.com/vitrifi/dhcp` in order to make it importable.