### PR TITLE
dhcpv6: add SNTP Servers option parsing

### DIFF
--- a/dhcpv6/dhcpv6message.go
+++ b/dhcpv6/dhcpv6message.go
@@ -354,6 +354,18 @@ func (mo MessageOptions) NTPServers() []net.IP {
 	return addrs
 }
 
+// SNTP returns the SNTP Servers option as defined by RFC 4075.
+func (mo MessageOptions) SNTP() []net.IP {
+	opt := mo.Options.GetOne(OptionSNTPServerList)
+	if opt == nil {
+		return nil
+	}
+	if sntp, ok := opt.(*optSNTP); ok {
+		return sntp.SNTPServers
+	}
+	return nil
+}
+
 // Message represents a DHCPv6 Message as defined by RFC 3315 Section 6.
 type Message struct {
 	MessageType   MessageType

--- a/dhcpv6/option_sntp_servers.go
+++ b/dhcpv6/option_sntp_servers.go
@@ -1,0 +1,45 @@
+package dhcpv6
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/u-root/uio/uio"
+)
+
+// OptSNTP returns a SNTP Servers option as defined by RFC 4075.
+func OptSNTP(ip ...net.IP) Option {
+	return &optSNTP{SNTPServers: ip}
+}
+
+type optSNTP struct {
+	SNTPServers []net.IP
+}
+
+// Code returns the option code
+func (op *optSNTP) Code() OptionCode {
+	return OptionSNTPServerList
+}
+
+// ToBytes returns the option serialized to bytes.
+func (op *optSNTP) ToBytes() []byte {
+	buf := uio.NewBigEndianBuffer(nil)
+	for _, ns := range op.SNTPServers {
+		buf.WriteBytes(ns.To16())
+	}
+	return buf.Data()
+}
+
+func (op *optSNTP) String() string {
+	return fmt.Sprintf("%s: %v", op.Code(), op.SNTPServers)
+}
+
+// FromBytes builds an optSNTP structure from a sequence of bytes. The input
+// data does not include option code and length bytes.
+func (op *optSNTP) FromBytes(data []byte) error {
+	buf := uio.NewBigEndianBuffer(data)
+	for buf.Has(net.IPv6len) {
+		op.SNTPServers = append(op.SNTPServers, buf.CopyN(net.IPv6len))
+	}
+	return buf.FinError()
+}

--- a/dhcpv6/option_sntp_servers_test.go
+++ b/dhcpv6/option_sntp_servers_test.go
@@ -1,0 +1,85 @@
+package dhcpv6
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/u-root/uio/uio"
+)
+
+func TestSNTPParseAndGetter(t *testing.T) {
+	for i, tt := range []struct {
+		buf  []byte
+		err  error
+		want []net.IP
+	}{
+		{
+			buf: []byte{
+				0, 31, // SNTP
+				0, 16, // length
+				0x2a, 0x03, 0x28, 0x80, 0xff, 0xfe, 0x00, 0x0c, 0xfa, 0xce, 0xb0, 0x0c, 0x00, 0x00, 0x00, 0x35,
+			},
+			want: []net.IP{
+				net.IP{0x2a, 0x03, 0x28, 0x80, 0xff, 0xfe, 0x00, 0x0c, 0xfa, 0xce, 0xb0, 0x0c, 0x00, 0x00, 0x00, 0x35},
+			},
+		},
+		{
+			buf: []byte{
+				0, 31, // SNTP
+				0, 32, // length
+				0x2a, 0x03, 0x28, 0x80, 0xff, 0xfe, 0x00, 0x0c, 0xfa, 0xce, 0xb0, 0x0c, 0x00, 0x00, 0x00, 0x35,
+				0x2a, 0x03, 0x28, 0x80, 0xff, 0xfe, 0x00, 0x0c, 0xfa, 0xce, 0xb0, 0x0c, 0x00, 0x00, 0x00, 0x35,
+			},
+			want: []net.IP{
+				net.IP{0x2a, 0x03, 0x28, 0x80, 0xff, 0xfe, 0x00, 0x0c, 0xfa, 0xce, 0xb0, 0x0c, 0x00, 0x00, 0x00, 0x35},
+				net.IP{0x2a, 0x03, 0x28, 0x80, 0xff, 0xfe, 0x00, 0x0c, 0xfa, 0xce, 0xb0, 0x0c, 0x00, 0x00, 0x00, 0x35},
+			},
+		},
+		{
+			buf:  nil,
+			want: nil,
+		},
+		{
+			buf: []byte{
+				0, 31,
+				0, 8,
+				0x2a, 0x03, 0x28, 0x80, 0xff, 0xfe, 0x00, 0x0c, // invalid IPv6 address
+			},
+			want: nil,
+			err:  uio.ErrUnreadBytes,
+		},
+		{
+			buf:  []byte{0, 23, 0, 1, 0},
+			want: nil,
+			err:  uio.ErrUnreadBytes,
+		},
+		{
+			buf:  []byte{0, 23, 0},
+			want: nil,
+			err:  uio.ErrUnreadBytes,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var mo MessageOptions
+			if err := mo.FromBytes(tt.buf); !errors.Is(err, tt.err) {
+				t.Errorf("FromBytes = %v, want %v", err, tt.err)
+			}
+			if got := mo.SNTP(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SNTP = %v, want %v", got, tt.want)
+			}
+
+			if tt.want != nil {
+				var m MessageOptions
+				m.Add(OptSNTP(tt.want...))
+				got := m.ToBytes()
+				if diff := cmp.Diff(tt.buf, got); diff != "" {
+					t.Errorf("ToBytes mismatch (-want, +got): %s", diff)
+				}
+			}
+		})
+	}
+}

--- a/dhcpv6/options.go
+++ b/dhcpv6/options.go
@@ -82,6 +82,8 @@ func ParseOption(code OptionCode, optData []byte) (Option, error) {
 		opt = &OptIAPD{}
 	case OptionIAPrefix:
 		opt = &OptIAPrefix{}
+	case OptionSNTPServerList:
+		opt = &optSNTP{}
 	case OptionInformationRefreshTime:
 		opt = &optInformationRefreshTime{}
 	case OptionRemoteID:


### PR DESCRIPTION
Some embedded/BMC devices can only use SNTP option (31) to configure time synchronization. Implement it in DHCPv6.