### PR TITLE
netboot: fix swallowed errors in ConfigureInterface

### DIFF
--- a/netboot/netconf.go
+++ b/netboot/netconf.go
@@ -187,7 +187,7 @@ func ConfigureInterface(ifname string, netconf *NetConf) (err error) {
 		return err
 	}
 	defer func() {
-		if cerr := rt.Close(); err != nil {
+		if cerr := rt.Close(); cerr != nil && err == nil {
 			err = cerr
 		}
 	}()


### PR DESCRIPTION
The deferred `rt.Close()` handler checked the wrong variable (`err`, the named return, instead of `cerr`). Any error returned from the function body was overwritten by the (almost always `nil`) `rt.Close()` result. Override the named return error only when it is `nil`.