### PR TITLE
fix: add CLOEXEC flag to socket created directly

### DIFF
--- a/dhcpv4/client4/client.go
+++ b/dhcpv4/client4/client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/insomniacslk/dhcp/internal/xsocket"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/sys/unix"
 )
@@ -77,7 +78,7 @@ func MakeRawUDPPacket(payload []byte, serverAddr, clientAddr net.UDPAddr) ([]byt
 
 // makeRawSocket creates a socket that can be passed to unix.Sendto.
 func makeRawSocket(ifname string) (int, error) {
-	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_RAW, unix.IPPROTO_RAW)
+	fd, err := xsocket.CloexecSocket(unix.AF_INET, unix.SOCK_RAW, unix.IPPROTO_RAW)
 	if err != nil {
 		return fd, err
 	}
@@ -123,7 +124,7 @@ func htons(v uint16) uint16 {
 }
 
 func makeListeningSocketWithCustomPort(ifname string, port int) (int, error) {
-	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_DGRAM, int(htons(unix.ETH_P_IP)))
+	fd, err := xsocket.CloexecSocket(unix.AF_PACKET, unix.SOCK_DGRAM, int(htons(unix.ETH_P_IP)))
 	if err != nil {
 		return fd, err
 	}

--- a/dhcpv4/server4/conn_unix.go
+++ b/dhcpv4/server4/conn_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package server4
@@ -9,6 +10,7 @@ import (
 	"os"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/insomniacslk/dhcp/internal/xsocket"
 	"golang.org/x/sys/unix"
 )
 
@@ -17,7 +19,7 @@ import (
 //
 // The interface must already be configured.
 func NewIPv4UDPConn(iface string, addr *net.UDPAddr) (*net.UDPConn, error) {
-	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, unix.IPPROTO_UDP)
+	fd, err := xsocket.CloexecSocket(unix.AF_INET, unix.SOCK_DGRAM, unix.IPPROTO_UDP)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get a UDP socket: %v", err)
 	}

--- a/dhcpv6/server6/conn_unix.go
+++ b/dhcpv6/server6/conn_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package server6
@@ -9,6 +10,7 @@ import (
 	"os"
 
 	"github.com/insomniacslk/dhcp/interfaces"
+	"github.com/insomniacslk/dhcp/internal/xsocket"
 	"golang.org/x/sys/unix"
 )
 
@@ -18,7 +20,7 @@ import (
 //
 // The interface must already be configured.
 func NewIPv6UDPConn(iface string, addr *net.UDPAddr) (*net.UDPConn, error) {
-	fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_DGRAM, unix.IPPROTO_UDP)
+	fd, err := xsocket.CloexecSocket(unix.AF_INET6, unix.SOCK_DGRAM, unix.IPPROTO_UDP)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get a UDP socket: %v", err)
 	}

--- a/internal/xsocket/xsocket.go
+++ b/internal/xsocket/xsocket.go
@@ -1,0 +1,34 @@
+package xsocket
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// CloexecSocket creates a new socket with the close-on-exec flag set.
+//
+// If the OS doesn't support the close-on-exec flag, this function will try a workaround.
+func CloexecSocket(domain, typ, proto int) (int, error) {
+	fd, err := socketCloexec(domain, typ, proto)
+	if err == nil {
+		return fd, nil
+	}
+
+	if err == unix.EINVAL || err == unix.EPROTONOSUPPORT {
+		// SOCK_CLOEXEC is not supported, try without it, but avoid racing with fork/exec
+		syscall.ForkLock.RLock()
+		defer syscall.ForkLock.RUnlock()
+
+		fd, err = unix.Socket(domain, typ, proto)
+		if err != nil {
+			return -1, err
+		}
+
+		unix.CloseOnExec(fd)
+
+		return fd, nil
+	}
+
+	return fd, err
+}

--- a/internal/xsocket/xsocket_cloexec.go
+++ b/internal/xsocket/xsocket_cloexec.go
@@ -1,0 +1,9 @@
+//go:build dragonfly || freebsd || linux || netbsd || openbsd
+
+package xsocket
+
+import "golang.org/x/sys/unix"
+
+func socketCloexec(domain, typ, proto int) (int, error) {
+	return unix.Socket(domain, typ|unix.SOCK_CLOEXEC, proto)
+}

--- a/internal/xsocket/xsocket_nocloexec.go
+++ b/internal/xsocket/xsocket_nocloexec.go
@@ -1,0 +1,9 @@
+//go:build !(dragonfly || freebsd || linux || netbsd || openbsd)
+
+package xsocket
+
+import "golang.org/x/sys/unix"
+
+func socketCloexec(domain, typ, proto int) (int, error) {
+	return unix.Socket(domain, typ, proto)
+}


### PR DESCRIPTION
Go runtime adds `CLOEXEC` flags automatically, but when using raw syscalls, we have to do it manually.

Without this flag, file descriptors leak to the child processes.