### PR TITLE
dhcpv6: Add RelayPort getter to RelayOptions 

### DIFF
--- a/dhcpv6/dhcpv6relay.go
+++ b/dhcpv6/dhcpv6relay.go
@@ -69,6 +69,18 @@ func (ro RelayOptions) ClientLinkLayerAddress() (iana.HWType, net.HardwareAddr) 
 	return 0, nil
 }
 
+// RelayPort returns the optRelayPort of this relay message.
+func (ro RelayOptions) RelayPort() *optRelayPort {
+	opt := ro.Options.GetOne(OptionRelayPort)
+	if opt == nil {
+		return nil
+	}
+	if relayPort, ok := opt.(*optRelayPort); ok {
+		return relayPort
+	}
+	return nil
+}
+
 // RelayMessage is a DHCPv6 relay agent message as defined by RFC 3315 Section
 // 7.
 type RelayMessage struct {

--- a/dhcpv6/option_relayport_test.go
+++ b/dhcpv6/option_relayport_test.go
@@ -1,9 +1,14 @@
 package dhcpv6
 
 import (
+	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"github.com/u-root/uio/uio"
 )
 
 func TestParseRelayPort(t *testing.T) {
@@ -11,6 +16,64 @@ func TestParseRelayPort(t *testing.T) {
 	err := opt.FromBytes([]byte{0x12, 0x32})
 	require.NoError(t, err)
 	require.Equal(t, optRelayPort{DownstreamSourcePort: 0x1232}, opt)
+}
+
+func TestRelayPortParseAndGetter(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		err  error
+		want *optRelayPort
+	}{
+		{
+			buf: []byte{
+				0, 135, // Relay Port
+				0, 2, // length
+				0x12, 0x34,
+			},
+			want: &optRelayPort{ DownstreamSourcePort: 0x1234 },
+		},
+		{
+			buf: []byte{
+				0, 135,
+				0, 2,
+				0, 0,
+			},
+			want: &optRelayPort{ DownstreamSourcePort: 0 },
+		},
+		{
+			buf: []byte{
+				0, 135,
+				0, 0,
+			},
+			err: uio.ErrBufferTooShort,
+		},
+		{
+			buf: []byte{
+				0, 135,
+				0,
+			},
+			err: uio.ErrUnreadBytes,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var ro RelayOptions
+			if err := ro.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			if got := ro.RelayPort(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RelayPort = %v want %v", got, tt.want)
+			}
+
+			if tt.want != nil {
+				var m RelayOptions
+				m.Add(OptRelayPort(tt.want.DownstreamSourcePort))
+				got := m.ToBytes()
+				if diff := cmp.Diff(tt.buf, got); diff != "" {
+					t.Errorf("ToBytes mismatch (-want, +got): %s", diff)
+				}
+			}
+		})
+	}
 }
 
 func TestRelayPortToBytes(t *testing.T) {

--- a/dhcpv6/option_relayport_test.go
+++ b/dhcpv6/option_relayport_test.go
@@ -80,3 +80,20 @@ func TestRelayPortToBytes(t *testing.T) {
 	op := OptRelayPort(0x3845)
 	require.Equal(t, []byte{0x38, 0x45}, op.ToBytes())
 }
+
+func TestRelayPortInvalidType(t *testing.T) {
+	// Create RelayOptions containing an option with the OptionRelayPort code
+	// but with an incorrect type (not *optRelayPort)
+	ro := RelayOptions{
+		Options: []Option{
+			&OptionGeneric{OptionCode: OptionRelayPort, OptionData: []byte("foobar")},
+		},
+	}
+
+	got := ro.RelayPort()
+
+	// Assert that nil is returned when type assertion fails
+	if got != nil {
+		t.Errorf("RelayPort = %v want nil", got)
+	}
+}


### PR DESCRIPTION
Add getter for accessing the RelayPort option.